### PR TITLE
[R4R] Add flags to auction queries

### DIFF
--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -62,7 +62,7 @@ func QueryGetAuctionCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			}
 
 			// Query
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetAuction), bz)
+			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetAuction), bz)
 			if err != nil {
 				return err
 			}
@@ -71,6 +71,8 @@ func QueryGetAuctionCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			var auction types.Auction
 			cdc.MustUnmarshalJSON(res, &auction)
 			auctionWithPhase := types.NewAuctionWithPhase(auction)
+
+			cliCtx = cliCtx.WithHeight(height)
 			return cliCtx.PrintOutput(auctionWithPhase)
 		},
 	}
@@ -83,9 +85,9 @@ func QueryGetAuctionsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		Short: "query auctions with optional filters",
 		Long: strings.TrimSpace(`Query for all paginated auctions that match optional filters:
 Example:
-$ kvcli q auction auctions --type=(Collateral|Surplus|Debt)
+$ kvcli q auction auctions --type=(collateral|surplus|debt)
 $ kvcli q auction auctions --denom=bnb
-$ kvcli q auction auctions --phase=(Forward|Reverse)
+$ kvcli q auction auctions --phase=(forward|reverse)
 $ kvcli q auction auctions --page=2 --limit=100
 `,
 		),
@@ -96,9 +98,11 @@ $ kvcli q auction auctions --page=2 --limit=100
 			page := viper.GetInt(flags.FlagPage)
 			limit := viper.GetInt(flags.FlagLimit)
 
-			var auctionType string
-			var auctionDenom string
-			var auctionPhase string
+			var (
+				auctionType  string
+				auctionDenom string
+				auctionPhase string
+			)
 
 			params := types.NewQueryAllAuctionParams(page, limit, auctionType, auctionDenom, auctionPhase)
 
@@ -183,7 +187,7 @@ func QueryParamsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 			// Query
 			route := fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetParams)
-			res, _, err := cliCtx.QueryWithData(route, nil)
+			res, height, err := cliCtx.QueryWithData(route, nil)
 			if err != nil {
 				return err
 			}
@@ -191,6 +195,7 @@ func QueryParamsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			// Decode and print results
 			var out types.Params
 			cdc.MustUnmarshalJSON(res, &out)
+			cliCtx = cliCtx.WithHeight(height)
 			return cliCtx.PrintOutput(out)
 		},
 	}

--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -3,14 +3,24 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/x/auction/types"
+)
+
+// Query auction flags
+const (
+	flagType  = "type"
+	flagDenom = "denom"
+	flagPhase = "phase"
 )
 
 // GetQueryCmd returns the cli query commands for this module
@@ -68,30 +78,95 @@ func QueryGetAuctionCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 
 // QueryGetAuctionsCmd queries the auctions in the store
 func QueryGetAuctionsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "auctions",
-		Short: "get a list of active auctions",
-		Args:  cobra.NoArgs,
+		Short: "query auctions with optional filters",
+		Long: strings.TrimSpace(`Query for all paginated auctions that match optional filters:
+Example:
+$ kvcli q auction auctions --type=(Collateral|Surplus|Debt)
+$ kvcli q auction auctions --denom=bnb
+$ kvcli q auction auctions --phase=(Forward|Reverse)
+$ kvcli q auction auctions --page=2 --limit=100
+`,
+		),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			strType := viper.GetString(flagType)
+			strDenom := viper.GetString(flagDenom)
+			strPhase := viper.GetString(flagPhase)
+			page := viper.GetInt(flags.FlagPage)
+			limit := viper.GetInt(flags.FlagLimit)
+
+			var auctionType string
+			var auctionDenom string
+			var auctionPhase string
+
+			params := types.NewQueryAllAuctionParams(page, limit, auctionType, auctionDenom, auctionPhase)
+
+			if len(strType) != 0 {
+				auctionType = strings.ToLower(strings.TrimSpace(strType))
+				if auctionType != "collateral" && auctionType != "surplus" && auctionType != "debt" {
+					return fmt.Errorf("invalid auction type %s", strType)
+				}
+				params.Type = auctionType
+			}
+
+			if len(strDenom) != 0 {
+				auctionDenom := strings.TrimSpace(strDenom)
+				err := sdk.ValidateDenom(auctionDenom)
+				if err != nil {
+					return err
+				}
+				params.Denom = auctionDenom
+			}
+
+			if len(strPhase) != 0 {
+				auctionPhase := strings.ToLower(strings.TrimSpace(strPhase))
+				if auctionType != "collateral" && auctionType != "" {
+					return fmt.Errorf("cannot apply phase flag to non-collateral auction type")
+				}
+				if auctionPhase != "forward" && auctionPhase != "reverse" {
+					return fmt.Errorf("invalid auction phase %s", strPhase)
+				}
+				params.Phase = auctionPhase
+			}
+
+			bz, err := cdc.MarshalJSON(params)
+			if err != nil {
+				return err
+			}
+
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			// Query
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetAuctions), nil)
+			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetAuctions), bz)
 			if err != nil {
 				return err
 			}
 
 			// Decode and print results
-			var auctions types.Auctions
-			cdc.MustUnmarshalJSON(res, &auctions)
+			var matchingAuctions types.Auctions
+			cdc.MustUnmarshalJSON(res, &matchingAuctions)
+
+			if len(matchingAuctions) == 0 {
+				return fmt.Errorf("No matching auctions found")
+			}
 
 			auctionsWithPhase := []types.AuctionWithPhase{} // using empty slice so json returns [] instead of null when there's no auctions
-			for _, a := range auctions {
+			for _, a := range matchingAuctions {
 				auctionsWithPhase = append(auctionsWithPhase, types.NewAuctionWithPhase(a))
 			}
-			return cliCtx.PrintOutput(auctionsWithPhase)
+			cliCtx = cliCtx.WithHeight(height)
+			return cliCtx.PrintOutput(auctionsWithPhase) // nolint:errcheck
 		},
 	}
+
+	cmd.Flags().Int(flags.FlagPage, 1, "pagination page of auctions to to query for")
+	cmd.Flags().Int(flags.FlagLimit, 100, "pagination limit of auctions to query for")
+	cmd.Flags().String(flagType, "", "(optional) filter by auction type, type: collateral, debt, surplus")
+	cmd.Flags().String(flagDenom, "", "(optional) filter by auction denom")
+	cmd.Flags().String(flagPhase, "", "(optional) filter by collateral auction phase, phase: forward/reverse")
+
+	return cmd
 }
 
 // QueryParamsCmd queries the auction module parameters

--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -104,7 +104,9 @@ $ kvcli q auction auctions --page=2 --limit=100
 
 			if len(strType) != 0 {
 				auctionType = strings.ToLower(strings.TrimSpace(strType))
-				if auctionType != "collateral" && auctionType != "surplus" && auctionType != "debt" {
+				if auctionType != types.CollateralAuctionType &&
+					auctionType != types.SurplusAuctionType &&
+					auctionType != types.DebtAuctionType {
 					return fmt.Errorf("invalid auction type %s", strType)
 				}
 				params.Type = auctionType
@@ -121,10 +123,10 @@ $ kvcli q auction auctions --page=2 --limit=100
 
 			if len(strPhase) != 0 {
 				auctionPhase := strings.ToLower(strings.TrimSpace(strPhase))
-				if auctionType != "collateral" && auctionType != "" {
+				if auctionType != types.CollateralAuctionType && len(auctionType) > 0 {
 					return fmt.Errorf("cannot apply phase flag to non-collateral auction type")
 				}
-				if auctionPhase != "forward" && auctionPhase != "reverse" {
+				if auctionPhase != types.ForwardAuctionPhase && auctionPhase != types.ReverseAuctionPhase {
 					return fmt.Errorf("invalid auction phase %s", strPhase)
 				}
 				params.Phase = auctionPhase

--- a/x/auction/client/rest/query.go
+++ b/x/auction/client/rest/query.go
@@ -88,7 +88,9 @@ func queryAuctionsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		if x := r.URL.Query().Get(RestType); len(x) != 0 {
 			auctionType = strings.ToLower(strings.TrimSpace(x))
-			if auctionType != "collateral" && auctionType != "surplus" && auctionType != "debt" {
+			if auctionType != types.CollateralAuctionType &&
+				auctionType != types.SurplusAuctionType &&
+				auctionType != types.DebtAuctionType {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid auction type %s", x))
 				return
 			}
@@ -105,11 +107,11 @@ func queryAuctionsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		if x := r.URL.Query().Get(RestPhase); len(x) != 0 {
 			auctionPhase = strings.ToLower(strings.TrimSpace(x))
-			if auctionType != "collateral" && auctionType != "" {
+			if auctionType != types.CollateralAuctionType && len(auctionType) > 0 {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, "cannot apply phase flag to non-collateral auction type")
 				return
 			}
-			if auctionPhase != "forward" && auctionPhase != "reverse" {
+			if auctionPhase != types.ForwardAuctionPhase && auctionPhase != types.ReverseAuctionPhase {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("invalid auction phase %s", x))
 				return
 			}

--- a/x/auction/client/rest/rest.go
+++ b/x/auction/client/rest/rest.go
@@ -4,10 +4,26 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+)
+
+// REST Variable names
+// nolint
+const (
+	RestType  = "type"
+	RestDenom = "denom"
+	RestPhase = "phase"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	registerQueryRoutes(cliCtx, r)
 	registerTxRoutes(cliCtx, r)
+}
+
+// placeBidReq defines the properties of a bid request's body
+type placeBidReq struct {
+	BaseReq rest.BaseReq `json:"base_req"`
+	Amount  sdk.Coin     `json:"amount"`
 }

--- a/x/auction/client/rest/tx.go
+++ b/x/auction/client/rest/tx.go
@@ -18,14 +18,8 @@ func registerTxRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc(fmt.Sprintf("/%s/auctions/{%s}/bids", types.ModuleName, restAuctionID), bidHandlerFn(cliCtx)).Methods("POST")
 }
 
-type placeBidReq struct {
-	BaseReq rest.BaseReq `json:"base_req"`
-	Amount  sdk.Coin     `json:"amount"`
-}
-
 func bidHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		// Get auction ID from url
 		auctionID, ok := rest.ParseUint64OrReturnBadRequest(w, mux.Vars(r)[restAuctionID])
 		if !ok {

--- a/x/auction/keeper/keeper.go
+++ b/x/auction/keeper/keeper.go
@@ -174,3 +174,12 @@ func (k Keeper) IterateAuctions(ctx sdk.Context, cb func(auction types.Auction) 
 		}
 	}
 }
+
+// GetAllAuctions returns all auctions from the store
+func (k Keeper) GetAllAuctions(ctx sdk.Context) (auctions types.Auctions) {
+	k.IterateAuctions(ctx, func(auction types.Auction) bool {
+		auctions = append(auctions, auction)
+		return false
+	})
+	return
+}

--- a/x/auction/keeper/querier_test.go
+++ b/x/auction/keeper/querier_test.go
@@ -107,7 +107,9 @@ func (suite *QuerierTestSuite) TestQueryAuctions() {
 	// Set up request query
 	query := abci.RequestQuery{
 		Path: strings.Join([]string{custom, types.QuerierRoute, types.QueryGetAuctions}, "/"),
-		Data: types.ModuleCdc.MustMarshalJSON(types.NewQueryAllAuctionParams(1, TestAuctionCount)),
+		Data: types.ModuleCdc.MustMarshalJSON(
+			types.NewQueryAllAuctionParams(int(1), int(TestAuctionCount), "", "", ""),
+		),
 	}
 
 	// Execute query and check the []byte result

--- a/x/auction/types/auctions.go
+++ b/x/auction/types/auctions.go
@@ -10,6 +10,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/supply"
 )
 
+const (
+	CollateralAuctionType = "collateral"
+	SurplusAuctionType    = "surplus"
+	DebtAuctionType       = "debt"
+	ForwardAuctionPhase   = "forward"
+	ReverseAuctionPhase   = "reverse"
+)
+
 // DistantFuture is a very large time value to use as initial the ending time for auctions.
 // It is not set to the max time supported. This can cause problems with time comparisons, see https://stackoverflow.com/a/32620397.
 // Also amino panics when encoding times ≥ the start of year 10000.
@@ -115,7 +123,7 @@ type SurplusAuction struct {
 func (a SurplusAuction) WithID(id uint64) Auction { a.ID = id; return a }
 
 // GetType returns the auction type. Used to identify auctions in event attributes.
-func (a SurplusAuction) GetType() string { return "surplus" }
+func (a SurplusAuction) GetType() string { return SurplusAuctionType }
 
 // GetModuleAccountCoins returns the total number of coins held in the module account for this auction.
 // It is used in genesis initialize the module account correctly.
@@ -125,7 +133,7 @@ func (a SurplusAuction) GetModuleAccountCoins() sdk.Coins {
 }
 
 // GetPhase returns the direction of a surplus auction, which never changes.
-func (a SurplusAuction) GetPhase() string { return "forward" }
+func (a SurplusAuction) GetPhase() string { return ForwardAuctionPhase }
 
 // NewSurplusAuction returns a new surplus auction.
 func NewSurplusAuction(seller string, lot sdk.Coin, bidDenom string, endTime time.Time) SurplusAuction {
@@ -154,7 +162,7 @@ type DebtAuction struct {
 func (a DebtAuction) WithID(id uint64) Auction { a.ID = id; return a }
 
 // GetType returns the auction type. Used to identify auctions in event attributes.
-func (a DebtAuction) GetType() string { return "debt" }
+func (a DebtAuction) GetType() string { return DebtAuctionType }
 
 // GetModuleAccountCoins returns the total number of coins held in the module account for this auction.
 // It is used in genesis initialize the module account correctly.
@@ -165,7 +173,7 @@ func (a DebtAuction) GetModuleAccountCoins() sdk.Coins {
 }
 
 // GetPhase returns the direction of a debt auction, which never changes.
-func (a DebtAuction) GetPhase() string { return "reverse" }
+func (a DebtAuction) GetPhase() string { return ReverseAuctionPhase }
 
 // Validate validates the DebtAuction fields values.
 func (a DebtAuction) Validate() error {
@@ -213,7 +221,7 @@ type CollateralAuction struct {
 func (a CollateralAuction) WithID(id uint64) Auction { a.ID = id; return a }
 
 // GetType returns the auction type. Used to identify auctions in event attributes.
-func (a CollateralAuction) GetType() string { return "collateral" }
+func (a CollateralAuction) GetType() string { return CollateralAuctionType }
 
 // GetModuleAccountCoins returns the total number of coins held in the module account for this auction.
 // It is used in genesis initialize the module account correctly.
@@ -231,9 +239,9 @@ func (a CollateralAuction) IsReversePhase() bool {
 // GetPhase returns the direction of a collateral auction.
 func (a CollateralAuction) GetPhase() string {
 	if a.IsReversePhase() {
-		return "reverse"
+		return ReverseAuctionPhase
 	}
-	return "forward"
+	return ForwardAuctionPhase
 }
 
 // Validate validates the CollateralAuction fields values.

--- a/x/auction/types/querier.go
+++ b/x/auction/types/querier.go
@@ -16,15 +16,21 @@ type QueryAuctionParams struct {
 
 // QueryAllAuctionParams is the params for an auctions query
 type QueryAllAuctionParams struct {
-	Page  int `json:"page" yaml:"page"`
-	Limit int `json:"limit" yaml:"limit"`
+	Page  int    `json:"page" yaml:"page"`
+	Limit int    `json:"limit" yaml:"limit"`
+	Type  string `json:"type" yaml:"type"`
+	Denom string `json:"denom" yaml:"denom"`
+	Phase string `json:"phase" yaml:"phase"`
 }
 
 // NewQueryAllAuctionParams creates a new QueryAllAuctionParams
-func NewQueryAllAuctionParams(page int, limit int) QueryAllAuctionParams {
+func NewQueryAllAuctionParams(page, limit int, aucType, aucDenom, aucPhase string) QueryAllAuctionParams {
 	return QueryAllAuctionParams{
 		Page:  page,
 		Limit: limit,
+		Type:  aucType,
+		Denom: aucDenom,
+		Phase: aucPhase,
 	}
 }
 

--- a/x/bep3/keeper/querier.go
+++ b/x/bep3/keeper/querier.go
@@ -124,7 +124,7 @@ func queryGetParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]by
 	return bz, nil
 }
 
-// getAtomicSwapsFiltered retrieves atomic swaps filtered by a given set of params.
+// filterAtomicSwaps retrieves atomic swaps filtered by a given set of params.
 // If no filters are provided, all atomic swaps will be returned in paginated form.
 func filterAtomicSwaps(ctx sdk.Context, swaps types.AtomicSwaps, params types.QueryAtomicSwaps) types.AtomicSwaps {
 	filteredSwaps := make(types.AtomicSwaps, 0, len(swaps))


### PR DESCRIPTION
Adds flags `type`, `denom`, and `phase` to cli and rest for auction queries.

To test:
1. `kvcli tx cdp create 100000000bnb 10000000usdx --from testuser --gas 250000`
2. `kvcli tx pricefeed postprice bnb:usd 1.001 99999999999 --from validator`
3. `kvcli q auction auctions --type=Collateral --denom=bnb --phase=Forward`