### PR TITLE
[R4R] Update secure RNG to generate bytes directly

### DIFF
--- a/x/bep3/client/cli/query.go
+++ b/x/bep3/client/cli/query.go
@@ -82,10 +82,10 @@ func QueryCalcRandomNumberHashCmd(queryRoute string, cdc *codec.Codec) *cobra.Co
 			if err != nil {
 				return err
 			}
-			randomNumberHash := types.CalculateRandomHash(randomNumber[:], timestamp)
+			randomNumberHash := types.CalculateRandomHash(randomNumber, timestamp)
 
 			// Prepare random number, timestamp, and hash for output
-			randomNumberStr := fmt.Sprintf("Random number: %s\n", string(randomNumber[:]))
+			randomNumberStr := fmt.Sprintf("Random number: %s\n", hex.EncodeToString(randomNumber))
 			timestampStr := fmt.Sprintf("Timestamp: %d\n", timestamp)
 			randomNumberHashStr := fmt.Sprintf("Random number hash: %s", hex.EncodeToString(randomNumberHash))
 			output := []string{randomNumberStr, timestampStr, randomNumberHashStr}

--- a/x/bep3/client/cli/tx.go
+++ b/x/bep3/client/cli/tx.go
@@ -81,10 +81,10 @@ func GetCmdCreateAtomicSwap(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			randomNumberHash := types.CalculateRandomHash(randomNumber[:], timestamp)
+			randomNumberHash := types.CalculateRandomHash(randomNumber, timestamp)
 
 			// Print random number, timestamp, and hash to user's console
-			fmt.Printf("\nRandom number: %s\n", string(randomNumber[:]))
+			fmt.Printf("\nRandom number: %s\n", hex.EncodeToString(randomNumber))
 			fmt.Printf("Timestamp: %d\n", timestamp)
 			fmt.Printf("Random number hash: %s\n\n", hex.EncodeToString(randomNumberHash))
 
@@ -135,7 +135,10 @@ func GetCmdClaimAtomicSwap(cdc *codec.Codec) *cobra.Command {
 			if len(strings.TrimSpace(args[1])) == 0 {
 				return fmt.Errorf("random-number cannot be empty")
 			}
-			randomNumber := []byte(args[1])
+			randomNumber, err := hex.DecodeString(args[1])
+			if err != nil {
+				return err
+			}
 
 			msg := types.NewMsgClaimAtomicSwap(from, swapID, randomNumber)
 

--- a/x/bep3/keeper/swap.go
+++ b/x/bep3/keeper/swap.go
@@ -175,7 +175,7 @@ func (k Keeper) ClaimAtomicSwap(ctx sdk.Context, from sdk.AccAddress, swapID []b
 			sdk.NewAttribute(types.AttributeKeyRecipient, atomicSwap.Recipient.String()),
 			sdk.NewAttribute(types.AttributeKeyAtomicSwapID, hex.EncodeToString(atomicSwap.GetSwapID())),
 			sdk.NewAttribute(types.AttributeKeyRandomNumberHash, hex.EncodeToString(atomicSwap.RandomNumberHash)),
-			sdk.NewAttribute(types.AttributeKeyRandomNumber, string(randomNumber)),
+			sdk.NewAttribute(types.AttributeKeyRandomNumber, hex.EncodeToString(randomNumber)),
 		),
 	)
 

--- a/x/bep3/types/hash.go
+++ b/x/bep3/types/hash.go
@@ -3,9 +3,6 @@ package types
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"errors"
-	"fmt"
-	"math/big"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,21 +11,12 @@ import (
 )
 
 // GenerateSecureRandomNumber generates cryptographically strong pseudo-random number
-func GenerateSecureRandomNumber() ([64]byte, error) {
-	// Max is a 256-bits integer i.e. 2^256
-	max := new(big.Int)
-	max.Exp(big.NewInt(2), big.NewInt(256), nil)
-
-	// Generate number in the range [0, max]
-	randomNumber, err := rand.Int(rand.Reader, max)
-	if err != nil {
-		return [64]byte{}, errors.New("random number generation error")
+func GenerateSecureRandomNumber() ([]byte, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return []byte{}, err
 	}
-
-	// Ensure length of 64 for hexadecimal encoding by padding with 0s
-	var paddedNumber [64]byte
-	copy(paddedNumber[:], fmt.Sprintf("%064x", randomNumber))
-	return paddedNumber, nil
+	return bytes, nil
 }
 
 // CalculateRandomHash calculates the hash of a number and timestamp

--- a/x/bep3/types/hash_test.go
+++ b/x/bep3/types/hash_test.go
@@ -36,7 +36,7 @@ func (suite *HashTestSuite) TestGenerateSecureRandomNumber() {
 	secureRandomNumber, err := types.GenerateSecureRandomNumber()
 	suite.Nil(err)
 	suite.NotNil(secureRandomNumber)
-	suite.Equal(64, len(secureRandomNumber))
+	suite.Equal(32, len(secureRandomNumber))
 }
 
 func (suite *HashTestSuite) TestCalculateRandomHash() {


### PR DESCRIPTION
BEP3 recently updated RNG was incorrectly failing to validate some numbers generated on bnbchain. This PR fixes the issue such that secret generation and validation work 100% of the time between Kava and bnbchain by directly generating hex-encodable bytes instead of using big.Int as an intermediary. The go-sdk has been updated with [this feature](https://github.com/Kava-Labs/go-sdk/pull/13) as well.

The function could return `[32]bytes` instead (or be renamed, as we're technically no longer generating a number) but I'm in favor of just merging a solution that works given our time constraints.