### PR TITLE
[R4R] Bep3 sim changes

### DIFF
--- a/x/bep3/simulation/genesis.go
+++ b/x/bep3/simulation/genesis.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	MaxSupplyLimit   = sdk.NewInt(10000000000000000)
+	MaxSupplyLimit   = sdk.NewInt(1000000000000)
 	Accs             []simulation.Account
 	ConsistentDenoms = [3]string{"bnb", "xrp", "btc"}
 )


### PR DESCRIPTION
* Changes claim amount to be a random, small percentage of the deputy's funds, rather than a random draw from the whole amount.
* Logs and returns `noOpMsg` instead of throwing when all coins for a particular swap denom have been exhausted. 
* Changes the initial supply to avoid cases where hundreds of thousands of auctions are being created. 