### PR TITLE
[R4R] Use standard abci query convention in auction

### DIFF
--- a/x/auction/client/rest/query.go
+++ b/x/auction/client/rest/query.go
@@ -46,7 +46,7 @@ func queryAuctionHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		// Query
-		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("/custom/%s/%s", types.ModuleName, types.QueryGetAuction), bz)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.ModuleName, types.QueryGetAuction), bz)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
@@ -75,7 +75,7 @@ func queryAuctionsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		// Get all auctions
-		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("/custom/%s/%s", types.ModuleName, types.QueryGetAuctions), nil)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.ModuleName, types.QueryGetAuctions), nil)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return


### PR DESCRIPTION
Changes abci query path used in auction module from `/custom/{}` to `custom/{}`, which seems to be the standard used throughout the `cosmos-sdk`. 