### PR TITLE
Optimize calculation in savings distribution

### DIFF
--- a/x/cdp/keeper/savings.go
+++ b/x/cdp/keeper/savings.go
@@ -45,9 +45,8 @@ func (k Keeper) DistributeSavingsRate(ctx sdk.Context, debtDenom string) error {
 		// interest is the ratable fraction of savings rate owed to that account, rounded using bankers rounding
 		interest := (sdk.NewDecFromInt(debtAmount).Mul(totalSurplus)).Quo(totalSupply).RoundInt()
 		// sanity check, if we are going to over-distribute due to rounding, distribute only the remaining savings rate that hasn't been distributed.
-		if interest.GT(surplusToDistribute) {
-			interest = surplusToDistribute
-		}
+		interest = sdk.MinInt(interest, surplusToDistribute)
+
 		// sanity check - don't send saving rate if the rounded amount is zero
 		if !interest.IsPositive() {
 			return false


### PR DESCRIPTION
Stores and uses the remaining surplus instead of comparing sum of distributions so far.

Fixes exhibit 33.