### PR TITLE
Fix withdraw typo

### DIFF
--- a/x/cdp/keeper/deposit.go
+++ b/x/cdp/keeper/deposit.go
@@ -98,7 +98,7 @@ func (k Keeper) WithdrawCollateral(ctx sdk.Context, owner sdk.AccAddress, deposi
 	cdp.AccumulatedFees = cdp.AccumulatedFees.Add(fees)
 	cdp.FeesUpdated = ctx.BlockTime()
 	cdp.Collateral = cdp.Collateral.Sub(collateral)
-	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
 	k.SetCdpAndCollateralRatioIndex(ctx, cdp, collateralToDebtRatio)
 
 	deposit.Amount = deposit.Amount.Sub(collateral)


### PR DESCRIPTION
Came across a weird bug where after withdrawing from a CDP, the CDP would be liquidated when it wasn't meant to, then the chain would halt.

This is what was going on:
- Withdraw makes a mistake in calculating the cdp's new collateralToDebt ratio due to a typo
- the incorrect collateralToDebt ratio makes the CDP liquidate prematurely
- then Seize calculates the correct collateralToDebt ratio and tries to remove the CDP from the db index using that value. But this does nothing, leaving the old value in the index. Seize still deletes the CDP correctly.
- This means next block the begin blocker tries to liquidate the CDP again (as it's still in the index) but this panics when the CDP cannot be found.