### PR TITLE
Cache redundant calculation in cdp RepayPrinciple

### DIFF
--- a/x/cdp/keeper/draw.go
+++ b/x/cdp/keeper/draw.go
@@ -89,10 +89,11 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 		return err
 	}
 
-	totalDebt := cdp.Principal.Add(cdp.AccumulatedFees)
+	// Note: assumes cdp.Principal and cdp.AccumulatedFees don't change during calculations
+	totalPrincipal := cdp.Principal.Add(cdp.AccumulatedFees)
 
 	// calculate fee and principal payment
-	feePayment, principalPayment := k.calculatePayment(ctx, totalDebt, cdp.AccumulatedFees, payment)
+	feePayment, principalPayment := k.calculatePayment(ctx, totalPrincipal, cdp.AccumulatedFees, payment)
 
 	err = k.validatePrincipalPayment(ctx, cdp, principalPayment)
 	if err != nil {
@@ -132,7 +133,7 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 	)
 
 	// remove the old collateral:debt ratio index
-	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, totalDebt)
+	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, totalPrincipal)
 	k.RemoveCdpCollateralRatioIndex(ctx, denom, cdp.ID, oldCollateralToDebtRatio)
 
 	// update cdp state

--- a/x/cdp/keeper/draw.go
+++ b/x/cdp/keeper/draw.go
@@ -89,8 +89,10 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 		return err
 	}
 
+	totalDebt := cdp.Principal.Add(cdp.AccumulatedFees)
+
 	// calculate fee and principal payment
-	feePayment, principalPayment := k.calculatePayment(ctx, cdp.Principal.Add(cdp.AccumulatedFees), cdp.AccumulatedFees, payment)
+	feePayment, principalPayment := k.calculatePayment(ctx, totalDebt, cdp.AccumulatedFees, payment)
 
 	err = k.validatePrincipalPayment(ctx, cdp, principalPayment)
 	if err != nil {
@@ -130,7 +132,7 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 	)
 
 	// remove the old collateral:debt ratio index
-	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, totalDebt)
 	k.RemoveCdpCollateralRatioIndex(ctx, denom, cdp.ID, oldCollateralToDebtRatio)
 
 	// update cdp state


### PR DESCRIPTION
Changes
---
Removes a redundant calculation and fixes exhibit 29 by using a temporary variable.

Discussion
---

Opening as a draft for discussion on direction as it feels possible that this change could cause an issue down the road.

The main thing to note is we are now storing the result of `cdp.Principal.Add(cdp.AccumulatedFees)` in a variable called `totalDebt` on line 92 of `draw.go`, and then using it on line 95 and line 135.  This assumes that the cdp.Principle and cdp.AccumulatedFees values do not change between lines 95 and 135, which is an assumption that may not be true in the future.

It feels safer to not cache the `totalDebt` value (leaving the code unchanged) and always recalculate it in order to remove the dependence on the principle and accumulated fees not changing.

I wouldn't worry for a small block of code, but there are 40 lines between calls to `totalDebt`, which is an opportunity for something sneaky to get in there.

Thoughts?

TLDR
---
Is the removal of an extra addition worth the possible introduction of a bug due to caching down the line?


Side Note
---
The `cdp.Principal.Add(cdp.AccumulatedFees)` pattern is used 15 times (16 times on master), which is a good opportunity for pushing into the CDP type.

Something like
```golang
func (cdp CDP) GetTotalDebt() sdk.Coin {
  return cdp.Principle.Add(cdp.AccumlatedFees)
}
```
?

Saves some typing and always recalculates the value, leaving it up to the caller to cache.