### PR TITLE
Fix simulations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -306,6 +306,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		slashing.NewAppModule(app.slashingKeeper, app.stakingKeeper),
 		cdp.NewAppModule(app.cdpKeeper, app.pricefeedKeeper), // TODO how is the order be decided here? Is this order correct?
 		pricefeed.NewAppModule(app.pricefeedKeeper),
+		auction.NewAppModule(app.auctionKeeper, app.supplyKeeper),
 	)
 
 	app.sm.RegisterStoreDecoders()

--- a/app/app.go
+++ b/app/app.go
@@ -304,6 +304,8 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		distr.NewAppModule(app.distrKeeper, app.supplyKeeper),
 		staking.NewAppModule(app.stakingKeeper, app.accountKeeper, app.supplyKeeper),
 		slashing.NewAppModule(app.slashingKeeper, app.stakingKeeper),
+		cdp.NewAppModule(app.cdpKeeper, app.pricefeedKeeper), // TODO how is the order be decided here? Is this order correct?
+		pricefeed.NewAppModule(app.pricefeedKeeper),
 	)
 
 	app.sm.RegisterStoreDecoders()

--- a/x/auction/module.go
+++ b/x/auction/module.go
@@ -3,23 +3,28 @@ package auction
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/gorilla/mux"
-	"github.com/spf13/cobra"
+	sim "github.com/cosmos/cosmos-sdk/x/simulation"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/kava-labs/kava/x/auction/client/cli"
 	"github.com/kava-labs/kava/x/auction/client/rest"
+	"github.com/kava-labs/kava/x/auction/simulation"
 	"github.com/kava-labs/kava/x/auction/types"
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModuleSimulation{}
 )
 
 // AppModuleBasic implements the sdk.AppModuleBasic interface.
@@ -65,9 +70,32 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 	return cli.GetQueryCmd(StoreKey, cdc)
 }
 
+//____________________________________________________________________________
+
+// AppModuleSimulation defines the module simulation functions used by the auction module.
+type AppModuleSimulation struct{}
+
+// RegisterStoreDecoder registers a decoder for auction module's types
+func (AppModuleSimulation) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	sdr[StoreKey] = simulation.DecodeStore
+}
+
+// GenerateGenesisState creates a randomized GenState of the auction module
+func (AppModuleSimulation) GenerateGenesisState(simState *module.SimulationState) {
+	simulation.RandomizedGenState(simState)
+}
+
+// RandomizedParams creates randomized auction param changes for the simulator.
+func (AppModuleSimulation) RandomizedParams(r *rand.Rand) []sim.ParamChange {
+	return simulation.ParamChanges(r)
+}
+
+//____________________________________________________________________________
+
 // AppModule implements the sdk.AppModule interface.
 type AppModule struct {
 	AppModuleBasic
+	AppModuleSimulation
 
 	keeper       Keeper
 	supplyKeeper types.SupplyKeeper

--- a/x/auction/simulation/decoder.go
+++ b/x/auction/simulation/decoder.go
@@ -1,0 +1,12 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+// DecodeStore unmarshals the KVPair's Value to the corresponding auction type
+func DecodeStore(cdc *codec.Codec, kvA, kvB cmn.KVPair) string {
+	// TODO implement this
+	return ""
+}

--- a/x/auction/simulation/genesis.go
+++ b/x/auction/simulation/genesis.go
@@ -1,0 +1,22 @@
+package simulation
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/kava-labs/kava/x/auction/types"
+)
+
+// RandomizedGenState generates a random GenesisState for auction
+func RandomizedGenState(simState *module.SimulationState) {
+
+	// TODO implement this fully
+	// - randomly generating the genesis params
+	// - overwriting with genesis provided to simulation
+	auctionGenesis := types.DefaultGenesisState()
+
+	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, auctionGenesis))
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(auctionGenesis)
+}

--- a/x/auction/simulation/params.go
+++ b/x/auction/simulation/params.go
@@ -1,0 +1,14 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+)
+
+// ParamChanges defines the parameters that can be modified by param change proposals
+// on the simulation
+func ParamChanges(r *rand.Rand) []simulation.ParamChange {
+	// TODO implement this
+	return []simulation.ParamChange{}
+}

--- a/x/cdp/alias.go
+++ b/x/cdp/alias.go
@@ -78,6 +78,7 @@ var (
 	ErrBelowDebtFloor           = types.ErrBelowDebtFloor
 	ErrPaymentExceedsDebt       = types.ErrPaymentExceedsDebt
 	ErrLoadingAugmentedCDP      = types.ErrLoadingAugmentedCDP
+	NewGenesisState             = types.NewGenesisState
 	DefaultGenesisState         = types.DefaultGenesisState
 	GetCdpIDBytes               = types.GetCdpIDBytes
 	GetCdpIDFromBytes           = types.GetCdpIDFromBytes

--- a/x/cdp/module.go
+++ b/x/cdp/module.go
@@ -2,6 +2,7 @@ package cdp
 
 import (
 	"encoding/json"
+	"math/rand"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -10,15 +11,18 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	sim "github.com/cosmos/cosmos-sdk/x/simulation"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/kava-labs/kava/x/cdp/client/cli"
 	"github.com/kava-labs/kava/x/cdp/client/rest"
+	"github.com/kava-labs/kava/x/cdp/simulation"
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModuleSimulation{}
 )
 
 // AppModuleBasic app module basics object
@@ -64,9 +68,33 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 	return cli.GetQueryCmd(StoreKey, cdc)
 }
 
+//____________________________________________________________________________
+
+// AppModuleSimulation defines the module simulation functions used by the cdp module.
+type AppModuleSimulation struct{}
+
+// RegisterStoreDecoder registers a decoder for cdp module's types
+func (AppModuleSimulation) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	sdr[StoreKey] = simulation.DecodeStore
+}
+
+// GenerateGenesisState creates a randomized GenState of the cdp module
+func (AppModuleSimulation) GenerateGenesisState(simState *module.SimulationState) {
+	simulation.RandomizedGenState(simState)
+}
+
+// RandomizedParams creates randomized cdp param changes for the simulator.
+func (AppModuleSimulation) RandomizedParams(r *rand.Rand) []sim.ParamChange {
+	return simulation.ParamChanges(r)
+}
+
+//____________________________________________________________________________
+
 // AppModule app module type
 type AppModule struct {
 	AppModuleBasic
+	AppModuleSimulation
+
 	keeper          Keeper
 	pricefeedKeeper PricefeedKeeper
 }

--- a/x/cdp/simulation/decoder.go
+++ b/x/cdp/simulation/decoder.go
@@ -1,0 +1,12 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+// DecodeStore unmarshals the KVPair's Value to the corresponding cdp type
+func DecodeStore(cdc *codec.Codec, kvA, kvB cmn.KVPair) string {
+	// TODO implement this
+	return ""
+}

--- a/x/cdp/simulation/genesis.go
+++ b/x/cdp/simulation/genesis.go
@@ -1,0 +1,22 @@
+package simulation
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/kava-labs/kava/x/cdp/types"
+)
+
+// RandomizedGenState generates a random GenesisState for cdp
+func RandomizedGenState(simState *module.SimulationState) {
+
+	// TODO implement this fully
+	// - randomly generating the genesis params
+	// - overwriting with genesis provided to simulation
+	cdpGenesis := types.DefaultGenesisState()
+
+	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, cdpGenesis))
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(cdpGenesis)
+}

--- a/x/cdp/simulation/params.go
+++ b/x/cdp/simulation/params.go
@@ -1,0 +1,14 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+)
+
+// ParamChanges defines the parameters that can be modified by param change proposals
+// on the simulation
+func ParamChanges(r *rand.Rand) []simulation.ParamChange {
+	// TODO implement this
+	return []simulation.ParamChange{}
+}

--- a/x/cdp/types/genesis.go
+++ b/x/cdp/types/genesis.go
@@ -17,6 +17,19 @@ type GenesisState struct {
 	PreviousBlockTime time.Time `json:"previous_block_time" yaml:"previous_block_time"`
 }
 
+// NewGenesisState returns a new genesis state
+func NewGenesisState(params Params, cdps CDPs, deposits Deposits, startingCdpID uint64, debtDenom, govDenom string, previousBlockTime time.Time) GenesisState {
+	return GenesisState{
+		Params:            params,
+		CDPs:              cdps,
+		Deposits:          deposits,
+		StartingCdpID:     startingCdpID,
+		DebtDenom:         debtDenom,
+		GovDenom:          govDenom,
+		PreviousBlockTime: previousBlockTime,
+	}
+}
+
 // DefaultGenesisState returns a default genesis state
 func DefaultGenesisState() GenesisState {
 	return GenesisState{

--- a/x/pricefeed/genesis.go
+++ b/x/pricefeed/genesis.go
@@ -48,8 +48,5 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
 		postedPrices = append(postedPrices, pp...)
 	}
 
-	return GenesisState{
-		Params:       params,
-		PostedPrices: postedPrices,
-	}
+	return NewGenesisState(params, postedPrices)
 }

--- a/x/pricefeed/module.go
+++ b/x/pricefeed/module.go
@@ -2,23 +2,27 @@ package pricefeed
 
 import (
 	"encoding/json"
+	"math/rand"
 
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	sim "github.com/cosmos/cosmos-sdk/x/simulation"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/kava-labs/kava/x/pricefeed/client/cli"
 	"github.com/kava-labs/kava/x/pricefeed/client/rest"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/kava-labs/kava/x/pricefeed/simulation"
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModuleSimulation{}
 )
 
 // AppModuleBasic app module basics object
@@ -64,9 +68,33 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 	return cli.GetQueryCmd(StoreKey, cdc)
 }
 
+//____________________________________________________________________________
+
+// AppModuleSimulation defines the module simulation functions used by the pricefeed module.
+type AppModuleSimulation struct{}
+
+// RegisterStoreDecoder registers a decoder for pricefeed module's types
+func (AppModuleSimulation) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	sdr[StoreKey] = simulation.DecodeStore
+}
+
+// GenerateGenesisState creates a randomized GenState of the pricefeed module
+func (AppModuleSimulation) GenerateGenesisState(simState *module.SimulationState) {
+	simulation.RandomizedGenState(simState)
+}
+
+// RandomizedParams creates randomized pricefeed param changes for the simulator.
+func (AppModuleSimulation) RandomizedParams(r *rand.Rand) []sim.ParamChange {
+	return simulation.ParamChanges(r)
+}
+
+//____________________________________________________________________________
+
 // AppModule app module type
 type AppModule struct {
 	AppModuleBasic
+	AppModuleSimulation
+
 	keeper Keeper
 }
 

--- a/x/pricefeed/simulation/decoder.go
+++ b/x/pricefeed/simulation/decoder.go
@@ -1,0 +1,12 @@
+package simulation
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+// DecodeStore unmarshals the KVPair's Value to the corresponding pricefeed type
+func DecodeStore(cdc *codec.Codec, kvA, kvB cmn.KVPair) string {
+	// TODO implement this
+	return ""
+}

--- a/x/pricefeed/simulation/genesis.go
+++ b/x/pricefeed/simulation/genesis.go
@@ -1,0 +1,22 @@
+package simulation
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/kava-labs/kava/x/pricefeed/types"
+)
+
+// RandomizedGenState generates a random GenesisState for pricefeed
+func RandomizedGenState(simState *module.SimulationState) {
+
+	// TODO implement this fully
+	// - randomly generating the genesis params
+	// - overwriting with genesis provided to simulation
+	pricefeedGenesis := types.DefaultGenesisState()
+
+	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, pricefeedGenesis))
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(pricefeedGenesis)
+}

--- a/x/pricefeed/simulation/params.go
+++ b/x/pricefeed/simulation/params.go
@@ -1,0 +1,14 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+)
+
+// ParamChanges defines the parameters that can be modified by param change proposals
+// on the simulation
+func ParamChanges(r *rand.Rand) []simulation.ParamChange {
+	// TODO implement this
+	return []simulation.ParamChange{}
+}

--- a/x/validator-vesting/genesis.go
+++ b/x/validator-vesting/genesis.go
@@ -22,5 +22,5 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, accountKeeper types.AccountKeep
 // ExportGenesis returns empty genesis state because auth exports all the genesis state we need.
 func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 	prevBlockTime := keeper.GetPreviousBlockTime(ctx)
-	return GenesisState{PreviousBlockTime: prevBlockTime}
+	return NewGenesisState(prevBlockTime)
 }


### PR DESCRIPTION
The simulations were failing because the genesis state created by the simulator for cdp, pricefeed, auction was empty, so those modules paniced on `InitGenesis()`.

So this PR stubs out simulation integration for cdp, pricefeed, auction enough to get it to run again. 

Genesis state should be randomly generated, but instead`DefaultGenesisState` is used. The future work on updating simulations should fix this.

There was also an issue with `cdp.ExportGenesis` that was caught by the simulator. Looks like the genesisState struct was updated but `ExportGenesis` was not. Changed `ExportGenesis`'s to use `NewGenesisState()` func to try and reduce chance this happens in the future.