### PR TITLE
R4R fix posted prices in genesis file

### DIFF
--- a/x/pricefeed/genesis.go
+++ b/x/pricefeed/genesis.go
@@ -25,9 +25,12 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, gs GenesisState) {
 	// Set the current price (if any) based on what's now in the store
 	for _, market := range params.Markets {
 		if market.Active {
-			err := keeper.SetCurrentPrices(ctx, market.MarketID)
-			if err != nil {
-				panic(err)
+			rps := keeper.GetRawPrices(ctx, market.MarketID)
+			if len(rps) > 0 {
+				err := keeper.SetCurrentPrices(ctx, market.MarketID)
+				if err != nil {
+					panic(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes panic on genesis initialization that occurred if no posted prices were set in the genesis file.

The old error message:
```$ kvd start
I[2020-01-29|14:01:03.625] starting ABCI with Tendermint                module=main 
panic: ERROR:
Codespace: pricefeed
Code: 3
Message: "All input prices are expired."


goroutine 1 [running]:
github.com/kava-labs/kava/x/pricefeed.InitGenesis(0x5296ce0, 0xc0000d8008, 0x52a8da0, 0xc000040dc0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/denali/go/src/github.com/kava-labs/kava/x/pricefeed/genesis.go:30 +0x5e2
github.com/kava-labs/kava/x/pricefeed.AppModule.InitGenesis(0x5286da0, 0xc000afb3a0, 0xc0001617a0, 0xc0001617a0, 0x5286da0, 0xc000afb360, 0x5286de0, 0xc000afb3b0, 0xc000b78360, 0x9, ...)
        /Users/denali/go/src/github.com/kava-labs/kava/x/pricefeed/module.go:122 +0x14b
github.com/cosmos/cosmos-sdk/types/module.(*Manager).InitGenesis(0xc00017a770, 0x5296ce0, 0xc0000d8008, 0x52a8da0, 0xc000040dc0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/types/module/module.go:265 +0x278
github.com/kava-labs/kava/app.(*App).InitChainer(0xc000b3ae00, 0x5296ce0, 0xc0000d8008, 0x52a8da0, 0xc000040dc0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/denali/go/src/github.com/kava-labs/kava/app/app.go:364 +0x11d
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).InitChain(0xc000b29540, 0x36e7b5b8, 0xed5c3bab1, 0x0, 0xc000c641b0, 0x7, 0xc000040600, 0x5b75038, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/baseapp/abci.go:38 +0x2cd
github.com/tendermint/tendermint/abci/client.(*localClient).InitChainSync(0xc000b32600, 0x36e7b5b8, 0xed5c3bab1, 0x0, 0xc000c641b0, 0x7, 0xc000040600, 0x5b75038, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/abci/client/local_client.go:223 +0x101
github.com/tendermint/tendermint/proxy.(*appConnConsensus).InitChainSync(0xc0009e7110, 0x36e7b5b8, 0xed5c3bab1, 0x0, 0xc000c641b0, 0x7, 0xc000040600, 0x5b75038, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/proxy/app_conn.go:65 +0x6b
github.com/tendermint/tendermint/consensus.(*Handshaker).ReplayBlocks(0xc001ca30b0, 0xa, 0x0, 0x4e81c63, 0x6, 0xc000c641b0, 0x7, 0x0, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/replay.go:311 +0x666
github.com/tendermint/tendermint/consensus.(*Handshaker).Handshake(0xc001ca30b0, 0x52abd20, 0xc000156c40, 0x80, 0x4ce0ca0)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/replay.go:269 +0x485
github.com/tendermint/tendermint/node.doHandshake(0x52aae20, 0xc0000cc398, 0xa, 0x0, 0x4e81c63, 0x6, 0xc000c641b0, 0x7, 0x0, 0x0, ...)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/node/node.go:275 +0x199
github.com/tendermint/tendermint/node.NewNode(0xc000c5f7c0, 0x52912a0, 0xc000b7a960, 0xc0009a0000, 0x5275f80, 0xc0000c0aa0, 0xc0000d5cf0, 0x5082cb8, 0xc0000d5d00, 0x5297720, ...)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/node/node.go:582 +0x334
github.com/cosmos/cosmos-sdk/server.startInProcess(0xc0000e7080, 0x5083508, 0x1d, 0x0, 0x0)
        /Users/denali/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/server/start.go:154 +0x4c1
github.com/cosmos/cosmos-sdk/server.StartCmd.func1(0xc000523b80, 0x5b75038, 0x0, 0x0, 0x0, 0x0)
        /Users/denali/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/server/start.go:66 +0xb4
github.com/spf13/cobra.(*Command).execute(0xc000523b80, 0x5b75038, 0x0, 0x0, 0xc000523b80, 0x5b75038)
        /Users/denali/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000f0c80, 0x4ea7c63, 0xc0003a7e90, 0x41853b2)
        /Users/denali/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/denali/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
github.com/tendermint/tendermint/libs/cli.Executor.Execute(0xc0000f0c80, 0x5083918, 0x4e8c463, 0x10)
        /Users/denali/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/libs/cli/setup.go:89 +0x3c
main.main()
        /Users/denali/go/src/github.com/kava-labs/kava/cmd/kvd/main.go:69 +0x589```