### PR TITLE
[R4R] Fix: prevent cdp sim from attempting to draw too much debt

### DIFF
--- a/x/cdp/simulation/operations/msgs.go
+++ b/x/cdp/simulation/operations/msgs.go
@@ -127,7 +127,7 @@ func SimulateMsgCdp(ak auth.AccountKeeper, k cdp.Keeper, pfk pricefeed.Keeper) s
 			// given the current collateral value, calculate how much debt we could add while maintaining a valid liquidation ratio
 			debt := existingCDP.Principal.AmountOf(randDebtParam.Denom).Add(totalFees)
 			maxTotalDebt := collateralValue.Quo(randCollateralParam.LiquidationRatio)
-			maxDebt := maxTotalDebt.Sub(sdk.NewDecFromInt(debt)).TruncateInt() // subtract 10 off of maxDebt to account for fees that may have accumulated and not yet accrued to AccumulatedFees.
+			maxDebt := maxTotalDebt.Sub(sdk.NewDecFromInt(debt)).TruncateInt()
 			if maxDebt.LTE(sdk.OneInt()) {
 				// debt in cdp is maxed out
 				return simulation.NewOperationMsgBasic(cdp.ModuleName, "no-operation", "cdp debt maxed out, cannot draw more debt", false, nil), nil, nil

--- a/x/cdp/simulation/operations/msgs.go
+++ b/x/cdp/simulation/operations/msgs.go
@@ -122,10 +122,12 @@ func SimulateMsgCdp(ak auth.AccountKeeper, k cdp.Keeper, pfk pricefeed.Keeper) s
 		if shouldDraw(r) {
 			collateralShifted := ShiftDec(sdk.NewDecFromInt(existingCDP.Collateral.AmountOf(randCollateralParam.Denom)), randCollateralParam.ConversionFactor.Neg())
 			collateralValue := collateralShifted.Mul(priceShifted)
+			newFeesAccumulated := k.CalculateFees(ctx, existingCDP.Principal, sdk.NewInt(ctx.BlockTime().Unix()-existingCDP.FeesUpdated.Unix()), randCollateralParam.Denom).AmountOf(randDebtParam.Denom)
+			totalFees := existingCDP.AccumulatedFees.AmountOf(randCollateralParam.Denom).Add(newFeesAccumulated)
 			// given the current collateral value, calculate how much debt we could add while maintaining a valid liquidation ratio
-			debt := (existingCDP.Principal.Add(existingCDP.AccumulatedFees)).AmountOf(randDebtParam.Denom)
+			debt := existingCDP.Principal.AmountOf(randDebtParam.Denom).Add(totalFees)
 			maxTotalDebt := collateralValue.Quo(randCollateralParam.LiquidationRatio)
-			maxDebt := maxTotalDebt.Sub(sdk.NewDecFromInt(debt)).TruncateInt()
+			maxDebt := maxTotalDebt.Sub(sdk.NewDecFromInt(debt)).TruncateInt() // subtract 10 off of maxDebt to account for fees that may have accumulated and not yet accrued to AccumulatedFees.
 			if maxDebt.LTE(sdk.OneInt()) {
 				// debt in cdp is maxed out
 				return simulation.NewOperationMsgBasic(cdp.ModuleName, "no-operation", "cdp debt maxed out, cannot draw more debt", false, nil), nil, nil


### PR DESCRIPTION
Sim `running non-determinism simulation; seed 8674665223082153551: 2/3, attempt: 1/5` was failing with 
```
Simulating... block 96/100, operation 100/146. {"codespace":"cdp","code":6,"message":"proposed collateral ratio of 1.499940240597705977 is below liqudation ratio of 1.500000000000000000 for collateral bnb"}
```

Fixed to account for fees that have accumulated since the CDP was last updated.