### PR TITLE
update bep3 docs for mainnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ clean:
 # This tool checks local markdown links as well.
 # Set to exclude riot links as they trigger false positives
 link-check:
-	@go run github.com/raviqqe/liche -r . --exclude "^http://127.*|^https://riot.im/app*|^http://kava-testnet*|^https://testnet-dex*"
+	@go run github.com/raviqqe/liche -r . --exclude "^http://127.*|^https://riot.im/app*|^http://kava-testnet*|^https://testnet-dex*|^https://kava3.data.kava.io*"
 
 
 lint:

--- a/x/bep3/spec/01_concepts.md
+++ b/x/bep3/spec/01_concepts.md
@@ -8,11 +8,11 @@ order: 1
 
 ## Requirements
 Kava
-- The deputy’s Kava testnet-5000 address is **kava1aphsdnz5hu2t5ty2au6znprug5kx3zpy6zwq29**.
-- We recommend using http://kava-testnet-5000.kava.io:1317 as Kava’s API endpoint.
+- The deputy’s Kava address on mainnet is **kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6**.
+- Kava's official API endpoint is https://kava3.data.kava.io.
 
 Binance Chain
-- The deputy’s Binance Chain testnet address is **tbnb1et8vmd0dgvswjnyaf73ez8ye0jehc8a7t7fljv**.
+- The deputy’s Binance Chain address on mainnet is **bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn**.
 - We recommend using https://testnet-dex.binance.org/ as Binance Chain’s API endpoint.
 
 Kava's [JavaScript SDK](https://github.com/Kava-Labs/javascript-sdk) and Binance Chain’s [JavaScript SDK](https://github.com/binance-chain/javascript-sdk) can be used to create, claim, and refund swaps.

--- a/x/bep3/spec/02_state.md
+++ b/x/bep3/spec/02_state.md
@@ -42,6 +42,10 @@ type GenesisState struct {
 
 ## Types
 
+AtomicSwap stores information about an individual atomic swap, including the sender, recipient, amount, random number hash (used to validate the secret and unlock funds), the status (open, completed, or expired). There are two types of atomic swaps:
+- Incoming: assets are being sent to Kava from another blockchain.
+- Outgoing: assets are being send to another blockchain from Kava.
+
 ```go
 // AtomicSwap contains the information for an atomic swap
 type AtomicSwap struct {
@@ -76,7 +80,15 @@ const (
 	Incoming SwapDirection = 0x01
 	Outgoing SwapDirection = 0x02
 )
+```
 
+AssetSupply stores information about an individual asset's BEP3 supply:
+- Incoming supply: total amount in incoming swaps (being sent to the chain).
+- Outgoing supply: total amount in outgoing swaps (being sent off the chain). It cannot be greater than the current supply.
+- Current supply: the amount that the deputy has released - it is the active supply on Kava. It is equal to the total amount successfully claimed from incoming swaps minus the total amount claimed from outgoing swaps.
+- Supply limit: the maximum amount currently allowed on Kava. The supply limit can be increased by Kava's stability committee, subject to an on-chain proposal vote.
+
+```go
 // AssetSupply contains information about an asset's supply
 type AssetSupply struct {
 	Denom          string   `json:"denom"  yaml:"denom"`

--- a/x/bep3/spec/03_messages.md
+++ b/x/bep3/spec/03_messages.md
@@ -35,8 +35,6 @@ type MsgClaimAtomicSwap struct {
 }
 ```
 
-
-
 ## Refund swap
 
 Expired swaps are refunded using the `MsgRefundAtomicSwap` message type.

--- a/x/bep3/spec/05_params.md
+++ b/x/bep3/spec/05_params.md
@@ -6,18 +6,21 @@ order: 5
 
 The bep3 module contains the following parameters:
 
-| Key               | Type                    | Example                                       | Description                   |
-|-------------------|-------------------------|-----------------------------------------------|-------------------------------|
-| BnbDeputyAddress  | string (sdk.AccAddress) | "kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6" | deputy's Kava address         |
-| BnbDeputyFixedFee | sdk.Int                 | sdk.NewInt(1000)                              | deputy's fixed bnb fee        |
-| MinAmount         | sdk.Int                 | sdk.NewInt(0)                                 | minimum swap amount           |
-| MaxAmount         | sdk.Int                 | sdk.NewInt(1000000000000)                     | maximum swap amount           |
-| MinBlockLock      | uint64                  | 220                                           | minimum swap expire height    |
-| MaxBlockLock      | uint64                  | 270                                           | maximum swap expire height    |
-| SupportedAssets   | AssetParams             | []AssetParam                                  | array of supported assets     |
-|-------------------|-------------------------|-----------------------------------------------|-------------------------------|
-| AssetParam        | AssetParam              | AssetParam{"bnb", 714, sdk.NewInt(100), true} | a supported asset             |
-| AssetParam.Denom  | string                  | "bnb"                                         | asset's name                  |
-| AssetParam.CoinID | int64                   | 714                                           | asset's international coin ID |
-| AssetParam.Limit  | sdk.Int                 | sdk.NewInt(100)                               | asset's supply limit          |
-| AssetParam.Active | boolean                 | true                                          | asset's state: live or paused |
+| Key               | Type           | Example                                       | Description                   |
+|-------------------|----------------|-----------------------------------------------|-------------------------------|
+| BnbDeputyAddress  | sdk.AccAddress | "kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6" | deputy's Kava address         |
+| BnbDeputyFixedFee | sdk.Int        | sdk.NewInt(1000)                              | deputy's fixed bnb fee        |
+| MinAmount         | sdk.Int        | sdk.NewInt(0)                                 | minimum swap amount           |
+| MaxAmount         | sdk.Int        | sdk.NewInt(1000000000000)                     | maximum swap amount           |
+| MinBlockLock      | uint64         | 220                                           | minimum swap expire height    |
+| MaxBlockLock      | uint64         | 270                                           | maximum swap expire height    |
+| SupportedAssets   | AssetParams    | []AssetParam                                  | array of supported assets     |
+
+Each AssetParam has the following parameters:
+
+| Key               | Type           | Example                                       | Description                   |
+|-------------------|----------------|-----------------------------------------------|-------------------------------|
+| AssetParam.Denom  | string         | "bnb"                                         | asset's name                  |
+| AssetParam.CoinID | int64          | 714                                           | asset's international coin ID |
+| AssetParam.Limit  | sdk.Int        | sdk.NewInt(100)                               | asset's supply limit          |
+| AssetParam.Active | boolean        | true                                          | asset's state: live or paused |

--- a/x/bep3/spec/README.md
+++ b/x/bep3/spec/README.md
@@ -17,4 +17,11 @@ parent:
 
 ## Abstract
 
-`x/bep3` is an implementation of a Cosmos SDK Module that handles cross-chain Atomic Swaps between Kava and blockchains that implement the BEP3 protocol. Atomic Swaps are created, then either claimed before their expiration block or refunded after they've expired.
+`x/bep3` is a module that handles cross-chain atomic swaps between Kava and blockchains that implement the BEP3 protocol. Atomic swaps are created, then either claimed before their expiration block or refunded after they've expired.
+
+Several user interfaces support Kava BEP3 swaps:
+- [Trust Wallet](https://trustwallet.com/)
+- [Cosmostation](https://wallet.cosmostation.io/?network=kava)
+- [Frontier Wallet](https://frontierwallet.com/)
+
+Swaps can also be created, claimed, and refunded using Kava's [Javascript SDK](https://github.com/Kava-Labs/javascript-sdk) or CLI.


### PR DESCRIPTION
Updates BEP3 docs for mainnet
- [x] Update abstract and link to available swap UIs
- [x] Change deputy addresses and Kava url endpoint
- [x] Add state descriptions for AtomicSwap and AssetSupply
- [x] Clean up params