### PR TITLE
[R4R]: Avoid divide by zero when price is very small

### DIFF
--- a/x/cdp/keeper/fees.go
+++ b/x/cdp/keeper/fees.go
@@ -41,9 +41,12 @@ func (k Keeper) UpdateFeesForRiskyCdps(ctx sdk.Context, collateralDenom string, 
 	}
 
 	liquidationRatio := k.getLiquidationRatio(ctx, collateralDenom)
-
+	priceDivLiqRatio := price.Price.Quo(liquidationRatio)
+	if priceDivLiqRatio.IsZero() {
+		priceDivLiqRatio = sdk.SmallestDec()
+	}
 	// NOTE - we have a fixed cutoff at 110% - this may or may not be changed in the future
-	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(liquidationRatio)).Mul(sdk.MustNewDecFromStr("1.1"))
+	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio).Mul(sdk.MustNewDecFromStr("1.1"))
 
 	// now iterate over all the cdps based on collateral ratio
 	k.IterateCdpsByCollateralRatio(ctx, collateralDenom, normalizedRatio, func(cdp types.CDP) bool {

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -116,7 +116,7 @@ func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, denom string, li
 	// price = $0.5
 	// liquidation ratio = 1.5
 	// normalizedRatio = (1/(0.5/1.5)) = 3
-	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(priceDivLiqRatio))
+	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio)
 	cdpsToLiquidate := k.GetAllCdpsByDenomAndRatio(ctx, denom, normalizedRatio)
 	for _, c := range cdpsToLiquidate {
 		err := k.SeizeCollateral(ctx, c)

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -109,10 +109,14 @@ func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, denom string, li
 	if err != nil {
 		return err
 	}
+	priceDivLiqRatio := price.Price.Quo(liquidationRatio)
+	if priceDivLiqRatio.IsZero() {
+		priceDivLiqRatio = sdk.SmallestDec()
+	}
 	// price = $0.5
 	// liquidation ratio = 1.5
 	// normalizedRatio = (1/(0.5/1.5)) = 3
-	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(liquidationRatio))
+	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(priceDivLiqRatio))
 	cdpsToLiquidate := k.GetAllCdpsByDenomAndRatio(ctx, denom, normalizedRatio)
 	for _, c := range cdpsToLiquidate {
 		err := k.SeizeCollateral(ctx, c)


### PR DESCRIPTION
Fixes divide by zero panic from simulations where price is equal to `sdk.SmallestDec` and Liquidation Ratio >= 2