### PR TITLE
R4R: add collateral value, collateralization ratio to CDP querier

### DIFF
--- a/x/cdp/alias.go
+++ b/x/cdp/alias.go
@@ -28,6 +28,7 @@ const (
 	CodeCdpNotAvailable             = types.CodeCdpNotAvailable
 	CodeBelowDebtFloor              = types.CodeBelowDebtFloor
 	CodePaymentExceedsDebt          = types.CodePaymentExceedsDebt
+	CodeLoadingAugmentedCDP         = types.CodeLoadingAugmentedCDP
 	EventTypeCreateCdp              = types.EventTypeCreateCdp
 	EventTypeCdpDeposit             = types.EventTypeCdpDeposit
 	EventTypeCdpDraw                = types.EventTypeCdpDraw
@@ -76,6 +77,7 @@ var (
 	ErrCdpNotAvailable          = types.ErrCdpNotAvailable
 	ErrBelowDebtFloor           = types.ErrBelowDebtFloor
 	ErrPaymentExceedsDebt       = types.ErrPaymentExceedsDebt
+	ErrLoadingAugmentedCDP      = types.ErrLoadingAugmentedCDP
 	DefaultGenesisState         = types.DefaultGenesisState
 	GetCdpIDBytes               = types.GetCdpIDBytes
 	GetCdpIDFromBytes           = types.GetCdpIDFromBytes
@@ -143,6 +145,8 @@ var (
 type (
 	CDP                    = types.CDP
 	CDPs                   = types.CDPs
+	AugmentedCDP           = types.AugmentedCDP
+	AugmentedCDPs          = types.AugmentedCDPs
 	Deposit                = types.Deposit
 	Deposits               = types.Deposits
 	SupplyKeeper           = types.SupplyKeeper

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -119,7 +119,7 @@ func QueryCdpsByDenomAndRatioCmd(queryRoute string, cdc *codec.Codec) *cobra.Com
 		Use:   "cdps-by-ratio [collateral-name] [collateralization-ratio]",
 		Short: "get cdps under a collateralization ratio",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`List all CDPs under a specified collateralization ratios.
+			fmt.Sprintf(`List all CDPs under a specified collateralization ratio.
 Collateralization ratio is: collateral * price / debt.
 
 Example:

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -150,9 +150,9 @@ $ %s query %s cdps-by-ratio uatom 1.5
 			}
 
 			// Decode and print results
-			var out types.CDPs
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
+			var cdps types.AugmentedCDPs
+			cdc.MustUnmarshalJSON(res, &cdps)
+			return cliCtx.PrintOutput(cdps)
 		},
 	}
 }

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -119,7 +119,7 @@ func QueryCdpsByDenomAndRatioCmd(queryRoute string, cdc *codec.Codec) *cobra.Com
 		Use:   "cdps-by-ratio [collateral-name] [collateralization-ratio]",
 		Short: "get cdps under a collateralization ratio",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`List all CDPs under a collateralization ratios.
+			fmt.Sprintf(`List all CDPs under a specified collateralization ratios.
 Collateralization ratio is: collateral * price / debt.
 
 Example:

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -69,7 +69,7 @@ $ %s query %s cdp kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw uatom
 			}
 
 			// Decode and print results
-			var cdp types.CDP
+			var cdp types.AugmentedCDP
 			cdc.MustUnmarshalJSON(res, &cdp)
 			return cliCtx.PrintOutput(cdp)
 		},

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -105,9 +105,9 @@ $ %s query %s cdps uatom
 			}
 
 			// Decode and print results
-			var out types.CDPs
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
+			var cdps types.AugmentedCDPs
+			cdc.MustUnmarshalJSON(res, &cdps)
+			return cliCtx.PrintOutput(cdps)
 		},
 	}
 }

--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kava-labs/kava/x/cdp/types"
 )
 
+// BaseDigitFactor is 10**18, used during coin calculations
 const BaseDigitFactor = 1000000000000000000
 
 // AddCdp adds a cdp for a specific owner and collateral type
@@ -419,7 +420,7 @@ func (k Keeper) LoadAugmentedCDP(ctx sdk.Context, cdp types.CDP) (types.Augmente
 	if err != nil {
 		return types.AugmentedCDP{}, err
 	}
-	// calcylate collateral value in debt coin
+	// calculate collateral value in debt coin
 	var totalDebt int64
 	if len(cdp.AccumulatedFees) > 0 {
 		totalDebt += cdp.AccumulatedFees[0].Amount.Int64()

--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -418,9 +418,10 @@ func (k Keeper) LoadAugmentedCDP(ctx sdk.Context, cdp types.CDP) (types.Augmente
 	// calculate additional fees
 	periods := sdk.NewInt(ctx.BlockTime().Unix()).Sub(sdk.NewInt(cdp.FeesUpdated.Unix()))
 	fees := k.CalculateFees(ctx, cdp.Principal.Add(cdp.AccumulatedFees), periods, cdp.Collateral[0].Denom)
+	totalFees := cdp.AccumulatedFees.Add(fees)
 
 	// calculate collateralization ratio
-	collateralizationRatio, err := k.CalculateCollateralizationRatio(ctx, cdp.Collateral, cdp.Principal, cdp.AccumulatedFees.Add(fees))
+	collateralizationRatio, err := k.CalculateCollateralizationRatio(ctx, cdp.Collateral, cdp.Principal, totalFees)
 	if err != nil {
 		return types.AugmentedCDP{}, err
 	}
@@ -430,7 +431,7 @@ func (k Keeper) LoadAugmentedCDP(ctx sdk.Context, cdp types.CDP) (types.Augmente
 	for _, principalCoin := range cdp.Principal {
 		totalDebt += principalCoin.Amount.Int64()
 	}
-	for _, feeCoin := range cdp.AccumulatedFees {
+	for _, feeCoin := range cdp.AccumulatedFees.Add(fees) {
 		totalDebt += feeCoin.Amount.Int64()
 	}
 

--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -460,6 +460,19 @@ func (k Keeper) CalculateCollateralizationRatio(ctx sdk.Context, collateral sdk.
 	return collateralRatio, nil
 }
 
+// CalculateCollateralizationRatioFromAbsoluteRatio takes a coin's denom and an absolute ratio and returns the respective collateralization ratio
+func (k Keeper) CalculateCollateralizationRatioFromAbsoluteRatio(ctx sdk.Context, collateralDenom string, absoluteRatio sdk.Dec) (sdk.Dec, sdk.Error) {
+	// get price collateral
+	marketID := k.getMarketID(ctx, collateralDenom)
+	price, err := k.pricefeedKeeper.GetCurrentPrice(ctx, marketID)
+	if err != nil {
+		return sdk.Dec{}, err
+	}
+	// convert absolute ratio to collateralization ratio
+	respectiveCollateralRatio := absoluteRatio.Quo(price.Price)
+	return respectiveCollateralRatio, nil
+}
+
 // converts the input collateral to base units (ie multiplies the input by 10^(-ConversionFactor))
 func (k Keeper) convertCollateralToBaseUnits(ctx sdk.Context, collateral sdk.Coin) (baseUnits sdk.Dec) {
 	cp, _ := k.GetCollateral(ctx, collateral.Denom)

--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -422,10 +422,12 @@ func (k Keeper) LoadAugmentedCDP(ctx sdk.Context, cdp types.CDP) (types.Augmente
 	}
 	// calculate collateral value in debt coin
 	var totalDebt int64
-	if len(cdp.AccumulatedFees) > 0 {
-		totalDebt += cdp.AccumulatedFees[0].Amount.Int64()
+	for _, principalCoin := range cdp.Principal {
+		totalDebt += principalCoin.Amount.Int64()
 	}
-	totalDebt += cdp.Principal[0].Amount.Int64()
+	for _, feeCoin := range cdp.AccumulatedFees {
+		totalDebt += feeCoin.Amount.Int64()
+	}
 	debtBaseAdjusted := sdk.NewDec(totalDebt).QuoInt64(BaseDigitFactor)
 	collateralValueInDebtDenom := collateralizationRatio.Mul(debtBaseAdjusted)
 	collateralValueInDebt := sdk.NewInt64Coin(cdp.Principal[0].Denom, collateralValueInDebtDenom.Int64())

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -44,7 +44,13 @@ func queryGetCdp(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte,
 		return nil, types.ErrCdpNotFound(keeper.codespace, requestParams.Owner, requestParams.CollateralDenom)
 	}
 
-	bz, err := codec.MarshalJSONIndent(keeper.cdc, cdp)
+	augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
+	if err != nil {
+		// TODO: types.ErrLoadingAugmentedCDP()
+		return nil, types.ErrCdpNotFound(keeper.codespace, requestParams.Owner, requestParams.CollateralDenom)
+	}
+
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, augmentedCDP)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -74,7 +74,6 @@ func queryGetCdpsByRatio(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	var augmentedCDPs types.AugmentedCDPs
 	for _, cdp := range cdps {
 		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
-		// TODO: we can do better...
 		if err == nil {
 			augmentedCDPs = append(augmentedCDPs, augmentedCDP)
 		}
@@ -103,7 +102,6 @@ func queryGetCdpsByDenom(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	var augmentedCDPs types.AugmentedCDPs
 	for _, cdp := range cdps {
 		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
-		// TODO: we can do better...
 		if err == nil {
 			augmentedCDPs = append(augmentedCDPs, augmentedCDP)
 		}

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -70,7 +70,16 @@ func queryGetCdpsByRatio(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	cdps := keeper.GetAllCdpsByDenomAndRatio(ctx, requestParams.CollateralDenom, requestParams.Ratio)
-	bz, err := codec.MarshalJSONIndent(keeper.cdc, cdps)
+
+	var augmentedCDPs types.AugmentedCDPs
+	for _, cdp := range cdps {
+		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
+		// TODO: we can do better...
+		if err == nil {
+			augmentedCDPs = append(augmentedCDPs, augmentedCDP)
+		}
+	}
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, augmentedCDPs)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -90,7 +99,16 @@ func queryGetCdpsByDenom(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	cdps := keeper.GetAllCdpsByDenom(ctx, requestParams.CollateralDenom)
-	bz, err := codec.MarshalJSONIndent(keeper.cdc, cdps)
+
+	var augmentedCDPs types.AugmentedCDPs
+	for _, cdp := range cdps {
+		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
+		// TODO: we can do better...
+		if err == nil {
+			augmentedCDPs = append(augmentedCDPs, augmentedCDP)
+		}
+	}
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, augmentedCDPs)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -69,8 +69,13 @@ func queryGetCdpsByRatio(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, types.ErrInvalidCollateralDenom(keeper.codespace, requestParams.CollateralDenom)
 	}
 
-	cdps := keeper.GetAllCdpsByDenomAndRatio(ctx, requestParams.CollateralDenom, requestParams.Ratio)
+	ratio, err := keeper.CalculateCollateralizationRatioFromAbsoluteRatio(ctx, requestParams.CollateralDenom, requestParams.Ratio)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could get collateralization ratio from absolute ratio", err.Error()))
+	}
 
+	cdps := keeper.GetAllCdpsByDenomAndRatio(ctx, requestParams.CollateralDenom, ratio)
+	// augment CDPs by adding collateral value and collateralization ratio
 	var augmentedCDPs types.AugmentedCDPs
 	for _, cdp := range cdps {
 		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -46,8 +46,7 @@ func queryGetCdp(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte,
 
 	augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)
 	if err != nil {
-		// TODO: types.ErrLoadingAugmentedCDP()
-		return nil, types.ErrCdpNotFound(keeper.codespace, requestParams.Owner, requestParams.CollateralDenom)
+		return nil, types.ErrLoadingAugmentedCDP(keeper.codespace, cdp.ID)
 	}
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, augmentedCDP)

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -103,7 +103,7 @@ func queryGetCdpsByDenom(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	cdps := keeper.GetAllCdpsByDenom(ctx, requestParams.CollateralDenom)
-
+	// augment CDPs by adding collateral value and collateralization ratio
 	var augmentedCDPs types.AugmentedCDPs
 	for _, cdp := range cdps {
 		augmentedCDP, err := keeper.LoadAugmentedCDP(ctx, cdp)

--- a/x/cdp/types/cdp.go
+++ b/x/cdp/types/cdp.go
@@ -62,3 +62,51 @@ func (cdps CDPs) String() string {
 	}
 	return out
 }
+
+// AugmentedCDP provides additional information about an active CDP
+type AugmentedCDP struct {
+	CDP                    `json:"cdp" yaml:"cdp"`
+	CollateralValue        sdk.Dec `json:"collateral_value" yaml:"collateral_value"`               // collateral's market value (quantity * price)
+	CollateralizationRatio sdk.Dec `json:"collateralization_ratio" yaml:"collateralization_ratio"` // current collateralization ratio
+}
+
+// NewAugmentedCDP creates a new AugmentedCDP object
+func NewAugmentedCDP(cdp CDP, collateralValue sdk.Dec, collateralizationRatio sdk.Dec) AugmentedCDP {
+	augmentedCDP := AugmentedCDP{
+		CDP: CDP{
+			ID:              cdp.ID,
+			Owner:           cdp.Owner,
+			Collateral:      cdp.Collateral,
+			Principal:       cdp.Principal,
+			AccumulatedFees: cdp.AccumulatedFees,
+			FeesUpdated:     cdp.FeesUpdated,
+		},
+		CollateralValue:        collateralValue,
+		CollateralizationRatio: collateralizationRatio,
+	}
+	return augmentedCDP
+}
+
+// String implements fmt.stringer
+func (augCDP AugmentedCDP) String() string {
+	return strings.TrimSpace(fmt.Sprintf(`AugmentedCDP:
+	Owner:      %s
+	ID: %d
+	Collateral Type: %s
+	Collateral: %s
+	Collateral Value: %s
+	Principal: %s
+	Fees: %s
+	Fees Last Updated: %s
+	Collateralization ratio: %s`,
+		augCDP.Owner,
+		augCDP.ID,
+		augCDP.Collateral[0].Denom,
+		augCDP.Collateral,
+		augCDP.CollateralValue,
+		augCDP.Principal,
+		augCDP.AccumulatedFees,
+		augCDP.FeesUpdated,
+		augCDP.CollateralizationRatio,
+	))
+}

--- a/x/cdp/types/cdp.go
+++ b/x/cdp/types/cdp.go
@@ -66,12 +66,12 @@ func (cdps CDPs) String() string {
 // AugmentedCDP provides additional information about an active CDP
 type AugmentedCDP struct {
 	CDP                    `json:"cdp" yaml:"cdp"`
-	CollateralUSDXValue    sdk.Dec `json:"collateral_usdx_value" yaml:"collateral_usdx_value"`     // collateral's market value (quantity * price)
-	CollateralizationRatio sdk.Dec `json:"collateralization_ratio" yaml:"collateralization_ratio"` // current collateralization ratio
+	CollateralValue        sdk.Coin `json:"collateral_value" yaml:"collateral_value"`               // collateral's market value in debt coin
+	CollateralizationRatio sdk.Dec  `json:"collateralization_ratio" yaml:"collateralization_ratio"` // current collateralization ratio
 }
 
 // NewAugmentedCDP creates a new AugmentedCDP object
-func NewAugmentedCDP(cdp CDP, collateralUSDXValue sdk.Dec, collateralizationRatio sdk.Dec) AugmentedCDP {
+func NewAugmentedCDP(cdp CDP, collateralValue sdk.Coin, collateralizationRatio sdk.Dec) AugmentedCDP {
 	augmentedCDP := AugmentedCDP{
 		CDP: CDP{
 			ID:              cdp.ID,
@@ -81,7 +81,7 @@ func NewAugmentedCDP(cdp CDP, collateralUSDXValue sdk.Dec, collateralizationRati
 			AccumulatedFees: cdp.AccumulatedFees,
 			FeesUpdated:     cdp.FeesUpdated,
 		},
-		CollateralUSDXValue:    collateralUSDXValue,
+		CollateralValue:        collateralValue,
 		CollateralizationRatio: collateralizationRatio,
 	}
 	return augmentedCDP
@@ -94,7 +94,7 @@ func (augCDP AugmentedCDP) String() string {
 	ID: %d
 	Collateral Type: %s
 	Collateral: %s
-	Collateral USDX Value: %s
+	Collateral Value: %s
 	Principal: %s
 	Fees: %s
 	Fees Last Updated: %s
@@ -103,7 +103,7 @@ func (augCDP AugmentedCDP) String() string {
 		augCDP.ID,
 		augCDP.Collateral[0].Denom,
 		augCDP.Collateral,
-		augCDP.CollateralUSDXValue,
+		augCDP.CollateralValue,
 		augCDP.Principal,
 		augCDP.AccumulatedFees,
 		augCDP.FeesUpdated,

--- a/x/cdp/types/cdp.go
+++ b/x/cdp/types/cdp.go
@@ -66,12 +66,12 @@ func (cdps CDPs) String() string {
 // AugmentedCDP provides additional information about an active CDP
 type AugmentedCDP struct {
 	CDP                    `json:"cdp" yaml:"cdp"`
-	CollateralValue        sdk.Dec `json:"collateral_value" yaml:"collateral_value"`               // collateral's market value (quantity * price)
+	CollateralUSDXValue    sdk.Dec `json:"collateral_usdx_value" yaml:"collateral_usdx_value"`     // collateral's market value (quantity * price)
 	CollateralizationRatio sdk.Dec `json:"collateralization_ratio" yaml:"collateralization_ratio"` // current collateralization ratio
 }
 
 // NewAugmentedCDP creates a new AugmentedCDP object
-func NewAugmentedCDP(cdp CDP, collateralValue sdk.Dec, collateralizationRatio sdk.Dec) AugmentedCDP {
+func NewAugmentedCDP(cdp CDP, collateralUSDXValue sdk.Dec, collateralizationRatio sdk.Dec) AugmentedCDP {
 	augmentedCDP := AugmentedCDP{
 		CDP: CDP{
 			ID:              cdp.ID,
@@ -81,7 +81,7 @@ func NewAugmentedCDP(cdp CDP, collateralValue sdk.Dec, collateralizationRatio sd
 			AccumulatedFees: cdp.AccumulatedFees,
 			FeesUpdated:     cdp.FeesUpdated,
 		},
-		CollateralValue:        collateralValue,
+		CollateralUSDXValue:    collateralUSDXValue,
 		CollateralizationRatio: collateralizationRatio,
 	}
 	return augmentedCDP
@@ -94,7 +94,7 @@ func (augCDP AugmentedCDP) String() string {
 	ID: %d
 	Collateral Type: %s
 	Collateral: %s
-	Collateral Value: %s
+	Collateral USDX Value: %s
 	Principal: %s
 	Fees: %s
 	Fees Last Updated: %s
@@ -103,10 +103,22 @@ func (augCDP AugmentedCDP) String() string {
 		augCDP.ID,
 		augCDP.Collateral[0].Denom,
 		augCDP.Collateral,
-		augCDP.CollateralValue,
+		augCDP.CollateralUSDXValue,
 		augCDP.Principal,
 		augCDP.AccumulatedFees,
 		augCDP.FeesUpdated,
 		augCDP.CollateralizationRatio,
 	))
+}
+
+// AugmentedCDPs a collection of AugmentedCDP objects
+type AugmentedCDPs []AugmentedCDP
+
+// String implements stringer
+func (augcdps AugmentedCDPs) String() string {
+	out := ""
+	for _, augcdp := range augcdps {
+		out += augcdp.String() + "\n"
+	}
+	return out
 }

--- a/x/cdp/types/codec.go
+++ b/x/cdp/types/codec.go
@@ -19,6 +19,4 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgWithdraw{}, "cdp/MsgWithdraw", nil)
 	cdc.RegisterConcrete(MsgDrawDebt{}, "cdp/MsgDrawDebt", nil)
 	cdc.RegisterConcrete(MsgRepayDebt{}, "cdp/MsgRepayDebt", nil)
-
-	cdc.RegisterConcrete(AugmentedCDP{}, "cdp/AugmentedCDP", nil)
 }

--- a/x/cdp/types/codec.go
+++ b/x/cdp/types/codec.go
@@ -19,4 +19,6 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgWithdraw{}, "cdp/MsgWithdraw", nil)
 	cdc.RegisterConcrete(MsgDrawDebt{}, "cdp/MsgDrawDebt", nil)
 	cdc.RegisterConcrete(MsgRepayDebt{}, "cdp/MsgRepayDebt", nil)
+
+	cdc.RegisterConcrete(AugmentedCDP{}, "cdp/AugmentedCDP", nil)
 }

--- a/x/cdp/types/errors.go
+++ b/x/cdp/types/errors.go
@@ -26,6 +26,7 @@ const (
 	CodeCdpNotAvailable         sdk.CodeType      = 14
 	CodeBelowDebtFloor          sdk.CodeType      = 15
 	CodePaymentExceedsDebt      sdk.CodeType      = 16
+	CodeLoadingAugmentedCDP     sdk.CodeType      = 17
 )
 
 // ErrCdpAlreadyExists error for duplicate cdps
@@ -106,4 +107,9 @@ func ErrBelowDebtFloor(codespace sdk.CodespaceType, debt sdk.Coins, floor sdk.In
 // ErrPaymentExceedsDebt error for repayments that are greater than the debt amount
 func ErrPaymentExceedsDebt(codespace sdk.CodespaceType, payment sdk.Coins, principal sdk.Coins) sdk.Error {
 	return sdk.NewError(codespace, CodePaymentExceedsDebt, fmt.Sprintf("payment of %s exceeds debt of %s", payment, principal))
+}
+
+// ErrLoadingAugmentedCDP error loading augmented cdp
+func ErrLoadingAugmentedCDP(codespace sdk.CodespaceType, cdpID uint64) sdk.Error {
+	return sdk.NewError(codespace, CodeCdpNotFound, fmt.Sprintf("augmented cdp could not be loaded from cdp id %d", cdpID))
 }


### PR DESCRIPTION
Resolves https://github.com/Kava-Labs/kava/issues/344.

Features
- New AugmentedCDP type contains _collateral value_ (in usdx/debt coin) and _collateralization ratio_ (based on collateral's current price)
- Query cdps-by-ratio now returns CDPs by their collateralization ratio instead of their absolute ratio

Example query with xrp price = $0.30:
```
$ kvcli q cdp cdps-by-ratio xrp 2.41
- cdp:
    id: 1
    owner: kava1xy7hrjy9r0algz9w3gzm8u6mrpq97kwta747gj
    collateral:
    - denom: xrp
      amount: "80000000"
    principal:
    - denom: usdx
      amount: "10000000"
    accumulated_fees: []
    fees_updated: 2020-01-25T00:34:58.418698Z
  collateral_value:
    denom: usdx
    amount: "24000000"
  collateralization_ratio: "2.400000000000000000"
```