### PR TITLE
[R4R] Fix pricefeed non-determinism

### DIFF
--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -304,7 +304,7 @@ func testAndRunTxs(app *App, config simulation.Config) []simulation.WeightedOper
 					})
 				return v
 			}(nil),
-			pricefeedsimops.SimulateMsgUpdatePrices(app.pricefeedKeeper),
+			pricefeedsimops.SimulateMsgUpdatePrices(app.pricefeedKeeper, config.NumBlocks),
 		},
 		{
 			func(_ *rand.Rand) int {


### PR DESCRIPTION
Fixes issue where multiple calls to `SimulateFromSeed` with the same seed would use the old 'recentPrice' variables and thus not be deterministic between runs. Uses  `sync.Once` to initialize a random walk for each market at the beginning of sim. 

Note: I'm pretty sure this means that calling `SimulateFromSeed` multiple times in the same simulation with different seeds, as is done in `TestAppStateDeterminism`, will create the same array of prices for all runs. There is probably a way to reinitialize the prices whenever the seed changes, but I'll call this sufficient for now, as our general simulation strategy strategy is to run lots of separate simulations with different seeds.  