### PR TITLE
[R4R] Blacklist module accounts

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -31,7 +31,7 @@ func TestBlackListedAddrs(t *testing.T) {
 	app := NewApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, 0)
 
 	for acc := range mAccPerms {
-		require.True(t, app.bankKeeper.BlacklistedAddr(app.supplyKeeper.GetModuleAddress(acc)))
+		require.Equal(t, !allowedReceivingModAcc[acc], app.bankKeeper.BlacklistedAddr(app.supplyKeeper.GetModuleAddress(acc)))
 	}
 }
 

--- a/x/bep3/handler.go
+++ b/x/bep3/handler.go
@@ -24,9 +24,8 @@ func NewHandler(k Keeper) sdk.Handler {
 
 // handleMsgCreateAtomicSwap handles requests to create a new AtomicSwap
 func handleMsgCreateAtomicSwap(ctx sdk.Context, k Keeper, msg MsgCreateAtomicSwap) (*sdk.Result, error) {
-	err := k.CreateAtomicSwap(ctx, msg.RandomNumberHash, msg.Timestamp, msg.HeightSpan, msg.From, msg.To,
-		msg.SenderOtherChain, msg.RecipientOtherChain, msg.Amount, true)
-
+	err := k.CreateAtomicSwap(ctx, msg.RandomNumberHash, msg.Timestamp, msg.HeightSpan,
+		msg.From, msg.To, msg.SenderOtherChain, msg.RecipientOtherChain, msg.Amount, true)
 	if err != nil {
 		return nil, err
 	}

--- a/x/bep3/keeper/keeper.go
+++ b/x/bep3/keeper/keeper.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/params/subspace"
-
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/kava-labs/kava/x/bep3/types"
@@ -20,13 +19,12 @@ type Keeper struct {
 	paramSubspace subspace.Subspace
 	supplyKeeper  types.SupplyKeeper
 	accountKeeper types.AccountKeeper
+	Maccs         map[string]bool
 }
 
 // NewKeeper creates a bep3 keeper
-func NewKeeper(cdc *codec.Codec, key sdk.StoreKey,
-	sk types.SupplyKeeper, ak types.AccountKeeper,
-	paramstore subspace.Subspace,
-) Keeper {
+func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, sk types.SupplyKeeper, ak types.AccountKeeper,
+	paramstore subspace.Subspace, maccs map[string]bool) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
 	}
@@ -37,6 +35,7 @@ func NewKeeper(cdc *codec.Codec, key sdk.StoreKey,
 		paramSubspace: paramstore,
 		supplyKeeper:  sk,
 		accountKeeper: ak,
+		Maccs:         maccs,
 	}
 	return keeper
 }

--- a/x/bep3/keeper/swap.go
+++ b/x/bep3/keeper/swap.go
@@ -23,6 +23,11 @@ func (k Keeper) CreateAtomicSwap(ctx sdk.Context, randomNumberHash []byte, times
 		return sdkerrors.Wrap(types.ErrAtomicSwapAlreadyExists, hex.EncodeToString(swapID))
 	}
 
+	// Cannot send coins to a module account
+	if k.Maccs[recipient.String()] {
+		return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is a module account", recipient)
+	}
+
 	// The heightSpan period should be more than 10 minutes and less than one week
 	// Assume average block time interval is 10 second. 10 mins = 60 blocks, 1 week = 60480 blocks
 	if heightSpan < k.GetMinBlockLock(ctx) || heightSpan > k.GetMaxBlockLock(ctx) {

--- a/x/cdp/keeper/keeper.go
+++ b/x/cdp/keeper/keeper.go
@@ -20,10 +20,12 @@ type Keeper struct {
 	supplyKeeper    types.SupplyKeeper
 	auctionKeeper   types.AuctionKeeper
 	accountKeeper   types.AccountKeeper
+	maccPerms       map[string][]string
 }
 
 // NewKeeper creates a new keeper
-func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramstore subspace.Subspace, pfk types.PricefeedKeeper, ak types.AuctionKeeper, sk types.SupplyKeeper, ack types.AccountKeeper) Keeper {
+func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramstore subspace.Subspace, pfk types.PricefeedKeeper,
+	ak types.AuctionKeeper, sk types.SupplyKeeper, ack types.AccountKeeper, maccs map[string][]string) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
 	}
@@ -36,6 +38,7 @@ func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, paramstore subspace.Subspace,
 		auctionKeeper:   ak,
 		supplyKeeper:    sk,
 		accountKeeper:   ack,
+		maccPerms:       maccs,
 	}
 }
 

--- a/x/cdp/keeper/savings.go
+++ b/x/cdp/keeper/savings.go
@@ -7,12 +7,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 
-	auctiontypes "github.com/kava-labs/kava/x/auction/types"
 	"github.com/kava-labs/kava/x/cdp/types"
-	kdtypes "github.com/kava-labs/kava/x/kavadist/types"
 )
 
 // DistributeSavingsRate distributes surplus that has accumulated in the liquidator account to address holding stable coins according the the savings rate
@@ -81,16 +78,14 @@ func (k Keeper) SetPreviousSavingsDistribution(ctx sdk.Context, distTime time.Ti
 	store.Set([]byte{}, k.cdc.MustMarshalBinaryLengthPrefixed(distTime))
 }
 
+// getModuleAccountCoins gets the total coin balance of this coin currently held by module accounts
 func (k Keeper) getModuleAccountCoins(ctx sdk.Context, denom string) sdk.Coins {
-	// NOTE: these are the module accounts that could end up holding stable denoms at some point.
-	// Since there are currently no api methods to 'GetAllModuleAccounts', this function will need to be updated if a
-	// new module account is added which can hold stable denoms.
-	savingsRateMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, types.SavingsRateMacc).GetCoins().AmountOf(denom)
-	cdpMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, types.ModuleName).GetCoins().AmountOf(denom)
-	auctionMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, auctiontypes.ModuleName).GetCoins().AmountOf(denom)
-	liquidatorMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, types.LiquidatorMacc).GetCoins().AmountOf(denom)
-	feeMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName).GetCoins().AmountOf(denom)
-	kavadistMaccCoinAmount := k.supplyKeeper.GetModuleAccount(ctx, kdtypes.ModuleName).GetCoins().AmountOf(denom)
-	totalModAccountAmount := savingsRateMaccCoinAmount.Add(cdpMaccCoinAmount).Add(auctionMaccCoinAmount).Add(liquidatorMaccCoinAmount).Add(feeMaccCoinAmount).Add(kavadistMaccCoinAmount)
-	return sdk.NewCoins(sdk.NewCoin(denom, totalModAccountAmount))
+	var totalModCoinBalance sdk.Coins
+	for macc := range k.maccPerms {
+		modCoinBalance := k.supplyKeeper.GetModuleAccount(ctx, macc).GetCoins().AmountOf(denom)
+		if !modCoinBalance.IsNegative() {
+			totalModCoinBalance = totalModCoinBalance.Add(sdk.NewCoin(denom, modCoinBalance))
+		}
+	}
+	return totalModCoinBalance
 }

--- a/x/cdp/keeper/savings.go
+++ b/x/cdp/keeper/savings.go
@@ -80,10 +80,10 @@ func (k Keeper) SetPreviousSavingsDistribution(ctx sdk.Context, distTime time.Ti
 
 // getModuleAccountCoins gets the total coin balance of this coin currently held by module accounts
 func (k Keeper) getModuleAccountCoins(ctx sdk.Context, denom string) sdk.Coins {
-	var totalModCoinBalance sdk.Coins
+	totalModCoinBalance := sdk.NewCoins(sdk.NewCoin(denom, sdk.ZeroInt()))
 	for macc := range k.maccPerms {
 		modCoinBalance := k.supplyKeeper.GetModuleAccount(ctx, macc).GetCoins().AmountOf(denom)
-		if !modCoinBalance.IsNegative() {
+		if modCoinBalance.IsPositive() {
 			totalModCoinBalance = totalModCoinBalance.Add(sdk.NewCoin(denom, modCoinBalance))
 		}
 	}


### PR DESCRIPTION
The module account blacklist prevents user addresses from sending coins to module account via MsgSend/MsgMultiSend. This mitigates the potential attack vector.