### PR TITLE
[R4R] BEP3 simulations 

### DIFF
--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingsimops "github.com/cosmos/cosmos-sdk/x/staking/simulation/operations"
 	"github.com/cosmos/cosmos-sdk/x/supply"
+	bep3simops "github.com/kava-labs/kava/x/bep3/simulation/operations"
 )
 
 // Simulation parameter constants
@@ -56,6 +57,7 @@ const (
 	OpWeightMsgUndelegate                              = "op_weight_msg_undelegate"
 	OpWeightMsgBeginRedelegate                         = "op_weight_msg_begin_redelegate"
 	OpWeightMsgUnjail                                  = "op_weight_msg_unjail"
+	OpWeightMsgCreateAtomicSwap                        = "op_weight_msg_create_atomic_Swap"
 )
 
 // TestMain runs setup and teardown code before all tests.
@@ -263,6 +265,17 @@ func testAndRunTxs(app *App, config simulation.Config) []simulation.WeightedOper
 				return v
 			}(nil),
 			slashingsimops.SimulateMsgUnjail(app.slashingKeeper),
+		},
+		{
+			func(_ *rand.Rand) int {
+				var v int
+				ap.GetOrGenerate(app.cdc, OpWeightMsgCreateAtomicSwap, &v, nil,
+					func(_ *rand.Rand) {
+						v = 100
+					})
+				return v
+			}(nil),
+			bep3simops.SimulateMsgCreateAtomicSwap(app.accountKeeper, app.bep3Keeper),
 		},
 	}
 }

--- a/x/bep3/simulation/genesis.go
+++ b/x/bep3/simulation/genesis.go
@@ -2,21 +2,185 @@ package simulation
 
 import (
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/kava-labs/kava/x/bep3/types"
 )
 
+// Simulation parameter constants
+const (
+	BnbDeputyAddress = "bnb_deputy_address"
+	MinBlockLock     = "min_block_lock"
+	MaxBlockLock     = "max_block_lock"
+	SupportedAssets  = "supported_assets"
+)
+
+var (
+	MaxSupplyLimit  = sdk.NewInt(10000000000000000)
+	BondedAddresses []sdk.AccAddress
+)
+
+// GenBnbDeputyAddress randomized BnbDeputyAddress
+func GenBnbDeputyAddress(r *rand.Rand) sdk.AccAddress {
+	return BondedAddresses[r.Intn(len(BondedAddresses))]
+}
+
+// GenMinBlockLock randomized MinBlockLock
+func GenMinBlockLock(r *rand.Rand) int64 {
+	min := int(types.AbsoluteMinimumBlockLock)
+	max := int(types.AbsoluteMaximumBlockLock)
+	return int64(r.Intn(max-min) + min)
+}
+
+// GenMaxBlockLock randomized MaxBlockLock
+func GenMaxBlockLock(r *rand.Rand, minBlockLock int64) int64 {
+	min := int(minBlockLock)
+	max := int(types.AbsoluteMaximumBlockLock)
+	return int64(r.Intn(max-min) + min)
+}
+
+// GenSupportedAssets gets randomized SupportedAssets
+func GenSupportedAssets(r *rand.Rand) types.AssetParams {
+	var assets types.AssetParams
+	for i := 0; i < (r.Intn(10) + 1); i++ {
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		asset := genSupportedAsset(r)
+		assets = append(assets, asset)
+	}
+	return assets
+}
+
+func genSupportedAsset(r *rand.Rand) types.AssetParam {
+	denom := strings.ToLower(simulation.RandStringOfLength(r, (r.Intn(3) + 3)))
+	coinID, _ := simulation.RandPositiveInt(r, sdk.NewInt(100000))
+	limit, _ := simulation.RandPositiveInt(r, MaxSupplyLimit)
+	return types.AssetParam{
+		Denom:  denom,
+		CoinID: int(coinID.Int64()),
+		Limit:  limit,
+		Active: true,
+	}
+}
+
 // RandomizedGenState generates a random GenesisState
 func RandomizedGenState(simState *module.SimulationState) {
+	BondedAddresses = loadBondedAddresses(simState)
 
-	// TODO implement this fully
-	// - randomly generating the genesis params
-	// - overwriting with genesis provided to simulation
-	genesisState := types.DefaultGenesisState()
+	bep3Genesis := loadRandomBep3GenState(simState)
+	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, bep3Genesis))
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(bep3Genesis)
 
-	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, genesisState))
-	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(genesisState)
+	authGenesis, totalCoins := loadAuthGenState(simState, bep3Genesis)
+	simState.GenState[auth.ModuleName] = simState.Cdc.MustMarshalJSON(authGenesis)
+
+	// Update supply to match amount of coins in auth
+	var supplyGenesis supply.GenesisState
+	simState.Cdc.MustUnmarshalJSON(simState.GenState[supply.ModuleName], &supplyGenesis)
+	for _, deputyCoin := range totalCoins {
+		supplyGenesis.Supply = supplyGenesis.Supply.Add(deputyCoin)
+	}
+	simState.GenState[supply.ModuleName] = simState.Cdc.MustMarshalJSON(supplyGenesis)
+}
+
+func loadRandomBep3GenState(simState *module.SimulationState) types.GenesisState {
+	var bnbDeputyAddress sdk.AccAddress
+	simState.AppParams.GetOrGenerate(
+		simState.Cdc, BnbDeputyAddress, &bnbDeputyAddress, simState.Rand,
+		func(r *rand.Rand) { bnbDeputyAddress = GenBnbDeputyAddress(r) },
+	)
+
+	var minBlockLock int64
+	simState.AppParams.GetOrGenerate(
+		simState.Cdc, MinBlockLock, &minBlockLock, simState.Rand,
+		func(r *rand.Rand) { minBlockLock = GenMinBlockLock(r) },
+	)
+
+	var maxBlockLock int64
+	simState.AppParams.GetOrGenerate(
+		simState.Cdc, MaxBlockLock, &maxBlockLock, simState.Rand,
+		func(r *rand.Rand) { maxBlockLock = GenMaxBlockLock(r, minBlockLock) },
+	)
+
+	var supportedAssets types.AssetParams
+	simState.AppParams.GetOrGenerate(
+		simState.Cdc, SupportedAssets, &supportedAssets, simState.Rand,
+		func(r *rand.Rand) { supportedAssets = GenSupportedAssets(r) },
+	)
+
+	bep3Genesis := types.GenesisState{
+		Params: types.Params{
+			BnbDeputyAddress: bnbDeputyAddress,
+			MinBlockLock:     minBlockLock,
+			MaxBlockLock:     maxBlockLock,
+			SupportedAssets:  supportedAssets,
+		},
+	}
+
+	return bep3Genesis
+}
+
+func loadAuthGenState(simState *module.SimulationState, bep3Genesis types.GenesisState) (
+	auth.GenesisState, []sdk.Coins) {
+	var authGenesis auth.GenesisState
+	simState.Cdc.MustUnmarshalJSON(simState.GenState[auth.ModuleName], &authGenesis)
+
+	deputy, found := getAccount(authGenesis.Accounts, bep3Genesis.Params.BnbDeputyAddress)
+	if !found {
+		panic("deputy address not found in available accounts")
+	}
+
+	// Load total limit of each supported asset to deputy's account
+	var totalCoins []sdk.Coins
+	for _, asset := range bep3Genesis.Params.SupportedAssets {
+		assetCoin := sdk.NewCoins(sdk.NewCoin(asset.Denom, asset.Limit))
+		if err := deputy.SetCoins(deputy.GetCoins().Add(assetCoin)); err != nil {
+			panic(err)
+		}
+		totalCoins = append(totalCoins, assetCoin)
+	}
+	authGenesis.Accounts = replaceOrAppendAccount(authGenesis.Accounts, deputy)
+
+	return authGenesis, totalCoins
+}
+
+// TODO: This function can be refactored
+// loadBondedAddresses loads an array of bonded account addresses
+func loadBondedAddresses(simState *module.SimulationState) []sdk.AccAddress {
+	addrs := make([]sdk.AccAddress, simState.NumBonded)
+	for i := 0; i < int(simState.NumBonded); i++ {
+		addr := simState.Accounts[i].Address
+		addrs[i] = addr
+	}
+	return addrs
+}
+
+// Return an account from a list of accounts that matches an address.
+func getAccount(accounts []authexported.GenesisAccount, addr sdk.AccAddress) (authexported.GenesisAccount, bool) {
+	for _, a := range accounts {
+		if a.GetAddress().Equals(addr) {
+			return a, true
+		}
+	}
+	return nil, false
+}
+
+// In a list of accounts, replace the first account found with the same address. If not found, append the account.
+func replaceOrAppendAccount(accounts []authexported.GenesisAccount, acc authexported.GenesisAccount) []authexported.GenesisAccount {
+	newAccounts := accounts
+	for i, a := range accounts {
+		if a.GetAddress().Equals(acc.GetAddress()) {
+			newAccounts[i] = acc
+			return newAccounts
+		}
+	}
+	return append(newAccounts, acc)
 }

--- a/x/bep3/simulation/genesis.go
+++ b/x/bep3/simulation/genesis.go
@@ -98,21 +98,9 @@ func loadRandomBep3GenState(simState *module.SimulationState) types.GenesisState
 		func(r *rand.Rand) { bnbDeputyAddress = GenBnbDeputyAddress(r) },
 	)
 
-	fmt.Println("simState:", simState.AppParams)
-	// TODO: set minBlockLock/maxBlockLock based off sim.numBlocks
+	// min/max block lock are hardcoded to 50/100 for expected -NumBlocks=100
 	minBlockLock := int64(types.AbsoluteMinimumBlockLock)
-	// var minBlockLock int64
-	// simState.AppParams.GetOrGenerate(
-	// 	simState.Cdc, MinBlockLock, &minBlockLock, simState.Rand,
-	// 	func(r *rand.Rand) { minBlockLock = GenMinBlockLock(r) },
-	// )
-
 	maxBlockLock := minBlockLock * 2
-	// var maxBlockLock int64
-	// simState.AppParams.GetOrGenerate(
-	// 	simState.Cdc, MaxBlockLock, &maxBlockLock, simState.Rand,
-	// 	func(r *rand.Rand) { maxBlockLock = GenMaxBlockLock(r, minBlockLock) },
-	// )
 
 	var supportedAssets types.AssetParams
 	simState.AppParams.GetOrGenerate(
@@ -156,7 +144,6 @@ func loadAuthGenState(simState *module.SimulationState, bep3Genesis types.Genesi
 	return authGenesis, totalCoins
 }
 
-// TODO: This function can be refactored
 // loadBondedAddresses loads an array of bonded account addresses
 func loadBondedAddresses(simState *module.SimulationState) []sdk.AccAddress {
 	addrs := make([]sdk.AccAddress, simState.NumBonded)

--- a/x/bep3/simulation/genesis.go
+++ b/x/bep3/simulation/genesis.go
@@ -25,8 +25,9 @@ const (
 )
 
 var (
-	MaxSupplyLimit = sdk.NewInt(10000000000000000)
-	Accs           []simulation.Account
+	MaxSupplyLimit   = sdk.NewInt(10000000000000000)
+	Accs             []simulation.Account
+	ConsistentDenoms = [3]string{"bnb", "xrp", "btc"}
 )
 
 // GenBnbDeputyAddress randomized BnbDeputyAddress
@@ -53,14 +54,18 @@ func GenSupportedAssets(r *rand.Rand) types.AssetParams {
 	var assets types.AssetParams
 	for i := 0; i < (r.Intn(10) + 1); i++ {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		asset := genSupportedAsset(r)
+		denom := strings.ToLower(simulation.RandStringOfLength(r, (r.Intn(3) + 3)))
+		asset := genSupportedAsset(r, denom)
 		assets = append(assets, asset)
 	}
+	// Add bnb, btc, or xrp as a supported asset for interactions with other modules
+	stableAsset := genSupportedAsset(r, ConsistentDenoms[r.Intn(3)])
+	assets = append(assets, stableAsset)
+
 	return assets
 }
 
-func genSupportedAsset(r *rand.Rand) types.AssetParam {
-	denom := strings.ToLower(simulation.RandStringOfLength(r, (r.Intn(3) + 3)))
+func genSupportedAsset(r *rand.Rand, denom string) types.AssetParam {
 	coinID, _ := simulation.RandPositiveInt(r, sdk.NewInt(100000))
 	limit, _ := simulation.RandPositiveInt(r, MaxSupplyLimit)
 	return types.AssetParam{

--- a/x/bep3/simulation/genesis.go
+++ b/x/bep3/simulation/genesis.go
@@ -98,17 +98,21 @@ func loadRandomBep3GenState(simState *module.SimulationState) types.GenesisState
 		func(r *rand.Rand) { bnbDeputyAddress = GenBnbDeputyAddress(r) },
 	)
 
-	var minBlockLock int64
-	simState.AppParams.GetOrGenerate(
-		simState.Cdc, MinBlockLock, &minBlockLock, simState.Rand,
-		func(r *rand.Rand) { minBlockLock = GenMinBlockLock(r) },
-	)
+	fmt.Println("simState:", simState.AppParams)
+	// TODO: set minBlockLock/maxBlockLock based off sim.numBlocks
+	minBlockLock := int64(types.AbsoluteMinimumBlockLock)
+	// var minBlockLock int64
+	// simState.AppParams.GetOrGenerate(
+	// 	simState.Cdc, MinBlockLock, &minBlockLock, simState.Rand,
+	// 	func(r *rand.Rand) { minBlockLock = GenMinBlockLock(r) },
+	// )
 
-	var maxBlockLock int64
-	simState.AppParams.GetOrGenerate(
-		simState.Cdc, MaxBlockLock, &maxBlockLock, simState.Rand,
-		func(r *rand.Rand) { maxBlockLock = GenMaxBlockLock(r, minBlockLock) },
-	)
+	maxBlockLock := minBlockLock * 2
+	// var maxBlockLock int64
+	// simState.AppParams.GetOrGenerate(
+	// 	simState.Cdc, MaxBlockLock, &maxBlockLock, simState.Rand,
+	// 	func(r *rand.Rand) { maxBlockLock = GenMaxBlockLock(r, minBlockLock) },
+	// )
 
 	var supportedAssets types.AssetParams
 	simState.AppParams.GetOrGenerate(

--- a/x/bep3/simulation/operations/msg.go
+++ b/x/bep3/simulation/operations/msg.go
@@ -37,10 +37,8 @@ func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulat
 		if err != nil {
 			return noOpMsg, nil, err
 		}
-
 		// Must use current blocktime instead of 'now' since initial blocktime was randomly generated
 		timestamp := ctx.BlockTime().Unix()
-
 		randomNumberHash := types.CalculateRandomHash(randomNumber.Bytes(), timestamp)
 
 		// Randomly select an asset from supported assets
@@ -68,9 +66,10 @@ func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulat
 		coins := sdk.NewCoins(coin)
 		expectedIncome := coin.String()
 
-		minLock := int(k.GetMinBlockLock(ctx))
-		maxLock := int(k.GetMaxBlockLock(ctx))
-		heightSpan := int64(r.Intn(maxLock-minLock) + minLock)
+		// minLock := int(k.GetMinBlockLock(ctx))
+		// maxLock := int(k.GetMaxBlockLock(ctx))
+		// TODO: heightSpan := int64(r.Intn(maxLock-minLock) + minLock)
+		heightSpan := int64(55)
 		crossChain := true
 
 		msg := types.NewMsgCreateAtomicSwap(
@@ -78,20 +77,76 @@ func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulat
 			timestamp, coins, expectedIncome, heightSpan, crossChain)
 
 		if err := msg.ValidateBasic(); err != nil {
-			return noOpMsg, nil, fmt.Errorf("expected msg to pass ValidateBasic: %s", err)
+			return noOpMsg, nil, fmt.Errorf("expected MsgCreateAtomicSwap to pass ValidateBasic: %s", err)
 		}
 
 		// Submit msg
 		ok := submitMsg(ctx, handler, msg)
 
-		// TODO: Create FutureOperation claimOp/refundOp
-		return simulation.NewOperationMsg(msg, ok, ""), nil, nil
+		// If created, construct a MsgClaimAtomicSwap or MsgRefundAtomicSwap future operation
+		var futureOp simulation.FutureOperation
+		if ok {
+			swapID := types.CalculateSwapID(msg.RandomNumberHash, msg.From, msg.SenderOtherChain)
+			acc := simulation.RandomAcc(r, accs)
+			evenOdd := r.Intn(2) + 1
+			if evenOdd%2 == 0 {
+				// Claim future operation
+				executionBlock := ctx.BlockHeight() + (msg.HeightSpan / 2)
+				futureOp = loadClaimFutureOp(acc.Address, swapID, randomNumber.Bytes(), executionBlock, handler)
+			} else {
+				// Refund future operation
+				executionBlock := ctx.BlockHeight() + msg.HeightSpan
+				futureOp = loadRefundFutureOp(acc.Address, swapID, executionBlock, handler)
+			}
+		}
+
+		return simulation.NewOperationMsg(msg, ok, ""), []simulation.FutureOperation{futureOp}, nil
+	}
+}
+
+func loadClaimFutureOp(sender sdk.AccAddress, swapID []byte, randomNumber []byte, height int64, handler sdk.Handler) simulation.FutureOperation {
+	claimOp := func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account) (
+		simulation.OperationMsg, []simulation.FutureOperation, error) {
+
+		// Build the refund msg and validate basic
+		claimMsg := types.NewMsgClaimAtomicSwap(sender, swapID, randomNumber)
+		if err := claimMsg.ValidateBasic(); err != nil {
+			return noOpMsg, nil, fmt.Errorf("expected MsgClaimAtomicSwap to pass ValidateBasic: %s", err)
+		}
+
+		// Test msg submission at target block height
+		ok := handler(ctx.WithBlockHeight(height), claimMsg).IsOK()
+		return simulation.NewOperationMsg(claimMsg, ok, ""), nil, nil
+	}
+
+	return simulation.FutureOperation{
+		BlockHeight: int(height),
+		Op:          claimOp,
+	}
+}
+
+func loadRefundFutureOp(sender sdk.AccAddress, swapID []byte, height int64, handler sdk.Handler) simulation.FutureOperation {
+	refundOp := func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account) (
+		simulation.OperationMsg, []simulation.FutureOperation, error) {
+		// Build the refund msg and validate basic
+		refundMsg := types.NewMsgRefundAtomicSwap(sender, swapID)
+		if err := refundMsg.ValidateBasic(); err != nil {
+			return noOpMsg, nil, fmt.Errorf("expected MsgRefundAtomicSwap to pass ValidateBasic: %s", err)
+		}
+
+		// Test msg submission at target block height
+		ok := handler(ctx.WithBlockHeight(height), refundMsg).IsOK()
+		return simulation.NewOperationMsg(refundMsg, ok, ""), nil, nil
+	}
+
+	return simulation.FutureOperation{
+		BlockHeight: int(height),
+		Op:          refundOp,
 	}
 }
 
 func submitMsg(ctx sdk.Context, handler sdk.Handler, msg sdk.Msg) (ok bool) {
 	ctx, write := ctx.CacheContext()
-	// TODO: I really want to get '.Log' out of handler(), but can't because it duplicates msg submission
 	ok = handler(ctx, msg).IsOK()
 	if ok {
 		write()

--- a/x/bep3/simulation/operations/msg.go
+++ b/x/bep3/simulation/operations/msg.go
@@ -1,0 +1,100 @@
+package operations
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/kava-labs/kava/x/bep3"
+	"github.com/kava-labs/kava/x/bep3/keeper"
+	"github.com/kava-labs/kava/x/bep3/types"
+)
+
+var (
+	noOpMsg = simulation.NoOpMsg(bep3.ModuleName)
+)
+
+// SimulateMsgCreateAtomicSwap generates a MsgCreateAtomicSwap with random values
+func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulation.Operation {
+	handler := bep3.NewHandler(k)
+
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account) (
+		simulation.OperationMsg, []simulation.FutureOperation, error) {
+
+		sender := k.GetBnbDeputyAddress(ctx)
+		recipient := simulation.RandomAcc(r, accs).Address
+
+		recipientOtherChain := simulation.RandStringOfLength(r, 43)
+		senderOtherChain := simulation.RandStringOfLength(r, 43)
+
+		// Generate cryptographically strong pseudo-random number
+		randomNumber, err := types.GenerateSecureRandomNumber()
+		if err != nil {
+			return noOpMsg, nil, err
+		}
+
+		// Must use current blocktime instead of 'now' since initial blocktime was randomly generated
+		timestamp := ctx.BlockTime().Unix()
+
+		randomNumberHash := types.CalculateRandomHash(randomNumber.Bytes(), timestamp)
+
+		// Randomly select an asset from supported assets
+		assets, found := k.GetAssets(ctx)
+		if !found {
+			return noOpMsg, nil, fmt.Errorf("no supported assets found")
+		}
+		asset := assets[r.Intn(len(assets))]
+
+		// Check that the sender has coins of this type
+		availableAmount := ak.GetAccount(ctx, sender).GetCoins().AmountOf(asset.Denom)
+		if !availableAmount.IsPositive() {
+			return noOpMsg, nil, fmt.Errorf("available amount must be positive")
+		}
+
+		// Get a random amount of the available coins
+		amount, err := simulation.RandPositiveInt(r, availableAmount)
+		if err != nil {
+			return noOpMsg, nil, err
+		}
+
+		// If we don't adjust the conversion factor, we'll be out of funds soon
+		adjustedAmount := amount.Int64() / int64(math.Pow10(8))
+		coin := sdk.NewInt64Coin(asset.Denom, adjustedAmount)
+		coins := sdk.NewCoins(coin)
+		expectedIncome := coin.String()
+
+		minLock := int(k.GetMinBlockLock(ctx))
+		maxLock := int(k.GetMaxBlockLock(ctx))
+		heightSpan := int64(r.Intn(maxLock-minLock) + minLock)
+		crossChain := true
+
+		msg := types.NewMsgCreateAtomicSwap(
+			sender, recipient, recipientOtherChain, senderOtherChain, randomNumberHash,
+			timestamp, coins, expectedIncome, heightSpan, crossChain)
+
+		if err := msg.ValidateBasic(); err != nil {
+			return noOpMsg, nil, fmt.Errorf("expected msg to pass ValidateBasic: %s", err)
+		}
+
+		// Submit msg
+		ok := submitMsg(ctx, handler, msg)
+
+		// TODO: Create FutureOperation claimOp/refundOp
+		return simulation.NewOperationMsg(msg, ok, ""), nil, nil
+	}
+}
+
+func submitMsg(ctx sdk.Context, handler sdk.Handler, msg sdk.Msg) (ok bool) {
+	ctx, write := ctx.CacheContext()
+	// TODO: I really want to get '.Log' out of handler(), but can't because it duplicates msg submission
+	ok = handler(ctx, msg).IsOK()
+	if ok {
+		write()
+	}
+	return ok
+}

--- a/x/bep3/simulation/operations/msg.go
+++ b/x/bep3/simulation/operations/msg.go
@@ -66,9 +66,7 @@ func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulat
 		coins := sdk.NewCoins(coin)
 		expectedIncome := coin.String()
 
-		// minLock := int(k.GetMinBlockLock(ctx))
-		// maxLock := int(k.GetMaxBlockLock(ctx))
-		// TODO: heightSpan := int64(r.Intn(maxLock-minLock) + minLock)
+		// We're assuming that sims are run with -NumBlocks=100
 		heightSpan := int64(55)
 		crossChain := true
 

--- a/x/bep3/simulation/params.go
+++ b/x/bep3/simulation/params.go
@@ -1,14 +1,46 @@
 package simulation
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/kava-labs/kava/x/bep3/types"
+)
+
+const (
+	keyBnbDeputyAddress = "BnbDeputyAddress"
+	keyMinBlockLock     = "MinBlockLock"
+	keyMaxBlockLock     = "MaxBlockLock"
+	keySupportedAssets  = "SupportedAssets"
 )
 
 // ParamChanges defines the parameters that can be modified by param change proposals
-// on the simulation
 func ParamChanges(r *rand.Rand) []simulation.ParamChange {
-	// TODO implement this
-	return []simulation.ParamChange{}
+	// We generate MinBlockLock first because the result is required by GenMaxBlockLock()
+	minBlockLockVal := GenMinBlockLock(r)
+
+	return []simulation.ParamChange{
+		simulation.NewSimParamChange(types.ModuleName, keyBnbDeputyAddress, "",
+			func(r *rand.Rand) string {
+				return fmt.Sprintf("\"%s\"", GenBnbDeputyAddress(r))
+			},
+		),
+		simulation.NewSimParamChange(types.ModuleName, keyMinBlockLock, "",
+			func(r *rand.Rand) string {
+				return fmt.Sprintf("\"%d\"", minBlockLockVal)
+			},
+		),
+		simulation.NewSimParamChange(types.ModuleName, keyMaxBlockLock, "",
+			func(r *rand.Rand) string {
+				return fmt.Sprintf("\"%d\"", GenMaxBlockLock(r, minBlockLockVal))
+			},
+		),
+		simulation.NewSimParamChange(types.ModuleName, keySupportedAssets, "",
+			func(r *rand.Rand) string {
+				return fmt.Sprintf("\"%v\"", GenSupportedAssets(r))
+			},
+		),
+	}
 }


### PR DESCRIPTION
This PR implements simulations for the BEP3 module.

Test simulations with `go test -mod=readonly ./app -run TestFullAppSimulation -Enabled -Commit -NumBlocks=100 -BlockSize=200 -Seed 2 -v -timeout 24h`

**Result**: 
```
...
"bep3": {
  "claimAtomicSwap": {
   "ok": 294
  },
  "createAtomicSwap": {
   "ok": 596
  },
  "refundAtomicSwap": {
   "ok": 302
  }
 }
...

GoLevelDB Stats
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------
   0   |          0 |       0.00000 |       0.09944 |       0.00000 |       4.49568
   1   |          1 |       1.51839 |       0.05802 |       4.49568 |       1.51839
-------+------------+---------------+---------------+---------------+---------------
 Total |          1 |       1.51839 |       0.15746 |       4.49568 |       6.01406

GoLevelDB cached block size 6265668
--- PASS: TestFullAppSimulation (34.99s)
PASS
ok      github.com/kava-labs/kava/app   35.088s
```

**Example BEP3 genesis state**:
```
Selected randomly generated bep3 parameters:
{
  "params": {
    "bnb_deputy_address": "kava19tx2kk0zyanymkaaf9es37ne3cx4zwy578fzg4",
    "min_block_lock": "2164",
    "max_block_lock": "8864",
    "supported_assets": [
      {
        "denom": "fywr",
        "coin_id": "20504",
        "limit": "4844229383411619",
        "active": true
      },
      {
        "denom": "xsh",
        "coin_id": "79534",
        "limit": "107355888546487",
        "active": true
      },
      {
        "denom": "zrk",
        "coin_id": "35580",
        "limit": "8408492798759511",
        "active": true
      },
      {
        "denom": "eoypw",
        "coin_id": "44910",
        "limit": "2618520531750665",
        "active": true
      },
      {
        "denom": "ndyc",
        "coin_id": "44815",
        "limit": "9772997587403019",
        "active": true
      },
      {
        "denom": "qji",
        "coin_id": "54046",
        "limit": "3806111389327919",
        "active": true
      },
      {
        "denom": "mvr",
        "coin_id": "88406",
        "limit": "9410408182287019",
        "active": true
      }
    ]
  },
  "atomic_swaps": null,
  "assets_supplies": null
}
```