### PR TITLE
clean orphaned MsgTransferCDP from CDP module

### DIFF
--- a/x/cdp/alias.go
+++ b/x/cdp/alias.go
@@ -152,7 +152,6 @@ type (
 	MsgWithdraw            = types.MsgWithdraw
 	MsgDrawDebt            = types.MsgDrawDebt
 	MsgRepayDebt           = types.MsgRepayDebt
-	MsgTransferCDP         = types.MsgTransferCDP
 	Params                 = types.Params
 	CollateralParam        = types.CollateralParam
 	CollateralParams       = types.CollateralParams

--- a/x/cdp/types/codec.go
+++ b/x/cdp/types/codec.go
@@ -19,5 +19,4 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgWithdraw{}, "cdp/MsgWithdraw", nil)
 	cdc.RegisterConcrete(MsgDrawDebt{}, "cdp/MsgDrawDebt", nil)
 	cdc.RegisterConcrete(MsgRepayDebt{}, "cdp/MsgRepayDebt", nil)
-	cdc.RegisterConcrete(MsgTransferCDP{}, "cdp/MsgTransferCDP", nil)
 }

--- a/x/cdp/types/msg.go
+++ b/x/cdp/types/msg.go
@@ -321,8 +321,3 @@ func (msg MsgRepayDebt) String() string {
 	Payment: %s
 `, msg.Sender, msg.CdpDenom, msg.Payment)
 }
-
-// MsgTransferCDP changes the ownership of a cdp
-type MsgTransferCDP struct {
-	// TODO
-}


### PR DESCRIPTION
`type MsgTransferCDP struct {}` was unimplemented and marked with TODO in the CDP module, but the msg not be included in the CDP testnet release. This PR removes the orphaned code and I've created issue https://github.com/Kava-Labs/kava/issues/324 to track the feature.
