### PR TITLE
R4R: Avoid panic when closing a single cdp via repayment

### DIFF
--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -110,7 +110,7 @@ func (k Keeper) MintDebtCoins(ctx sdk.Context, moduleAccount string, denom strin
 	return nil
 }
 
-// BurnDebtCoins burns debts coins from the cdp module account
+// BurnDebtCoins burns debt coins from the cdp module account
 func (k Keeper) BurnDebtCoins(ctx sdk.Context, moduleAccount string, denom string, paymentCoins sdk.Coins) sdk.Error {
 	coinsToBurn := sdk.NewCoins()
 	for _, pc := range paymentCoins {


### PR DESCRIPTION
Related to #320 and #326 

When there is a single cdp in the system, closing it via repayment causes a panic if the fees accumulated by the cdp exceed the fees accumulated via the module account in the end blocker. This PR limits the debt coins burned to the total amount of debt coins in the cdp module account. 

```
rawlog: '{"codespace":"sdk","code":1,"message":"recovered: ERROR:\nCodespace: sdk\nCode:
  10\nMessage: \"insufficient account funds; 100000000btc,1000000287debt < 1000000354debt\"\n\nstack:\ngoroutine
  327104 [running]:\nruntime/debug.Stack(0xc0043e3d98, 0x1222e00, 0xc005602750)\n\t/usr/local/go/src/runtime/debug/stack.go:24
  +0x9d\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx.func1(0xc0043e7ee0,
  0xc0043e85b8, 0xc0043e9da0)\n\t/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/baseapp/baseapp.go:543
  +0x90\npanic(0x1222e00, 0xc005602750)\n\t/usr/local/go/src/runtime/panic.go:679
  +0x1b2\ngithub.com/cosmos/cosmos-sdk/x/supply/internal/keeper.Keeper.BurnCoins(0xc0008e68c0,
  0x16d3ca0, 0xc000c7b670, 0x16e4fa0, 0xc0008e6d20, 0x7f16edbecc88, 0xc0000e4460,
  0xc000c64e70, 0x16e4020, 0xc000034038, ...)\n\t/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/x/supply/internal/keeper/bank.go:134
  +0x5f5\ngithub.com/kava-labs/kava/x/cdp/keeper.Keeper.BurnDebtCoins(0x16d3ca0, 0xc000c7b6f0,
  0xc0008e68c0, 0xc0008e68c0, 0x16d3ca0, 0xc000c7b6c0, 0x16d3ce0, 0xc000c7b710, 0xc0009bdda0,
  0x3, ...)\n\t/home/ubuntu/kava/x/cdp/keeper/cdp.go:119 +0xd9\ngithub.com/kava-labs/kava/x/cdp/keeper.Keeper.RepayPrincipal(0x16d3ca0,
  0xc000c7b6f0, 0xc0008e68c0, 0xc0008e68c0, 0x16d3ca0, 0xc000c7b6c0, 0x16d3ce0, 0xc000c7b710,
  0xc0009bdda0, 0x3, ...)\n\t/home/ubuntu/kava/x/cdp/keeper/draw.go:113 +0xa8f\ngithub.com/kava-labs/kava/x/cdp.handleMsgRepayDebt(0x16e4020,
  0xc000034038, 0x16f65c0, 0xc004d41200, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/home/ubuntu/kava/x/cdp/handler.go:100
  +0x126\ngithub.com/kava-labs/kava/x/cdp.NewHandler.func1(0x16e4020, 0xc000034038,
  0x16f65c0, 0xc004d41200, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/home/ubuntu/kava/x/cdp/handler.go:22
  +0xabd\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runMsgs(0xc000bbb680, 0x16e4020,
  0xc000034038, 0x16f65c0, 0xc004d41200, 0xa, 0x0, 0x0, 0x0, 0x0, ...)\n\t/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/baseapp/baseapp.go:659
  +0xc07\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0xc000bbb680, 0x2,
  0xc001e9c790, 0xad, 0xad, 0x16d5ca0, 0xc001f56f60, 0x0, 0x0, 0x0, ...)\n\t/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/baseapp/baseapp.go:617
  +0x39f\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).DeliverTx(0xc000bbb680,
  0xc001e9c790, 0xad, 0xad, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.34.4-0.20191010193331-18de630d0ae1/baseapp/abci.go:189
  +0x2c1\ngithub.com/tendermint/tendermint/abci/client.(*localClient).DeliverTxAsync(0xc000838000,
  0xc001e9c790, 0xad, 0xad, 0x0, 0x0, 0x0, 0x0, 0x0)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/abci/client/local_client.go:88
  +0xed\ngithub.com/tendermint/tendermint/proxy.(*appConnConsensus).DeliverTxAsync(0xc000c7b600,
  0xc001e9c790, 0xad, 0xad, 0x0, 0x0, 0x0, 0x0, 0x0)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/proxy/app_conn.go:73
  +0x5e\ngithub.com/tendermint/tendermint/state.execBlockOnProxyApp(0x16e4a60, 0xc0008945c0,
  0x16ef860, 0xc000c7b600, 0xc001cdbe00, 0x16f8740, 0xc000011228, 0x6, 0xc000b1e230,
  0xd)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/state/execution.go:286
  +0x613\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(0xc00012fdc0,
  0xa, 0x0, 0xc000b1e210, 0x6, 0xc000b1e230, 0xd, 0x37cd, 0x12, 0xc000cc6a60, ...)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/state/execution.go:124
  +0x17a\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).finalizeCommit(0xc0008d7c00,
  0x37ce)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1348
  +0x928\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).tryFinalizeCommit(0xc0008d7c00,
  0x37ce)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1276
  +0x383\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).enterCommit.func1(0xc0008d7c00,
  0x0, 0x37ce)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1221
  +0x90\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).enterCommit(0xc0008d7c00,
  0x37ce, 0x0)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1253
  +0x61a\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).addVote(0xc0008d7c00,
  0xc001efa6e0, 0xc000a36660, 0x28, 0xc000df1a38, 0xbe11d2, 0x0)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1684
  +0xa39\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).tryAddVote(0xc0008d7c00,
  0xc001efa6e0, 0xc000a36660, 0x28, 0xda5efd7dd5c51b9b, 0x106, 0xfe)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:1527
  +0x59\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).handleMsg(0xc0008d7c00,
  0x16c29e0, 0xc003e59fa0, 0xc000a36660, 0x28)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:691
  +0x252\ngithub.com/tendermint/tendermint/consensus.(*ConsensusState).receiveRoutine(0xc0008d7c00,
  0x0)\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:633
  +0x6eb\ncreated by github.com/tendermint/tendermint/consensus.(*ConsensusState).OnStart\n\t/home/ubuntu/go/pkg/mod/github.com/tendermint/tendermint@v0.32.7/consensus/state.go:334
  +0x13a\n"}'
```
