### PR TITLE
[R4R] Enable bep3 claim txs from new addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -311,6 +311,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		app.cdc,
 		keys[bep3.StoreKey],
 		app.supplyKeeper,
+		app.accountKeeper,
 		bep3Subspace,
 	)
 	app.kavadistKeeper = kavadist.NewKeeper(

--- a/x/bep3/alias.go
+++ b/x/bep3/alias.go
@@ -135,7 +135,6 @@ type (
 	QueryAssetSupply    = types.QueryAssetSupply
 	QueryAtomicSwapByID = types.QueryAtomicSwapByID
 	QueryAtomicSwaps    = types.QueryAtomicSwaps
-	SupplyKeeper        = types.SupplyKeeper
 	SwapDirection       = types.SwapDirection
 	SwapStatus          = types.SwapStatus
 )

--- a/x/bep3/genesis.go
+++ b/x/bep3/genesis.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/bep3/types"
 )
 
 // InitGenesis initializes the store state from a genesis state.
-func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper SupplyKeeper, gs GenesisState) {
+func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper types.SupplyKeeper, gs GenesisState) {
 	if err := gs.Validate(); err != nil {
 		panic(fmt.Sprintf("failed to validate %s genesis state: %s", ModuleName, err))
 	}

--- a/x/bep3/keeper/keeper.go
+++ b/x/bep3/keeper/keeper.go
@@ -19,10 +19,14 @@ type Keeper struct {
 	cdc           *codec.Codec
 	paramSubspace subspace.Subspace
 	supplyKeeper  types.SupplyKeeper
+	accountKeeper types.AccountKeeper
 }
 
 // NewKeeper creates a bep3 keeper
-func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, sk types.SupplyKeeper, paramstore subspace.Subspace) Keeper {
+func NewKeeper(cdc *codec.Codec, key sdk.StoreKey,
+	sk types.SupplyKeeper, ak types.AccountKeeper,
+	paramstore subspace.Subspace,
+) Keeper {
 	if addr := sk.GetModuleAddress(types.ModuleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
 	}
@@ -36,6 +40,7 @@ func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, sk types.SupplyKeeper, params
 		cdc:           cdc,
 		paramSubspace: paramstore,
 		supplyKeeper:  sk,
+		accountKeeper: ak,
 	}
 	return keeper
 }

--- a/x/bep3/keeper/swap.go
+++ b/x/bep3/keeper/swap.go
@@ -55,7 +55,8 @@ func (k Keeper) CreateAtomicSwap(ctx sdk.Context, randomNumberHash []byte, times
 
 	switch direction {
 	case types.Incoming:
-		// If recipient's account doesn't exist, register it in state
+		// If recipient's account doesn't exist, register it in state so that the address can send
+		// a claim swap tx without needing to be registered in state by receiving a coin transfer.
 		recipientAcc := k.accountKeeper.GetAccount(ctx, recipient)
 		if recipientAcc == nil {
 			newAcc := k.accountKeeper.NewAccountWithAddress(ctx, recipient)

--- a/x/bep3/keeper/swap.go
+++ b/x/bep3/keeper/swap.go
@@ -56,6 +56,12 @@ func (k Keeper) CreateAtomicSwap(ctx sdk.Context, randomNumberHash []byte, times
 	switch direction {
 	case types.Incoming:
 		err = k.IncrementIncomingAssetSupply(ctx, amount[0])
+		// If recipient's account doesn't exist, register it in state
+		recipientAcc := k.accountKeeper.GetAccount(ctx, recipient)
+		if recipientAcc == nil {
+			newAcc := k.accountKeeper.NewAccountWithAddress(ctx, recipient)
+			k.accountKeeper.SetAccount(ctx, newAcc)
+		}
 	case types.Outgoing:
 		err = k.IncrementOutgoingAssetSupply(ctx, amount[0])
 	default:

--- a/x/bep3/keeper/swap.go
+++ b/x/bep3/keeper/swap.go
@@ -55,13 +55,13 @@ func (k Keeper) CreateAtomicSwap(ctx sdk.Context, randomNumberHash []byte, times
 
 	switch direction {
 	case types.Incoming:
-		err = k.IncrementIncomingAssetSupply(ctx, amount[0])
 		// If recipient's account doesn't exist, register it in state
 		recipientAcc := k.accountKeeper.GetAccount(ctx, recipient)
 		if recipientAcc == nil {
 			newAcc := k.accountKeeper.NewAccountWithAddress(ctx, recipient)
 			k.accountKeeper.SetAccount(ctx, newAcc)
 		}
+		err = k.IncrementIncomingAssetSupply(ctx, amount[0])
 	case types.Outgoing:
 		err = k.IncrementOutgoingAssetSupply(ctx, amount[0])
 	default:

--- a/x/bep3/module.go
+++ b/x/bep3/module.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth"
 	sim "github.com/cosmos/cosmos-sdk/x/simulation"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -19,6 +18,7 @@ import (
 	"github.com/kava-labs/kava/x/bep3/client/cli"
 	"github.com/kava-labs/kava/x/bep3/client/rest"
 	"github.com/kava-labs/kava/x/bep3/simulation"
+	"github.com/kava-labs/kava/x/bep3/types"
 )
 
 var (
@@ -78,12 +78,12 @@ type AppModule struct {
 	AppModuleBasic
 
 	keeper        Keeper
-	accountKeeper auth.AccountKeeper
-	supplyKeeper  SupplyKeeper
+	accountKeeper types.AccountKeeper
+	supplyKeeper  types.SupplyKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(keeper Keeper, accountKeeper auth.AccountKeeper, supplyKeeper SupplyKeeper) AppModule {
+func NewAppModule(keeper Keeper, accountKeeper types.AccountKeeper, supplyKeeper types.SupplyKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         keeper,

--- a/x/bep3/simulation/operations.go
+++ b/x/bep3/simulation/operations.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp/helpers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
 	appparams "github.com/kava-labs/kava/app/params"
@@ -28,7 +27,7 @@ const (
 
 // WeightedOperations returns all the operations from the module with their respective weights
 func WeightedOperations(
-	appParams simulation.AppParams, cdc *codec.Codec, ak auth.AccountKeeper, k keeper.Keeper,
+	appParams simulation.AppParams, cdc *codec.Codec, ak types.AccountKeeper, k keeper.Keeper,
 ) simulation.WeightedOperations {
 	var weightCreateAtomicSwap int
 
@@ -47,7 +46,7 @@ func WeightedOperations(
 }
 
 // SimulateMsgCreateAtomicSwap generates a MsgCreateAtomicSwap with random values
-func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulation.Operation {
+func SimulateMsgCreateAtomicSwap(ak types.AccountKeeper, k keeper.Keeper) simulation.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string,
 	) (simulation.OperationMsg, []simulation.FutureOperation, error) {
@@ -143,7 +142,7 @@ func SimulateMsgCreateAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper) simulat
 	}
 }
 
-func operationClaimAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper, swapID []byte, randomNumber []byte) simulation.Operation {
+func operationClaimAtomicSwap(ak types.AccountKeeper, k keeper.Keeper, swapID []byte, randomNumber []byte) simulation.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string,
 	) (simulation.OperationMsg, []simulation.FutureOperation, error) {
@@ -176,7 +175,7 @@ func operationClaimAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper, swapID []b
 	}
 }
 
-func operationRefundAtomicSwap(ak auth.AccountKeeper, k keeper.Keeper, swapID []byte) simulation.Operation {
+func operationRefundAtomicSwap(ak types.AccountKeeper, k keeper.Keeper, swapID []byte) simulation.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simulation.Account, chainID string,
 	) (simulation.OperationMsg, []simulation.FutureOperation, error) {

--- a/x/bep3/types/expected_keepers.go
+++ b/x/bep3/types/expected_keepers.go
@@ -6,7 +6,7 @@ import (
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 )
 
-// SupplyKeeper defines the expected supply keeper
+// SupplyKeeper defines the expected supply keeper (noalias)
 type SupplyKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
 	GetModuleAccount(ctx sdk.Context, moduleName string) supplyexported.ModuleAccountI
@@ -19,7 +19,7 @@ type SupplyKeeper interface {
 	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 }
 
-// AccountKeeper defines the expected account keeper
+// AccountKeeper defines the expected account keeper (noalias)
 type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authexported.Account
 	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authexported.Account

--- a/x/bep3/types/expected_keepers.go
+++ b/x/bep3/types/expected_keepers.go
@@ -2,10 +2,11 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 )
 
-// SupplyKeeper defines the expected supply Keeper
+// SupplyKeeper defines the expected supply keeper
 type SupplyKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
 	GetModuleAccount(ctx sdk.Context, moduleName string) supplyexported.ModuleAccountI
@@ -16,4 +17,11 @@ type SupplyKeeper interface {
 
 	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
+}
+
+// AccountKeeper defines the expected account keeper
+type AccountKeeper interface {
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authexported.Account
+	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authexported.Account
+	SetAccount(ctx sdk.Context, acc authexported.Account)
 }


### PR DESCRIPTION
**Goal**: remove claiming kava via faucet step from the bep3 user flow.

**Approach**: add an account keeper to bep3 module and automatically register an account in state for the atomic swap's recipient address.

**Details**: automatic registration occurs if and only if the atomic swap is incoming (i.e. sent by deputy) and the recipient's address is not found in state. If the recipient's address has an invalid bech32 encoding, the swap is rejected and the address is not registered. Registered accounts are able to claim atomic swaps. After receiving their claimed bnb, the user can send bnb to other addresses in state.