### PR TITLE
Various Auction TODOs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -261,7 +261,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		slashing.NewAppModule(app.slashingKeeper, app.stakingKeeper),
 		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
 		validatorvesting.NewAppModule(app.vvKeeper, app.accountKeeper),
-		auction.NewAppModule(app.auctionKeeper),
+		auction.NewAppModule(app.auctionKeeper, app.supplyKeeper),
 		cdp.NewAppModule(app.cdpKeeper, app.pricefeedKeeper),
 		pricefeed.NewAppModule(app.pricefeedKeeper),
 	)

--- a/x/auction/alias.go
+++ b/x/auction/alias.go
@@ -29,7 +29,6 @@ var (
 	RegisterCodec        = types.RegisterCodec
 	NewGenesisState      = types.NewGenesisState
 	DefaultGenesisState  = types.DefaultGenesisState
-	ValidateGenesis      = types.ValidateGenesis
 	GetAuctionKey        = types.GetAuctionKey
 	GetAuctionByTimeKey  = types.GetAuctionByTimeKey
 	Uint64FromBytes      = types.Uint64FromBytes
@@ -58,7 +57,7 @@ type (
 	CollateralAuction = types.CollateralAuction
 	WeightedAddresses = types.WeightedAddresses
 	SupplyKeeper      = types.SupplyKeeper
-	Auctions          = types.Auctions
+	GenesisAuctions   = types.GenesisAuctions
 	GenesisState      = types.GenesisState
 	MsgPlaceBid       = types.MsgPlaceBid
 	Params            = types.Params

--- a/x/auction/alias.go
+++ b/x/auction/alias.go
@@ -58,6 +58,7 @@ type (
 	WeightedAddresses = types.WeightedAddresses
 	SupplyKeeper      = types.SupplyKeeper
 	GenesisAuctions   = types.GenesisAuctions
+	GenesisAuction    = types.GenesisAuction
 	GenesisState      = types.GenesisState
 	MsgPlaceBid       = types.MsgPlaceBid
 	Params            = types.Params

--- a/x/auction/genesis.go
+++ b/x/auction/genesis.go
@@ -1,17 +1,39 @@
 package auction
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/auction/types"
 )
 
-// InitGenesis initializes the store state from genesis data.
-func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
-	keeper.SetNextAuctionID(ctx, data.NextAuctionID)
+// InitGenesis initializes the store state from a genesis state.
+func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper types.SupplyKeeper, gs GenesisState) {
+	if err := gs.Validate(); err != nil {
+		panic(fmt.Sprintf("failed to validate %s genesis state: %s", ModuleName, err))
+	}
 
-	keeper.SetParams(ctx, data.Params)
+	keeper.SetNextAuctionID(ctx, gs.NextAuctionID)
 
-	for _, a := range data.Auctions {
+	keeper.SetParams(ctx, gs.Params)
+
+	totalAuctionCoins := sdk.NewCoins()
+	for _, a := range gs.Auctions {
 		keeper.SetAuction(ctx, a)
+		// find the total coins that should be present in the module account
+		totalAuctionCoins.Add(a.GetModuleAccountCoins())
+	}
+
+	// check if the module account exists
+	moduleAcc := supplyKeeper.GetModuleAccount(ctx, ModuleName)
+	if moduleAcc == nil {
+		panic(fmt.Sprintf("%s module account has not been set", ModuleName))
+	}
+	// check module coins match auction coins
+	// Note: Other sdk modules do not check this, instead just using the existing module account coins, or if zero, setting them.
+	if !moduleAcc.GetCoins().IsEqual(totalAuctionCoins) {
+		panic(fmt.Sprintf("total auction coins (%s) do not equal (%s) module account (%s) ", moduleAcc.GetCoins(), ModuleName, totalAuctionCoins))
 	}
 }
 
@@ -24,9 +46,13 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
 
 	params := keeper.GetParams(ctx)
 
-	var genAuctions Auctions
+	var genAuctions GenesisAuctions
 	keeper.IterateAuctions(ctx, func(a Auction) bool {
-		genAuctions = append(genAuctions, a)
+		ga, ok := a.(types.GenesisAuction)
+		if !ok {
+			panic("could not convert stored auction to GenesisAuction type")
+		}
+		genAuctions = append(genAuctions, ga)
 		return false
 	})
 

--- a/x/auction/genesis.go
+++ b/x/auction/genesis.go
@@ -46,7 +46,7 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
 
 	params := keeper.GetParams(ctx)
 
-	var genAuctions GenesisAuctions
+	genAuctions := GenesisAuctions{} // return empty list instead of nil if no auctions
 	keeper.IterateAuctions(ctx, func(a Auction) bool {
 		ga, ok := a.(types.GenesisAuction)
 		if !ok {

--- a/x/auction/genesis_test.go
+++ b/x/auction/genesis_test.go
@@ -1,0 +1,109 @@
+package auction_test
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/x/auction"
+)
+
+var testTime = time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC)
+var testAuction = auction.NewCollateralAuction(
+	"seller",
+	c("lotdenom", 10),
+	testTime,
+	c("biddenom", 1000),
+	auction.WeightedAddresses{},
+	c("debt", 1000),
+).WithID(3).(auction.GenesisAuction)
+
+func TestInitGenesis(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		// setup keepers
+		tApp := app.NewTestApp()
+		keeper := tApp.GetAuctionKeeper()
+		ctx := tApp.NewContext(true, abci.Header{})
+		// create genesis
+		gs := auction.NewGenesisState(
+			10,
+			auction.DefaultParams(),
+			auction.GenesisAuctions{testAuction},
+		)
+
+		// run init
+		require.NotPanics(t, func() {
+			auction.InitGenesis(ctx, keeper, tApp.GetSupplyKeeper(), gs)
+		})
+
+		// check state is as expected
+		actualID, err := keeper.GetNextAuctionID(ctx)
+		require.NoError(t, err)
+		require.Equal(t, gs.NextAuctionID, actualID)
+
+		require.Equal(t, gs.Params, keeper.GetParams(ctx))
+
+		// TODO is there a nicer way of comparing state?
+		sort.Slice(gs.Auctions, func(i, j int) bool {
+			return gs.Auctions[i].GetID() > gs.Auctions[j].GetID()
+		})
+		i := 0
+		keeper.IterateAuctions(ctx, func(a auction.Auction) bool {
+			require.Equal(t, gs.Auctions[i], a)
+			i++
+			return false
+		})
+	})
+	t.Run("invalid", func(t *testing.T) {
+		// setup keepers
+		tApp := app.NewTestApp()
+		ctx := tApp.NewContext(true, abci.Header{})
+
+		// create invalid genesis
+		gs := auction.NewGenesisState(
+			0, // next id < testAuction ID
+			auction.DefaultParams(),
+			auction.GenesisAuctions{testAuction},
+		)
+
+		// check init fails
+		require.Panics(t, func() {
+			auction.InitGenesis(ctx, tApp.GetAuctionKeeper(), tApp.GetSupplyKeeper(), gs)
+		})
+	})
+}
+
+func TestExportGenesis(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		// setup state
+		tApp := app.NewTestApp()
+		ctx := tApp.NewContext(true, abci.Header{})
+		tApp.InitializeFromGenesisStates()
+
+		// export
+		gs := auction.ExportGenesis(ctx, tApp.GetAuctionKeeper())
+
+		// check state matches
+		require.Equal(t, auction.DefaultGenesisState(), gs)
+	})
+	t.Run("one auction", func(t *testing.T) {
+		// setup state
+		tApp := app.NewTestApp()
+		ctx := tApp.NewContext(true, abci.Header{})
+		tApp.InitializeFromGenesisStates()
+		tApp.GetAuctionKeeper().SetAuction(ctx, testAuction)
+
+		// export
+		gs := auction.ExportGenesis(ctx, tApp.GetAuctionKeeper())
+
+		// check state matches
+		expectedGenesisState := auction.DefaultGenesisState()
+		expectedGenesisState.Auctions = append(expectedGenesisState.Auctions, testAuction)
+		require.Equal(t, expectedGenesisState, gs)
+	})
+}

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -176,7 +176,7 @@ func (k Keeper) PlaceBidSurplus(ctx sdk.Context, a types.SurplusAuction, bidder 
 	}
 
 	// New bidder pays back old bidder
-	// Catch edge cases of a bidder replacing their own bid, and the amount being zero (sending zero coins produces meaningless send events).
+	// Catch edge cases of a bidder replacing their own bid, or the amount being zero (sending zero coins produces meaningless send events).
 	if !bidder.Equals(a.Bidder) && !a.Bid.IsZero() {
 		err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, bidder, types.ModuleName, sdk.NewCoins(a.Bid))
 		if err != nil {

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -27,6 +27,15 @@ func (k Keeper) StartSurplusAuction(ctx sdk.Context, seller string, lot sdk.Coin
 	if err != nil {
 		return 0, err
 	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeAuctionStart,
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.Name()),
+			sdk.NewAttribute(types.AttributeKeyLotDenom, auction.Lot.Denom),
+		),
+	)
 	return auctionID, nil
 }
 
@@ -55,6 +64,15 @@ func (k Keeper) StartDebtAuction(ctx sdk.Context, buyer string, bid sdk.Coin, in
 	if err != nil {
 		return 0, err
 	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeAuctionStart,
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.Name()),
+			sdk.NewAttribute(types.AttributeKeyLotDenom, auction.Lot.Denom),
+		),
+	)
 	return auctionID, nil
 }
 
@@ -86,6 +104,15 @@ func (k Keeper) StartCollateralAuction(ctx sdk.Context, seller string, lot sdk.C
 	if err != nil {
 		return 0, err
 	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeAuctionStart,
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.Name()),
+			sdk.NewAttribute(types.AttributeKeyLotDenom, auction.Lot.Denom),
+		),
+	)
 	return auctionID, nil
 }
 
@@ -128,6 +155,13 @@ func (k Keeper) PlaceBid(ctx sdk.Context, auctionID uint64, bidder sdk.AccAddres
 	}
 
 	k.SetAuction(ctx, updatedAuction)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeAuctionBid,
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+		),
+	)
 	return nil
 }
 
@@ -370,6 +404,13 @@ func (k Keeper) CloseAuction(ctx sdk.Context, auctionID uint64) sdk.Error {
 	}
 
 	k.DeleteAuction(ctx, auctionID)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeAuctionClose,
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+		),
+	)
 	return nil
 }
 

--- a/x/auction/keeper/auctions_test.go
+++ b/x/auction/keeper/auctions_test.go
@@ -227,13 +227,14 @@ func TestStartSurplusAuction(t *testing.T) {
 				// check auction in store and is correct
 				require.True(t, found)
 				expectedAuction := types.Auction(types.SurplusAuction{BaseAuction: types.BaseAuction{
-					ID:         0,
-					Initiator:  tc.args.seller,
-					Lot:        tc.args.lot,
-					Bidder:     nil,
-					Bid:        c(tc.args.bidDenom, 0),
-					EndTime:    tc.blockTime.Add(types.DefaultMaxAuctionDuration),
-					MaxEndTime: tc.blockTime.Add(types.DefaultMaxAuctionDuration),
+					ID:              0,
+					Initiator:       tc.args.seller,
+					Lot:             tc.args.lot,
+					Bidder:          nil,
+					Bid:             c(tc.args.bidDenom, 0),
+					HasReceivedBids: false,
+					EndTime:         types.DistantFuture,
+					MaxEndTime:      types.DistantFuture,
 				}})
 				require.Equal(t, expectedAuction, actualAuc)
 			} else {

--- a/x/auction/spec/04_events.md
+++ b/x/auction/spec/04_events.md
@@ -1,5 +1,27 @@
 # Events
 
-<!--
-TODO: Add events for auction_start, auction_end, auction_bid
- -->
+The `x/auction` module emits the following events:
+
+## EndBlock
+
+| Type          | Attribute Key | Attribute Value |
+| ------------- | ------------- | --------------- |
+| auction_close | auction_id    | {auction ID}    |
+
+## Handlers
+
+### MsgPlaceBid
+
+| Type        | Attribute Key | Attribute Value     |
+| ----------- | ------------- | ------------------- |
+| auction_bid | auction_id    | {auction ID}        |
+| message     | module        | auction             |
+| message     | sender        | {sender address}    |
+
+## Triggered By Other Modules
+
+| Type          | Attribute Key | Attribute Value     |
+| ------------- | ------------- | ------------------- |
+| auction_start | auction_id    | {auction ID}        |
+| auction_start | auction_type  | {auction type}      |
+| auction_start | lot_denom     | {auction lot denom} |

--- a/x/auction/spec/04_events.md
+++ b/x/auction/spec/04_events.md
@@ -2,22 +2,6 @@
 
 The `x/auction` module emits the following events:
 
-## EndBlock
-
-| Type          | Attribute Key | Attribute Value |
-| ------------- | ------------- | --------------- |
-| auction_close | auction_id    | {auction ID}    |
-
-## Handlers
-
-### MsgPlaceBid
-
-| Type        | Attribute Key | Attribute Value     |
-| ----------- | ------------- | ------------------- |
-| auction_bid | auction_id    | {auction ID}        |
-| message     | module        | auction             |
-| message     | sender        | {sender address}    |
-
 ## Triggered By Other Modules
 
 | Type          | Attribute Key | Attribute Value     |
@@ -25,3 +9,24 @@ The `x/auction` module emits the following events:
 | auction_start | auction_id    | {auction ID}        |
 | auction_start | auction_type  | {auction type}      |
 | auction_start | lot_denom     | {auction lot denom} |
+| auction_start | bid_denom     | {auction bid denom} |
+
+## Handlers
+
+### MsgPlaceBid
+
+| Type        | Attribute Key | Attribute Value    |
+| ----------- | ------------- | ------------------ |
+| auction_bid | auction_id    | {auction ID}       |
+| auction_bid | bidder        | {latest bidder}    |
+| auction_bid | bid_amount    | {coin amount}      |
+| auction_bid | lot_amount    | {coin amount}      |
+| auction_bid | end_time      | {auction end time} |
+| message     | module        | auction            |
+| message     | sender        | {sender address}   |
+
+## EndBlock
+
+| Type          | Attribute Key | Attribute Value |
+| ------------- | ------------- | --------------- |
+| auction_close | auction_id    | {auction ID}    |

--- a/x/auction/types/auctions.go
+++ b/x/auction/types/auctions.go
@@ -61,6 +61,9 @@ type SurplusAuction struct {
 // WithID returns an auction with the ID set.
 func (a SurplusAuction) WithID(id uint64) Auction { a.ID = id; return a }
 
+// Name returns a name for this auction type. Used to identify auctions in event attributes.
+func (a SurplusAuction) Name() string { return "surplus" }
+
 // NewSurplusAuction returns a new surplus auction.
 func NewSurplusAuction(seller string, lot sdk.Coin, bidDenom string, endTime time.Time) SurplusAuction {
 	auction := SurplusAuction{BaseAuction{
@@ -85,6 +88,9 @@ type DebtAuction struct {
 
 // WithID returns an auction with the ID set.
 func (a DebtAuction) WithID(id uint64) Auction { a.ID = id; return a }
+
+// Name returns a name for this auction type. Used to identify auctions in event attributes.
+func (a DebtAuction) Name() string { return "debt" }
 
 // NewDebtAuction returns a new debt auction.
 func NewDebtAuction(buyerModAccName string, bid sdk.Coin, initialLot sdk.Coin, endTime time.Time, debt sdk.Coin) DebtAuction {
@@ -120,6 +126,9 @@ type CollateralAuction struct {
 
 // WithID returns an auction with the ID set.
 func (a CollateralAuction) WithID(id uint64) Auction { a.ID = id; return a }
+
+// Name returns a name for this auction type. Used to identify auctions in event attributes.
+func (a CollateralAuction) Name() string { return "collateral" }
 
 // IsReversePhase returns whether the auction has switched over to reverse phase or not.
 // Auction initially start in forward phase.

--- a/x/auction/types/codec.go
+++ b/x/auction/types/codec.go
@@ -15,6 +15,7 @@ func init() {
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgPlaceBid{}, "auction/MsgPlaceBid", nil)
 
+	cdc.RegisterInterface((*GenesisAuction)(nil), nil)
 	cdc.RegisterInterface((*Auction)(nil), nil)
 	cdc.RegisterConcrete(SurplusAuction{}, "auction/SurplusAuction", nil)
 	cdc.RegisterConcrete(DebtAuction{}, "auction/DebtAuction", nil)

--- a/x/auction/types/events.go
+++ b/x/auction/types/events.go
@@ -1,0 +1,12 @@
+package types
+
+const (
+	EventTypeAuctionStart = "auction_start"
+	EventTypeAuctionBid   = "auction_bid"
+	EventTypeAuctionClose = "auction_close"
+
+	AttributeValueCategory  = ModuleName
+	AttributeKeyAuctionID   = "auction_id"
+	AttributeKeyAuctionType = "auction_type"
+	AttributeKeyLotDenom    = "lot_denom"
+)

--- a/x/auction/types/events.go
+++ b/x/auction/types/events.go
@@ -8,5 +8,10 @@ const (
 	AttributeValueCategory  = ModuleName
 	AttributeKeyAuctionID   = "auction_id"
 	AttributeKeyAuctionType = "auction_type"
+	AttributeKeyBidder      = "bidder"
+	AttributeKeyBidDenom    = "bid_denom"
 	AttributeKeyLotDenom    = "lot_denom"
+	AttributeKeyBidAmount   = "bid_amount"
+	AttributeKeyLotAmount   = "lot_amount"
+	AttributeKeyEndTime     = "end_time"
 )

--- a/x/auction/types/genesis.go
+++ b/x/auction/types/genesis.go
@@ -2,20 +2,30 @@ package types
 
 import (
 	"bytes"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// GenesisAuction is an interface that extends the auction interface to add functionality needed for initializing auctions from genesis.
+type GenesisAuction interface {
+	Auction
+	GetModuleAccountCoins() sdk.Coins
+	Validate() error
+}
+
 // Auctions is a slice of auctions.
-type Auctions []Auction
+type GenesisAuctions []GenesisAuction
 
 // GenesisState is auction state that must be provided at chain genesis.
 type GenesisState struct {
-	NextAuctionID uint64   `json:"next_auction_id" yaml:"next_auction_id"`
-	Params        Params   `json:"auction_params" yaml:"auction_params"`
-	Auctions      Auctions `json:"genesis_auctions" yaml:"genesis_auctions"`
+	NextAuctionID uint64          `json:"next_auction_id" yaml:"next_auction_id"`
+	Params        Params          `json:"auction_params" yaml:"auction_params"`
+	Auctions      GenesisAuctions `json:"genesis_auctions" yaml:"genesis_auctions"`
 }
 
 // NewGenesisState returns a new genesis state object for auctions module.
-func NewGenesisState(nextID uint64, ap Params, ga Auctions) GenesisState {
+func NewGenesisState(nextID uint64, ap Params, ga GenesisAuctions) GenesisState {
 	return GenesisState{
 		NextAuctionID: nextID,
 		Params:        ap,
@@ -25,25 +35,42 @@ func NewGenesisState(nextID uint64, ap Params, ga Auctions) GenesisState {
 
 // DefaultGenesisState returns the default genesis state for auction module.
 func DefaultGenesisState() GenesisState {
-	return NewGenesisState(0, DefaultParams(), Auctions{})
+	return NewGenesisState(0, DefaultParams(), GenesisAuctions{})
 }
 
 // Equal checks whether two GenesisState structs are equivalent.
-func (data GenesisState) Equal(data2 GenesisState) bool {
-	b1 := ModuleCdc.MustMarshalBinaryBare(data)
-	b2 := ModuleCdc.MustMarshalBinaryBare(data2)
+func (gs GenesisState) Equal(gs2 GenesisState) bool {
+	b1 := ModuleCdc.MustMarshalBinaryBare(gs)
+	b2 := ModuleCdc.MustMarshalBinaryBare(gs2)
 	return bytes.Equal(b1, b2)
 }
 
 // IsEmpty returns true if a GenesisState is empty.
-func (data GenesisState) IsEmpty() bool {
-	return data.Equal(GenesisState{})
+func (gs GenesisState) IsEmpty() bool {
+	return gs.Equal(GenesisState{})
 }
 
 // ValidateGenesis validates genesis inputs. It returns error if validation of any input fails.
-func ValidateGenesis(data GenesisState) error {
-	if err := data.Params.Validate(); err != nil {
+func (gs GenesisState) Validate() error {
+	if err := gs.Params.Validate(); err != nil {
 		return err
+	}
+
+	ids := map[uint64]bool{}
+	for _, a := range gs.Auctions {
+
+		if err := a.Validate(); err != nil {
+			return fmt.Errorf("found invalid auction: %w", err)
+		}
+
+		if ids[a.GetID()] {
+			return fmt.Errorf("found duplicate auction ID (%d)", a.GetID())
+		}
+		ids[a.GetID()] = true
+
+		if a.GetID() >= gs.NextAuctionID {
+			return fmt.Errorf("found auction ID (%d) >= the nextAuctionID (%d)", a.GetID(), gs.NextAuctionID)
+		}
 	}
 	return nil
 }

--- a/x/auction/types/genesis.go
+++ b/x/auction/types/genesis.go
@@ -14,7 +14,7 @@ type GenesisAuction interface {
 	Validate() error
 }
 
-// Auctions is a slice of auctions.
+// GenesisAuctions is a slice of genesis auctions.
 type GenesisAuctions []GenesisAuction
 
 // GenesisState is auction state that must be provided at chain genesis.

--- a/x/auction/types/genesis.go
+++ b/x/auction/types/genesis.go
@@ -69,7 +69,7 @@ func (gs GenesisState) Validate() error {
 		ids[a.GetID()] = true
 
 		if a.GetID() >= gs.NextAuctionID {
-			return fmt.Errorf("found auction ID (%d) >= the nextAuctionID (%d)", a.GetID(), gs.NextAuctionID)
+			return fmt.Errorf("found auction ID >= the nextAuctionID (%d >= %d)", a.GetID(), gs.NextAuctionID)
 		}
 	}
 	return nil

--- a/x/auction/types/genesis_test.go
+++ b/x/auction/types/genesis_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+var testCoin = sdk.NewInt64Coin("test", 20)
+
+func TestGenesisState_Validate(t *testing.T) {
+	testCases := []struct {
+		name       string
+		nextID     uint64
+		auctions   GenesisAuctions
+		expectPass bool
+	}{
+		{"default", DefaultGenesisState().NextAuctionID, DefaultGenesisState().Auctions, true},
+		{"invalid next ID", 54, GenesisAuctions{SurplusAuction{BaseAuction{ID: 105}}}, false},
+		{
+			"repeated ID",
+			1000,
+			GenesisAuctions{
+				SurplusAuction{BaseAuction{ID: 105}},
+				DebtAuction{BaseAuction{ID: 105}, testCoin},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := NewGenesisState(tc.nextID, DefaultParams(), tc.auctions)
+
+			err := gs.Validate()
+
+			if tc.expectPass {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Changes:
- make auctions not expire without bids
  - auction end times start as a  distant future date, then on the first bid it's reduced to the normal timeout
- add events for start, bid, and close auctions, with some minimal set of attributes for each event
- review how chain halts effect auctions, add more validation for init genesis (and some genesis tests)
  - Added a new `GenesisAuction` interface type following the pattern in `auth`
  - When a chain halts, is exported and restarted, auctions have the same end times as they had when the chain stopped. So any auction that ended during the downtime will close on the restart. And any with time still left will still be open for bidding.