### PR TITLE
Auctions Clean Up - Fixes redenancy and legibility

### DIFF
--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -34,7 +34,7 @@ func (k Keeper) StartSurplusAuction(ctx sdk.Context, seller string, lot sdk.Coin
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeAuctionStart,
-			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auctionID)),
 			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.GetType()),
 			sdk.NewAttribute(types.AttributeKeyBid, auction.Bid.String()),
 			sdk.NewAttribute(types.AttributeKeyLot, auction.Lot.String()),
@@ -74,7 +74,7 @@ func (k Keeper) StartDebtAuction(ctx sdk.Context, buyer string, bid sdk.Coin, in
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeAuctionStart,
-			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auctionID)),
 			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.GetType()),
 			sdk.NewAttribute(types.AttributeKeyBid, auction.Bid.String()),
 			sdk.NewAttribute(types.AttributeKeyLot, auction.Lot.String()),
@@ -119,7 +119,7 @@ func (k Keeper) StartCollateralAuction(
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeAuctionStart,
-			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auctionID)),
 			sdk.NewAttribute(types.AttributeKeyAuctionType, auction.GetType()),
 			sdk.NewAttribute(types.AttributeKeyBid, auction.Bid.String()),
 			sdk.NewAttribute(types.AttributeKeyLot, auction.Lot.String()),
@@ -482,7 +482,7 @@ func (k Keeper) CloseAuction(ctx sdk.Context, auctionID uint64) error {
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeAuctionClose,
-			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auction.GetID())),
+			sdk.NewAttribute(types.AttributeKeyAuctionID, fmt.Sprintf("%d", auctionID)),
 			sdk.NewAttribute(types.AttributeKeyCloseBlock, fmt.Sprintf("%d", ctx.BlockHeight())),
 		),
 	)

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -490,20 +490,20 @@ func (k Keeper) CloseAuction(ctx sdk.Context, auctionID uint64) error {
 }
 
 // PayoutDebtAuction pays out the proceeds for a debt auction, first minting the coins.
-func (k Keeper) PayoutDebtAuction(ctx sdk.Context, a types.DebtAuction) error {
+func (k Keeper) PayoutDebtAuction(ctx sdk.Context, auction types.DebtAuction) error {
 	// create the coins that are needed to pay off the debt
-	err := k.supplyKeeper.MintCoins(ctx, a.Initiator, sdk.NewCoins(a.Lot))
+	err := k.supplyKeeper.MintCoins(ctx, auction.Initiator, sdk.NewCoins(auction.Lot))
 	if err != nil {
 		panic(fmt.Errorf("could not mint coins: %w", err))
 	}
 	// send the new coins from the initiator module to the bidder
-	err = k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, a.Initiator, a.Bidder, sdk.NewCoins(a.Lot))
+	err = k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, auction.Initiator, auction.Bidder, sdk.NewCoins(auction.Lot))
 	if err != nil {
 		return err
 	}
 	// if there is remaining debt, return it to the calling module to manage
-	if a.CorrespondingDebt.IsPositive() {
-		err = k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, a.Initiator, sdk.NewCoins(a.CorrespondingDebt))
+	if auction.CorrespondingDebt.IsPositive() {
+		err = k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, auction.Initiator, sdk.NewCoins(auction.CorrespondingDebt))
 		if err != nil {
 			return err
 		}
@@ -512,9 +512,9 @@ func (k Keeper) PayoutDebtAuction(ctx sdk.Context, a types.DebtAuction) error {
 }
 
 // PayoutSurplusAuction pays out the proceeds for a surplus auction.
-func (k Keeper) PayoutSurplusAuction(ctx sdk.Context, a types.SurplusAuction) error {
+func (k Keeper) PayoutSurplusAuction(ctx sdk.Context, auction types.SurplusAuction) error {
 	// Send the tokens from the auction module account where they are being managed to the bidder who won the auction
-	err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, a.Bidder, sdk.NewCoins(a.Lot))
+	err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, auction.Bidder, sdk.NewCoins(auction.Lot))
 	if err != nil {
 		return err
 	}
@@ -522,16 +522,16 @@ func (k Keeper) PayoutSurplusAuction(ctx sdk.Context, a types.SurplusAuction) er
 }
 
 // PayoutCollateralAuction pays out the proceeds for a collateral auction.
-func (k Keeper) PayoutCollateralAuction(ctx sdk.Context, a types.CollateralAuction) error {
+func (k Keeper) PayoutCollateralAuction(ctx sdk.Context, auction types.CollateralAuction) error {
 	// Send the tokens from the auction module account where they are being managed to the bidder who won the auction
-	err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, a.Bidder, sdk.NewCoins(a.Lot))
+	err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, auction.Bidder, sdk.NewCoins(auction.Lot))
 	if err != nil {
 		return err
 	}
 
 	// if there is remaining debt after the auction, send it back to the initiating module for management
-	if a.CorrespondingDebt.IsPositive() {
-		err = k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, a.Initiator, sdk.NewCoins(a.CorrespondingDebt))
+	if auction.CorrespondingDebt.IsPositive() {
+		err = k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, auction.Initiator, sdk.NewCoins(auction.CorrespondingDebt))
 		if err != nil {
 			return err
 		}

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -153,7 +153,7 @@ func (k Keeper) PlaceBid(ctx sdk.Context, auctionID uint64, bidder sdk.AccAddres
 	case types.DebtAuction:
 		updatedAuction, err = k.PlaceBidDebt(ctx, auctionType, bidder, newAmount)
 	case types.CollateralAuction:
-		if !a.IsReversePhase() {
+		if !auctionType.IsReversePhase() {
 			updatedAuction, err = k.PlaceForwardBidCollateral(ctx, auctionType, bidder, newAmount)
 		} else {
 			updatedAuction, err = k.PlaceReverseBidCollateral(ctx, auctionType, bidder, newAmount)
@@ -308,7 +308,7 @@ func (k Keeper) PlaceForwardBidCollateral(ctx sdk.Context, auction types.Collate
 }
 
 // PlaceReverseBidCollateral places a reverse bid on a collateral auction, moving coins and returning the updated auction.
-func (k Keeper) PlaceReverseBidCollateral(ctx sdk.Context, aunction types.CollateralAuction, bidder sdk.AccAddress, lot sdk.Coin) (types.CollateralAuction, error) {
+func (k Keeper) PlaceReverseBidCollateral(ctx sdk.Context, auction types.CollateralAuction, bidder sdk.AccAddress, lot sdk.Coin) (types.CollateralAuction, error) {
 	// Validate new bid
 	if lot.Denom != auction.Lot.Denom {
 		return auction, sdkerrors.Wrapf(types.ErrInvalidLotDenom, lot.Denom, auction.Lot.Denom)

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -214,9 +214,9 @@ func (k Keeper) PlaceBidSurplus(ctx sdk.Context, a types.SurplusAuction, bidder 
 	a.Bid = bid
 	if !a.HasReceivedBids {
 		a.MaxEndTime = ctx.BlockTime().Add(k.GetParams(ctx).MaxAuctionDuration) // set maximum ending time on receipt of first bid
+		a.HasReceivedBids = true
 	}
 	a.EndTime = earliestTime(ctx.BlockTime().Add(k.GetParams(ctx).BidDuration), a.MaxEndTime) // increment timeout, up to MaxEndTime
-	a.HasReceivedBids = true
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
@@ -290,9 +290,9 @@ func (k Keeper) PlaceForwardBidCollateral(ctx sdk.Context, a types.CollateralAuc
 	a.Bid = bid
 	if !a.HasReceivedBids {
 		a.MaxEndTime = ctx.BlockTime().Add(k.GetParams(ctx).MaxAuctionDuration) // set maximum ending time on receipt of first bid
+		a.HasReceivedBids = true
 	}
 	a.EndTime = earliestTime(ctx.BlockTime().Add(k.GetParams(ctx).BidDuration), a.MaxEndTime) // increment timeout, up to MaxEndTime
-	a.HasReceivedBids = true
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
@@ -364,9 +364,9 @@ func (k Keeper) PlaceReverseBidCollateral(ctx sdk.Context, a types.CollateralAuc
 	a.Lot = lot
 	if !a.HasReceivedBids {
 		a.MaxEndTime = ctx.BlockTime().Add(k.GetParams(ctx).MaxAuctionDuration) // set maximum ending time on receipt of first bid
+		a.HasReceivedBids = true
 	}
 	a.EndTime = earliestTime(ctx.BlockTime().Add(k.GetParams(ctx).BidDuration), a.MaxEndTime) // increment timeout, up to MaxEndTime
-	a.HasReceivedBids = true
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
@@ -430,9 +430,9 @@ func (k Keeper) PlaceBidDebt(ctx sdk.Context, a types.DebtAuction, bidder sdk.Ac
 	a.Lot = lot
 	if !a.HasReceivedBids {
 		a.MaxEndTime = ctx.BlockTime().Add(k.GetParams(ctx).MaxAuctionDuration) // set maximum ending time on receipt of first bid
+		a.HasReceivedBids = true
 	}
 	a.EndTime = earliestTime(ctx.BlockTime().Add(k.GetParams(ctx).BidDuration), a.MaxEndTime) // increment timeout, up to MaxEndTime
-	a.HasReceivedBids = true
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/x/auction/keeper/auctions.go
+++ b/x/auction/keeper/auctions.go
@@ -147,16 +147,16 @@ func (k Keeper) PlaceBid(ctx sdk.Context, auctionID uint64, bidder sdk.AccAddres
 		err            error
 		updatedAuction types.Auction
 	)
-	switch a := auction.(type) {
+	switch auctionType := auction.(type) {
 	case types.SurplusAuction:
-		updatedAuction, err = k.PlaceBidSurplus(ctx, a, bidder, newAmount)
+		updatedAuction, err = k.PlaceBidSurplus(ctx, auctionType, bidder, newAmount)
 	case types.DebtAuction:
-		updatedAuction, err = k.PlaceBidDebt(ctx, a, bidder, newAmount)
+		updatedAuction, err = k.PlaceBidDebt(ctx, auctionType, bidder, newAmount)
 	case types.CollateralAuction:
 		if !a.IsReversePhase() {
-			updatedAuction, err = k.PlaceForwardBidCollateral(ctx, a, bidder, newAmount)
+			updatedAuction, err = k.PlaceForwardBidCollateral(ctx, auctionType, bidder, newAmount)
 		} else {
-			updatedAuction, err = k.PlaceReverseBidCollateral(ctx, a, bidder, newAmount)
+			updatedAuction, err = k.PlaceReverseBidCollateral(ctx, auctionType, bidder, newAmount)
 		}
 	default:
 		err = sdkerrors.Wrap(types.ErrUnrecognizedAuctionType, auction.GetType())


### PR DESCRIPTION
- use `auction` and `auctionType` instead of `a` for variable names
- move `hasReceivedBids = true` into if statements (it's redundant outside, as it's already true)
- use existing `auctionID` variable instead of `auction.GetID()` in event logging

