### PR TITLE
Remove some redunancy in RepayPrinciple

### DIFF
--- a/x/cdp/keeper/draw.go
+++ b/x/cdp/keeper/draw.go
@@ -104,14 +104,18 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 		panic(err)
 	}
 
-	// burn the corresponding amount of debt coins
 	cdpDebt := k.getModAccountDebt(ctx, types.ModuleName)
-	paymentAmount := feePayment.Amount.Add(principalPayment.Amount)
-	coinsToBurn := sdk.NewCoin(k.GetDebtDenom(ctx), paymentAmount)
+	paymentAmount := feePayment.Add(principalPayment).Amount
+
+	debtDenom := k.GetDebtDenom(ctx)
+	coinsToBurn := sdk.NewCoin(debtDenom, paymentAmount)
+
 	if paymentAmount.GT(cdpDebt) {
-		coinsToBurn = sdk.NewCoin(k.GetDebtDenom(ctx), cdpDebt)
+		coinsToBurn = sdk.NewCoin(debtDenom, cdpDebt)
 	}
-	err = k.BurnDebtCoins(ctx, types.ModuleName, k.GetDebtDenom(ctx), coinsToBurn)
+
+	err = k.BurnDebtCoins(ctx, types.ModuleName, debtDenom, coinsToBurn)
+
 	if err != nil {
 		panic(err)
 	}

--- a/x/cdp/keeper/draw.go
+++ b/x/cdp/keeper/draw.go
@@ -104,6 +104,7 @@ func (k Keeper) RepayPrincipal(ctx sdk.Context, owner sdk.AccAddress, denom stri
 		panic(err)
 	}
 
+	// burn the corresponding amount of debt coins
 	cdpDebt := k.getModAccountDebt(ctx, types.ModuleName)
 	paymentAmount := feePayment.Add(principalPayment).Amount
 


### PR DESCRIPTION
- Uses `sdk.Coin#Add` method instead of using `sdk.Int#Add` on amounts for adding principle and fee
- store result of `GetDebtDenom` in variable

Fixes exhibit 30