### PR TITLE
Add QueryGetAccounts to CDP Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+[\#596](https://github.com/Kava-Labs/kava/pull/596) Add REST client and CLI query to get module account information for the CDP module
+
 [\#590](https://github.com/Kava-Labs/kava/pull/590) Add CLI query to return kavadist module account balance
 
 [\#584](https://github.com/Kava-Labs/kava/pulls/584) Add REST client and CLI queries for `kavadist` module

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -599,6 +599,42 @@
             description: Invalid request
           500:
             description: Server internal error
+    /cdp/accounts:
+      get:
+        summary: Get the cdp module accounts
+        tags:
+          - CDP
+        produces:
+          - application/json
+        responses:
+          200:
+            description: The cdp module accounts
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  account_number:
+                    type: number
+                  address:
+                    $ref: '#/definitions/Address'
+                  coins:
+                    type: array
+                    items:
+                      $ref: '#/definitions/Coin'
+                  name:
+                    type: string
+                  permissions:
+                    type: array
+                    items:
+                      type: string
+                  public_key:
+                    $ref: "#/definitions/PublicKey"
+                  sequence:
+                    type: number
+          500:
+            description: Server internal error
+
     /cdp/parameters:
       get:
         summary: Get the parameters of the cdp module

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -610,28 +610,34 @@
           200:
             description: The cdp module accounts
             schema:
-              type: array
-              items:
-                type: object
-                properties:
-                  account_number:
-                    type: number
-                  address:
-                    $ref: '#/definitions/Address'
-                  coins:
-                    type: array
-                    items:
-                      $ref: '#/definitions/Coin'
-                  name:
-                    type: string
-                  permissions:
-                    type: array
-                    items:
-                      type: string
-                  public_key:
-                    $ref: "#/definitions/PublicKey"
-                  sequence:
-                    type: number
+              type: object
+              properties:
+                height:
+                  type: string
+                  example: "100"
+                result:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      account_number:
+                        type: number
+                      address:
+                        $ref: '#/definitions/Address'
+                      coins:
+                        type: array
+                        items:
+                          $ref: '#/definitions/Coin'
+                      name:
+                        type: string
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                      public_key:
+                        $ref: "#/definitions/PublicKey"
+                      sequence:
+                        type: number
           500:
             description: Server internal error
 

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	supply "github.com/cosmos/cosmos-sdk/x/supply"
 
 	"github.com/kava-labs/kava/x/cdp/types"
 )
@@ -29,7 +30,6 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		QueryCdpsByDenomAndRatioCmd(queryRoute, cdc),
 		QueryCdpDepositsCmd(queryRoute, cdc),
 		QueryParamsCmd(queryRoute, cdc),
-		QueryTotalSupply(queryRoute, cdc),
 		QueryGetAccounts(queryRoute, cdc),
 	)...)
 
@@ -228,32 +228,6 @@ func QueryParamsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-func QueryTotalSupply(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "total-supply",
-		Short: "Get total supply",
-		Long:  "Get the current total supply of usdx.",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-
-			// Query
-			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryTotalSupply), nil)
-			if err != nil {
-				return err
-			}
-			cliCtx = cliCtx.WithHeight(height)
-
-			// Decode and print results
-			var out int64
-			if err := cdc.UnmarshalJSON(res, &out); err != nil {
-				return fmt.Errorf("failed to unmarshal supply: %w", err)
-			}
-			return cliCtx.PrintOutput(out)
-		},
-	}
-}
-
 func QueryGetAccounts(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "accounts",
@@ -271,7 +245,7 @@ func QueryGetAccounts(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			cliCtx = cliCtx.WithHeight(height)
 
 			// Decode and print results
-			var out types.QueryGetAccountsResponse
+			var out []supply.ModuleAccount
 			if err := cdc.UnmarshalJSON(res, &out); err != nil {
 				return fmt.Errorf("failed to unmarshal accounts: %w", err)
 			}

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -30,6 +30,7 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		QueryCdpDepositsCmd(queryRoute, cdc),
 		QueryParamsCmd(queryRoute, cdc),
 		QueryTotalSupply(queryRoute, cdc),
+		QueryGetAccounts(queryRoute, cdc),
 	)...)
 
 	return cdpQueryCmd
@@ -247,6 +248,32 @@ func QueryTotalSupply(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			var out int64
 			if err := cdc.UnmarshalJSON(res, &out); err != nil {
 				return fmt.Errorf("failed to unmarshal supply: %w", err)
+			}
+			return cliCtx.PrintOutput(out)
+		},
+	}
+}
+
+func QueryGetAccounts(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "accounts",
+		Short: "Get module accounts",
+		Long:  "Get cdp module account addresses",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			// Query
+			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetAccounts), nil)
+			if err != nil {
+				return err
+			}
+			cliCtx = cliCtx.WithHeight(height)
+
+			// Decode and print results
+			var out types.QueryGetAccountsResponse
+			if err := cdc.UnmarshalJSON(res, &out); err != nil {
+				return fmt.Errorf("failed to unmarshal accounts: %w", err)
 			}
 			return cliCtx.PrintOutput(out)
 		},

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -29,6 +29,7 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		QueryCdpsByDenomAndRatioCmd(queryRoute, cdc),
 		QueryCdpDepositsCmd(queryRoute, cdc),
 		QueryParamsCmd(queryRoute, cdc),
+		QueryTotalSupply(queryRoute, cdc),
 	)...)
 
 	return cdpQueryCmd
@@ -221,6 +222,32 @@ func QueryParamsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			// Decode and print results
 			var out types.Params
 			cdc.MustUnmarshalJSON(res, &out)
+			return cliCtx.PrintOutput(out)
+		},
+	}
+}
+
+func QueryTotalSupply(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "total-supply",
+		Short: "Get total supply",
+		Long:  "Get the current total supply of usdx.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			// Query
+			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryTotalSupply), nil)
+			if err != nil {
+				return err
+			}
+			cliCtx = cliCtx.WithHeight(height)
+
+			// Decode and print results
+			var out int64
+			if err := cdc.UnmarshalJSON(res, &out); err != nil {
+				return fmt.Errorf("failed to unmarshal supply: %w", err)
+			}
 			return cliCtx.PrintOutput(out)
 		},
 	}

--- a/x/cdp/client/rest/query.go
+++ b/x/cdp/client/rest/query.go
@@ -16,7 +16,6 @@ import (
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc("/cdp/accounts", getAccountsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc("/cdp/parameters", getParamsHandlerFn(cliCtx)).Methods("GET")
-	r.HandleFunc("/cdp/totalsupply", getTotalSupplyHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/cdp/{%s}/{%s}", types.RestOwner, types.RestCollateralDenom), queryCdpHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/denom/{%s}", types.RestCollateralDenom), queryCdpsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/ratio/{%s}/{%s}", types.RestCollateralDenom, types.RestRatio), queryCdpsByRatioHandlerFn(cliCtx)).Methods("GET")
@@ -167,24 +166,6 @@ func getParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/cdp/%s", types.QueryGetParams), nil)
-		cliCtx = cliCtx.WithHeight(height)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-
-		rest.PostProcessResponse(w, cliCtx, res)
-	}
-}
-
-func getTotalSupplyHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
-		if !ok {
-			return
-		}
-
-		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/cdp/%s", types.QueryTotalSupply), nil)
 		cliCtx = cliCtx.WithHeight(height)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())

--- a/x/cdp/client/rest/query.go
+++ b/x/cdp/client/rest/query.go
@@ -15,6 +15,7 @@ import (
 // define routes that get registered by the main application
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc("/cdp/parameters", getParamsHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc("/cdp/totalsupply", getTotalSupplyHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/cdp/{%s}/{%s}", types.RestOwner, types.RestCollateralDenom), queryCdpHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/denom/{%s}", types.RestCollateralDenom), queryCdpsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/cdp/cdps/ratio/{%s}/{%s}", types.RestCollateralDenom, types.RestRatio), queryCdpsByRatioHandlerFn(cliCtx)).Methods("GET")
@@ -165,6 +166,24 @@ func getParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/cdp/%s", types.QueryGetParams), nil)
+		cliCtx = cliCtx.WithHeight(height)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+func getTotalSupplyHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/cdp/%s", types.QueryTotalSupply), nil)
 		cliCtx = cliCtx.WithHeight(height)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -26,6 +26,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryGetDeposits(ctx, req, keeper)
 		case types.QueryTotalSupply:
 			return queryGetTotalSupply(ctx, req, keeper)
+		case types.QueryGetAccounts:
+			return queryGetAccounts(ctx, req, keeper)
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint %s", types.ModuleName, path[0])
 		}
@@ -164,6 +166,26 @@ func queryGetTotalSupply(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	bz, err := types.ModuleCdc.MarshalJSON(supplyInt)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+	return bz, nil
+}
+
+// query cdp module accounts
+func queryGetAccounts(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	cdpAccAddress := keeper.supplyKeeper.GetModuleAddress(types.ModuleName)
+	liquidatorAccAddress := keeper.supplyKeeper.GetModuleAddress(types.LiquidatorMacc)
+	savingsRateAccAddress := keeper.supplyKeeper.GetModuleAddress(types.SavingsRateMacc)
+
+	res := types.QueryGetAccountsResponse{
+		Cdp:         cdpAccAddress,
+		Liquidator:  liquidatorAccAddress,
+		SavingsRate: savingsRateAccAddress,
+	}
+
+	// Encode results
+	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, res)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 	return bz, nil
 }

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -24,6 +24,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryGetParams(ctx, req, keeper)
 		case types.QueryGetCdpDeposits:
 			return queryGetDeposits(ctx, req, keeper)
+		case types.QueryTotalSupply:
+			return queryGetTotalSupply(ctx, req, keeper)
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint %s", types.ModuleName, path[0])
 		}
@@ -152,6 +154,16 @@ func queryGetParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]by
 	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, params)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+	return bz, nil
+}
+
+func queryGetTotalSupply(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	totalSupply := keeper.supplyKeeper.GetSupply(ctx).GetTotal().AmountOf("usdx")
+	supplyInt := sdk.NewDecFromInt(totalSupply).Mul(sdk.MustNewDecFromStr("0.000001")).TruncateInt64()
+	bz, err := types.ModuleCdc.MarshalJSON(supplyInt)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 	return bz, nil
 }

--- a/x/cdp/keeper/querier_test.go
+++ b/x/cdp/keeper/querier_test.go
@@ -11,7 +11,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
-	//supply "github.com/cosmos/cosmos-sdk/x/supply"
+	supply "github.com/cosmos/cosmos-sdk/x/supply"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -285,6 +285,22 @@ func (suite *QuerierTestSuite) TestQueryAccounts() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(bz)
 
+	var accounts []supply.ModuleAccount
+	suite.Require().Nil(supply.ModuleCdc.UnmarshalJSON(bz, &accounts))
+	suite.Require().Equal(3, len(accounts))
+
+	findByName := func(name string) bool {
+		for _, account := range accounts {
+			if account.GetName() == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	suite.Require().True(findByName("cdp"))
+	suite.Require().True(findByName("liquidator"))
+	suite.Require().True(findByName("savings"))
 }
 
 func TestQuerierTestSuite(t *testing.T) {

--- a/x/cdp/keeper/querier_test.go
+++ b/x/cdp/keeper/querier_test.go
@@ -289,6 +289,20 @@ func (suite *QuerierTestSuite) TestQueryTotalSupply() {
 	suite.Require().Equal(int64(602400), supply)
 }
 
+func (suite *QuerierTestSuite) TestQueryAccounts() {
+	bz, err := suite.querier(suite.ctx, []string{types.QueryGetAccounts}, abci.RequestQuery{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(bz)
+
+	sk := suite.app.GetSupplyKeeper()
+
+	var res types.QueryGetAccountsResponse
+	types.ModuleCdc.UnmarshalJSON(bz, &res)
+	suite.Require().Equal(sk.GetModuleAddress(types.ModuleName), res.Cdp)
+	suite.Require().Equal(sk.GetModuleAddress(types.LiquidatorMacc), res.Liquidator)
+	suite.Require().Equal(sk.GetModuleAddress(types.SavingsRateMacc), res.SavingsRate)
+}
+
 func TestQuerierTestSuite(t *testing.T) {
 	suite.Run(t, new(QuerierTestSuite))
 }

--- a/x/cdp/keeper/querier_test.go
+++ b/x/cdp/keeper/querier_test.go
@@ -279,6 +279,16 @@ func (suite *QuerierTestSuite) TestQueryDeposits() {
 
 }
 
+func (suite *QuerierTestSuite) TestQueryTotalSupply() {
+	bz, err := suite.querier(suite.ctx, []string{types.QueryTotalSupply}, abci.RequestQuery{})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(bz)
+
+	var supply int64
+	types.ModuleCdc.UnmarshalJSON(bz, &supply)
+	suite.Require().Equal(int64(602400), supply)
+}
+
 func TestQuerierTestSuite(t *testing.T) {
 	suite.Run(t, new(QuerierTestSuite))
 }

--- a/x/cdp/keeper/querier_test.go
+++ b/x/cdp/keeper/querier_test.go
@@ -11,6 +11,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+	//supply "github.com/cosmos/cosmos-sdk/x/supply"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -279,28 +280,11 @@ func (suite *QuerierTestSuite) TestQueryDeposits() {
 
 }
 
-func (suite *QuerierTestSuite) TestQueryTotalSupply() {
-	bz, err := suite.querier(suite.ctx, []string{types.QueryTotalSupply}, abci.RequestQuery{})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(bz)
-
-	var supply int64
-	types.ModuleCdc.UnmarshalJSON(bz, &supply)
-	suite.Require().Equal(int64(602400), supply)
-}
-
 func (suite *QuerierTestSuite) TestQueryAccounts() {
 	bz, err := suite.querier(suite.ctx, []string{types.QueryGetAccounts}, abci.RequestQuery{})
 	suite.Require().NoError(err)
 	suite.Require().NotNil(bz)
 
-	sk := suite.app.GetSupplyKeeper()
-
-	var res types.QueryGetAccountsResponse
-	types.ModuleCdc.UnmarshalJSON(bz, &res)
-	suite.Require().Equal(sk.GetModuleAddress(types.ModuleName), res.Cdp)
-	suite.Require().Equal(sk.GetModuleAddress(types.LiquidatorMacc), res.Liquidator)
-	suite.Require().Equal(sk.GetModuleAddress(types.SavingsRateMacc), res.SavingsRate)
 }
 
 func TestQuerierTestSuite(t *testing.T) {

--- a/x/cdp/types/querier.go
+++ b/x/cdp/types/querier.go
@@ -12,6 +12,7 @@ const (
 	QueryGetCdpsByCollateralization = "ratio"
 	QueryGetParams                  = "params"
 	QueryTotalSupply                = "total-supply"
+	QueryGetAccounts                = "accounts"
 	RestOwner                       = "owner"
 	RestCollateralDenom             = "collateral-denom"
 	RestRatio                       = "ratio"

--- a/x/cdp/types/querier.go
+++ b/x/cdp/types/querier.go
@@ -11,6 +11,7 @@ const (
 	QueryGetCdps                    = "cdps"
 	QueryGetCdpsByCollateralization = "ratio"
 	QueryGetParams                  = "params"
+	QueryTotalSupply                = "total-supply"
 	RestOwner                       = "owner"
 	RestCollateralDenom             = "collateral-denom"
 	RestRatio                       = "ratio"

--- a/x/cdp/types/querier.go
+++ b/x/cdp/types/querier.go
@@ -11,7 +11,6 @@ const (
 	QueryGetCdps                    = "cdps"
 	QueryGetCdpsByCollateralization = "ratio"
 	QueryGetParams                  = "params"
-	QueryTotalSupply                = "total-supply"
 	QueryGetAccounts                = "accounts"
 	RestOwner                       = "owner"
 	RestCollateralDenom             = "collateral-denom"
@@ -70,10 +69,4 @@ func NewQueryCdpsByRatioParams(denom string, ratio sdk.Dec) QueryCdpsByRatioPara
 		CollateralDenom: denom,
 		Ratio:           ratio,
 	}
-}
-
-type QueryGetAccountsResponse struct {
-	Cdp         sdk.AccAddress `json:"cdp" yaml:"cdp"`
-	Liquidator  sdk.AccAddress `json:"liquidator" yaml:"liquidator"`
-	SavingsRate sdk.AccAddress `json:"savings_rate" yaml:"savings_rate"`
 }

--- a/x/cdp/types/querier.go
+++ b/x/cdp/types/querier.go
@@ -71,3 +71,9 @@ func NewQueryCdpsByRatioParams(denom string, ratio sdk.Dec) QueryCdpsByRatioPara
 		Ratio:           ratio,
 	}
 }
+
+type QueryGetAccountsResponse struct {
+	Cdp         sdk.AccAddress `json:"cdp" yaml:"cdp"`
+	Liquidator  sdk.AccAddress `json:"liquidator" yaml:"liquidator"`
+	SavingsRate sdk.AccAddress `json:"savings_rate" yaml:"savings_rate"`
+}


### PR DESCRIPTION
Adds a method to the CDP client to retrieve module account information.

<img width="433" alt="Screen Shot 2020-06-19 at 2 10 37 PM" src="https://user-images.githubusercontent.com/903469/85172556-f4027000-b236-11ea-860a-f51e9b7d3157.png">
<img width="930" alt="Screen Shot 2020-06-19 at 2 10 14 PM" src="https://user-images.githubusercontent.com/903469/85172561-f664ca00-b236-11ea-803d-e433ebee833c.png">
