### PR TITLE
[R4R] Update pricefeed sims genesis

### DIFF
--- a/x/cdp/keeper/fees.go
+++ b/x/cdp/keeper/fees.go
@@ -41,9 +41,12 @@ func (k Keeper) UpdateFeesForRiskyCdps(ctx sdk.Context, collateralDenom string, 
 	}
 
 	liquidationRatio := k.getLiquidationRatio(ctx, collateralDenom)
-
+	priceDivLiqRatio := price.Price.Quo(liquidationRatio)
+	if priceDivLiqRatio.IsZero() {
+		priceDivLiqRatio = sdk.SmallestDec()
+	}
 	// NOTE - we have a fixed cutoff at 110% - this may or may not be changed in the future
-	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(liquidationRatio)).Mul(sdk.MustNewDecFromStr("1.1"))
+	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio).Mul(sdk.MustNewDecFromStr("1.1"))
 
 	// now iterate over all the cdps based on collateral ratio
 	k.IterateCdpsByCollateralRatio(ctx, collateralDenom, normalizedRatio, func(cdp types.CDP) bool {

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -109,10 +109,14 @@ func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, denom string, li
 	if err != nil {
 		return err
 	}
+	priceDivLiqRatio := price.Price.Quo(liquidationRatio)
+	if priceDivLiqRatio.IsZero() {
+		priceDivLiqRatio = sdk.SmallestDec()
+	}
 	// price = $0.5
 	// liquidation ratio = 1.5
 	// normalizedRatio = (1/(0.5/1.5)) = 3
-	normalizedRatio := sdk.OneDec().Quo(price.Price.Quo(liquidationRatio))
+	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio)
 	cdpsToLiquidate := k.GetAllCdpsByDenomAndRatio(ctx, denom, normalizedRatio)
 	for _, c := range cdpsToLiquidate {
 		err := k.SeizeCollateral(ctx, c)

--- a/x/pricefeed/simulation/genesis.go
+++ b/x/pricefeed/simulation/genesis.go
@@ -12,40 +12,48 @@ import (
 	pricefeed "github.com/kava-labs/kava/x/pricefeed/types"
 )
 
+var (
+	BaseAssets = [3]string{"bnb", "xrp", "btc"}
+	QuoteAsset = "usd"
+)
+
 // RandomizedGenState generates a random GenesisState for pricefeed
 func RandomizedGenState(simState *module.SimulationState) {
-	// get the params with xrp, btc and bnb to usd
-	// getPricefeedSimulationParams is defined to return params with xrp:usd, btc:usd, bnb:usd
-	params := getPricefeedSimulationParams()
-	markets := []types.Market{}
-	genPrices := []types.PostedPrice{}
-	// chose one account to be the oracle
-	oracle := simState.Accounts[simulation.RandIntBetween(simState.Rand, 0, len(simState.Accounts))]
-	for _, market := range params.Markets {
-		updatedMarket := types.Market{market.MarketID, market.BaseAsset, market.QuoteAsset, []sdk.AccAddress{oracle.Address}, true}
-		markets = append(markets, updatedMarket)
-		genPrice := types.PostedPrice{market.MarketID, oracle.Address, getInitialPrice(market.MarketID), simState.GenTimestamp.Add(time.Hour * 24)}
-		genPrices = append(genPrices, genPrice)
-	}
-	params = types.NewParams(markets)
-	pricefeedGenesis := types.NewGenesisState(params, genPrices)
+	pricefeedGenesis := loadPricefeedGenState(simState)
 	fmt.Printf("Selected randomly generated %s parameters:\n%s\n", types.ModuleName, codec.MustMarshalJSONIndent(simState.Cdc, pricefeedGenesis))
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(pricefeedGenesis)
 }
 
-// getPricefeedSimulationParams returns the params with xrp:usd, btc:usd, bnb:usd
-func getPricefeedSimulationParams() types.Params {
-	// SET UP THE PRICEFEED GENESIS STATE
-	pricefeedGenesis := pricefeed.GenesisState{
-		Params: pricefeed.Params{
-			Markets: []pricefeed.Market{
-				pricefeed.Market{MarketID: "btc:usd", BaseAsset: "btc", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-				pricefeed.Market{MarketID: "xrp:usd", BaseAsset: "xrp", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-				pricefeed.Market{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-			},
-		},
+// loadPricefeedGenState loads a valid pricefeed gen state
+func loadPricefeedGenState(simState *module.SimulationState) pricefeed.GenesisState {
+	var markets []pricefeed.Market
+	var postedPrices []pricefeed.PostedPrice
+	for _, denom := range BaseAssets {
+		// Select an account to be the oracle
+		oracle := simState.Accounts[simulation.RandIntBetween(simState.Rand, 0, len(simState.Accounts))]
+
+		marketID := fmt.Sprintf("%s:%s", denom, QuoteAsset)
+		// Construct market for asset
+		market := pricefeed.Market{
+			MarketID:   marketID,
+			BaseAsset:  denom,
+			QuoteAsset: QuoteAsset,
+			Oracles:    []sdk.AccAddress{oracle.Address},
+			Active:     true,
+		}
+
+		// Construct posted price for asset
+		postedPrice := pricefeed.PostedPrice{
+			MarketID:      market.MarketID,
+			OracleAddress: oracle.Address,
+			Price:         getInitialPrice(marketID),
+			Expiry:        simState.GenTimestamp.Add(time.Hour * 24 * 36500), // 1000 years
+		}
+		markets = append(markets, market)
+		postedPrices = append(postedPrices, postedPrice)
 	}
-	return pricefeedGenesis.Params
+	params := pricefeed.NewParams(markets)
+	return pricefeed.NewGenesisState(params, postedPrices)
 }
 
 // getInitialPrice gets the starting price for each of the base assets

--- a/x/pricefeed/simulation/genesis.go
+++ b/x/pricefeed/simulation/genesis.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	// BaseAssets is a list of collateral asset denoms
 	BaseAssets = [3]string{"bnb", "xrp", "btc"}
 	QuoteAsset = "usd"
 )
@@ -57,14 +58,15 @@ func loadPricefeedGenState(simState *module.SimulationState) pricefeed.GenesisSt
 }
 
 // getInitialPrice gets the starting price for each of the base assets
-func getInitialPrice(marketId string) (price sdk.Dec) {
-	switch marketId {
+func getInitialPrice(marketID string) (price sdk.Dec) {
+	switch marketID {
 	case "btc:usd":
 		return sdk.MustNewDecFromStr("7000")
 	case "bnb:usd":
 		return sdk.MustNewDecFromStr("14")
 	case "xrp:usd":
 		return sdk.MustNewDecFromStr("0.2")
+	default:
+		return sdk.MustNewDecFromStr("20") // Catch future additional assets
 	}
-	panic(fmt.Sprintf("Invalid marketId in getInitialPrice: %s\n", marketId))
 }

--- a/x/pricefeed/simulation/genesis.go
+++ b/x/pricefeed/simulation/genesis.go
@@ -48,7 +48,7 @@ func loadPricefeedGenState(simState *module.SimulationState) pricefeed.GenesisSt
 			MarketID:      market.MarketID,
 			OracleAddress: oracle.Address,
 			Price:         getInitialPrice(marketID),
-			Expiry:        simState.GenTimestamp.Add(time.Hour * 24 * 36500), // 1000 years
+			Expiry:        simState.GenTimestamp.Add(time.Hour * 24),
 		}
 		markets = append(markets, market)
 		postedPrices = append(postedPrices, postedPrice)


### PR DESCRIPTION
Implemented a version of pricefeed genesis state generation while working on incentive sims. I didn't end up using it, so I'm submitting it as an enhancement. Assets can be added to `BaseAssets` at the top, enabling a more dynamic asset list.

We should consider randomizing the genesis state:
- Adding more than 1 oracle, because if `len(oracles) > 1` market prices are the average of valid submitted prices.
- Different expiry times for posted prices.
- Different prices for initial posted prices. I think a range of `0.000001 < x < 10,000,000` makes sense for pricefeed sims.

** **Edit**: it looks like we can reuse part of the random params generation methods in https://github.com/Kava-Labs/kava/pull/434. I've also updated the base branch from master to jd-pricefeed-fix.