### PR TITLE
[R4R] benchmark test for account and cdp iteration

### DIFF
--- a/x/cdp/keeper/keeper_bench_test.go
+++ b/x/cdp/keeper/keeper_bench_test.go
@@ -1,0 +1,61 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/kava-labs/kava/app"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
+)
+
+// savings the result to a module level variable ensures the compiler doesn't optimize the test away
+var coinsResult sdk.Coins
+
+func BenchmarkAccountIteration(b *testing.B) {
+	benchmarks := []struct {
+		name           string
+		numberAccounts int
+		coins          bool
+	}{
+		{name: "10000 Accounts, No Coins", numberAccounts: 10000, coins: false},
+		{name: "100000 Accounts, No Coins", numberAccounts: 100000, coins: false},
+		{name: "1000000 Accounts, No Coins", numberAccounts: 1000000, coins: false},
+		{name: "10000 Accounts, With Coins", numberAccounts: 10000, coins: true},
+		{name: "100000 Accounts, With Coins", numberAccounts: 100000, coins: true},
+		{name: "1000000 Accounts, With Coins", numberAccounts: 1000000, coins: true},
+	}
+	coins := sdk.Coins{
+		sdk.NewCoin("xrp", sdk.NewInt(1000000000)),
+		sdk.NewCoin("usdx", sdk.NewInt(1000000000)),
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			tApp := app.NewTestApp()
+			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+			ak := tApp.GetAccountKeeper()
+			tApp.InitializeFromGenesisStates()
+			for i := 0; i < bm.numberAccounts; i++ {
+				arr := []byte{byte((i & 0xFF0000) >> 16), byte((i & 0xFF00) >> 8), byte(i & 0xFF)}
+				addr := sdk.AccAddress(arr)
+				acc := ak.NewAccountWithAddress(ctx, addr)
+				if bm.coins {
+					acc.SetCoins(coins)
+				}
+				ak.SetAccount(ctx, acc)
+			}
+			// reset timer ensures we don't count setup time
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ak.IterateAccounts(ctx,
+					func(acc exported.Account) (stop bool) {
+						coins := acc.GetCoins()
+						coinsResult = coins
+						return false
+					})
+			}
+		})
+	}
+}

--- a/x/cdp/keeper/keeper_bench_test.go
+++ b/x/cdp/keeper/keeper_bench_test.go
@@ -15,6 +15,10 @@ import (
 // saving the result to a module level variable ensures the compiler doesn't optimize the test away
 var coinsResult sdk.Coins
 
+// Note - the iteration benchmarks take a long time to stabilize, to get stable results use:
+// go test -benchmem -bench ^(BenchmarkAccountIteration)$ -benchtime 60s  -timeout 2h
+// go test -benchmem -bench ^(BenchmarkCdpIteration)$ -benchtime 60s  -timeout 2h
+
 func BenchmarkAccountIteration(b *testing.B) {
 	benchmarks := []struct {
 		name           string


### PR DESCRIPTION
Adds benchmark tests for:
1. Iterating over accounts 
2. Creating a CDP
3. Iterating over CDPs

For the large iteration tests, you need to run the benchmarks for longer than default to get stable results. For example, 
```
go test -benchmem -run=^$ github.com/kava-labs/kava/x/cdp/keeper -bench ^(BenchmarkCdpIteration)$ -benchtime 60s  -timeout 2h
``` 

for Cdp iteration and
```
go test -benchmem -run=^$ github.com/kava-labs/kava/x/cdp/keeper -bench ^(BenchmarkAccountIteration)$ -benchtime 60s  -timeout 2h
```
for account iteration. 

Results on my machine (do test on yours)

```
BenchmarkAccountIteration:
BenchmarkAccountIteration/10000_Accounts,_No_Coins-4                2426          30091650 ns/op     2310140 B/op       70130 allocs/op
BenchmarkAccountIteration/100000_Accounts,_No_Coins-4                217         328770263 ns/op    23941546 B/op      701510 allocs/op
BenchmarkAccountIteration/1000000_Accounts,_No_Coins-4                21        3278740202 ns/op    245819389 B/op    7142997 allocs/op
BenchmarkAccountIteration/10000_Accounts,_With_Coins-4               987          72903261 ns/op    13031192 B/op      470149 allocs/op
BenchmarkAccountIteration/100000_Accounts,_With_Coins-4               84         790491364 ns/op    131274723 B/op    4703700 allocs/op
BenchmarkAccountIteration/1000000_Accounts,_With_Coins-4               7        8660316086 ns/op    1335071627 B/op  47428715 allocs/op

BenchmarkCdpCreation:
BenchmarkCdpCreation-4              5127            218991 ns/op           58630 B/op       1141 allocs/op

BenchmarkCdpIteration:
BenchmarkCdpIteration/1000_Cdps-4                   7786           9876851 ns/op         1457345 B/op      49026 allocs/op
BenchmarkCdpIteration/10000_Cdps-4                   709         116629855 ns/op        14789815 B/op     490077 allocs/op
BenchmarkCdpIteration/100000_Cdps-4                   54        1162592702 ns/op        149008130 B/op   4905601 allocs/op
```
