### PR TITLE
Update BEB3 CLI Client to Support JSON

### DIFF
--- a/x/bep3/client/cli/query.go
+++ b/x/bep3/client/cli/query.go
@@ -286,7 +286,7 @@ $ kvcli q bep3 swaps --page=2 --limit=100
 				return err
 			}
 
-			var matchingAtomicSwaps []types.AugmentedAtomicSwap
+			var matchingAtomicSwaps types.AugmentedAtomicSwaps
 			cdc.UnmarshalJSON(res, &matchingAtomicSwaps)
 
 			if len(matchingAtomicSwaps) == 0 {

--- a/x/bep3/client/cli/query.go
+++ b/x/bep3/client/cli/query.go
@@ -204,11 +204,11 @@ func QueryGetAtomicSwapCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			var atomicSwap types.AtomicSwap
+			var atomicSwap types.AugmentedAtomicSwap
 			cdc.MustUnmarshalJSON(res, &atomicSwap)
 
 			cliCtx = cliCtx.WithHeight(height)
-			return cliCtx.PrintOutput(atomicSwap.String())
+			return cliCtx.PrintOutput(atomicSwap)
 		},
 	}
 }
@@ -286,7 +286,7 @@ $ kvcli q bep3 swaps --page=2 --limit=100
 				return err
 			}
 
-			var matchingAtomicSwaps types.AtomicSwaps
+			var matchingAtomicSwaps []types.AugmentedAtomicSwap
 			cdc.UnmarshalJSON(res, &matchingAtomicSwaps)
 
 			if len(matchingAtomicSwaps) == 0 {
@@ -294,7 +294,7 @@ $ kvcli q bep3 swaps --page=2 --limit=100
 			}
 
 			cliCtx = cliCtx.WithHeight(height)
-			return cliCtx.PrintOutput(matchingAtomicSwaps.String()) // nolint:errcheck
+			return cliCtx.PrintOutput(matchingAtomicSwaps) // nolint:errcheck
 		},
 	}
 

--- a/x/bep3/client/rest/query.go
+++ b/x/bep3/client/rest/query.go
@@ -62,7 +62,7 @@ func queryAtomicSwapHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		// Decode and return results
 		cliCtx = cliCtx.WithHeight(height)
 
-		var swap types.AtomicSwap
+		var swap types.AugmentedAtomicSwap
 		err = cliCtx.Codec.UnmarshalJSON(res, &swap)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())

--- a/x/bep3/keeper/querier.go
+++ b/x/bep3/keeper/querier.go
@@ -105,7 +105,7 @@ func queryAtomicSwaps(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]
 		swaps = types.AtomicSwaps{}
 	}
 
-	augmentedSwaps := []types.AugmentedAtomicSwap{}
+	augmentedSwaps := types.AugmentedAtomicSwaps{}
 
 	for _, swap := range swaps {
 		augmentedSwaps = append(augmentedSwaps, types.NewAugmentedAtomicSwap(swap))

--- a/x/bep3/keeper/querier.go
+++ b/x/bep3/keeper/querier.go
@@ -81,8 +81,10 @@ func queryAtomicSwap(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]b
 		return nil, sdkerrors.Wrapf(types.ErrAtomicSwapNotFound, "%d", requestParams.SwapID)
 	}
 
+	augmentedAtomicSwap := types.NewAugmentedAtomicSwap(atomicSwap)
+
 	// Encode results
-	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, atomicSwap)
+	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, augmentedAtomicSwap)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
@@ -103,7 +105,13 @@ func queryAtomicSwaps(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]
 		swaps = types.AtomicSwaps{}
 	}
 
-	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, swaps)
+	augmentedSwaps := []types.AugmentedAtomicSwap{}
+
+	for _, swap := range swaps {
+		augmentedSwaps = append(augmentedSwaps, types.NewAugmentedAtomicSwap(swap))
+	}
+
+	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, augmentedSwaps)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/bep3/keeper/querier_test.go
+++ b/x/bep3/keeper/querier_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -120,8 +121,10 @@ func (suite *QuerierTestSuite) TestQueryAtomicSwap() {
 	suite.Nil(err)
 	suite.NotNil(bz)
 
+	fmt.Printf("%s\n", string(bz))
+
 	// Unmarshal the bytes into type atomic swap
-	var swap types.AtomicSwap
+	var swap types.AugmentedAtomicSwap
 	suite.Nil(types.ModuleCdc.UnmarshalJSON(bz, &swap))
 
 	// Check the returned atomic swap's ID
@@ -161,7 +164,7 @@ func (suite *QuerierTestSuite) TestQueryAtomicSwaps() {
 	suite.Nil(err)
 	suite.NotNil(bz)
 
-	var swaps types.AtomicSwaps
+	var swaps []types.AugmentedAtomicSwap
 	suite.Nil(types.ModuleCdc.UnmarshalJSON(bz, &swaps))
 
 	suite.Equal(len(suite.swapIDs), len(swaps))

--- a/x/bep3/keeper/querier_test.go
+++ b/x/bep3/keeper/querier_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -120,8 +119,6 @@ func (suite *QuerierTestSuite) TestQueryAtomicSwap() {
 	bz, err := suite.querier(ctx, []string{types.QueryGetAtomicSwap}, query)
 	suite.Nil(err)
 	suite.NotNil(bz)
-
-	fmt.Printf("%s\n", string(bz))
 
 	// Unmarshal the bytes into type atomic swap
 	var swap types.AugmentedAtomicSwap

--- a/x/bep3/keeper/querier_test.go
+++ b/x/bep3/keeper/querier_test.go
@@ -128,7 +128,7 @@ func (suite *QuerierTestSuite) TestQueryAtomicSwap() {
 	suite.Nil(types.ModuleCdc.UnmarshalJSON(bz, &swap))
 
 	// Check the returned atomic swap's ID
-	suite.True(suite.isSwapID[hex.EncodeToString(swap.GetSwapID())])
+	suite.True(suite.isSwapID[swap.ID])
 }
 
 func (suite *QuerierTestSuite) TestQueryAssetSupplies() {
@@ -164,12 +164,12 @@ func (suite *QuerierTestSuite) TestQueryAtomicSwaps() {
 	suite.Nil(err)
 	suite.NotNil(bz)
 
-	var swaps []types.AugmentedAtomicSwap
+	var swaps types.AugmentedAtomicSwaps
 	suite.Nil(types.ModuleCdc.UnmarshalJSON(bz, &swaps))
 
 	suite.Equal(len(suite.swapIDs), len(swaps))
 	for _, swap := range swaps {
-		suite.True(suite.isSwapID[hex.EncodeToString(swap.GetSwapID())])
+		suite.True(suite.isSwapID[swap.ID])
 	}
 }
 

--- a/x/bep3/types/swap.go
+++ b/x/bep3/types/swap.go
@@ -276,3 +276,5 @@ func NewAugmentedAtomicSwap(swap AtomicSwap) AugmentedAtomicSwap {
 		AtomicSwap: swap,
 	}
 }
+
+type AugmentedAtomicSwaps []AugmentedAtomicSwap

--- a/x/bep3/types/swap.go
+++ b/x/bep3/types/swap.go
@@ -266,14 +266,39 @@ func (direction SwapDirection) IsValid() bool {
 }
 
 type AugmentedAtomicSwap struct {
-	ID         string `json:"id" yaml:"id"`
-	AtomicSwap `json:"swap" yaml:"swap"`
+	ID string `json:"id" yaml:"id"`
+
+	// Embed AtomicSwap fields explicity in order to output as top level JSON fields
+	// This prevents breaking changes for clients using REST API
+	Amount              sdk.Coins        `json:"amount"  yaml:"amount"`
+	RandomNumberHash    tmbytes.HexBytes `json:"random_number_hash"  yaml:"random_number_hash"`
+	ExpireHeight        uint64           `json:"expire_height"  yaml:"expire_height"`
+	Timestamp           int64            `json:"timestamp"  yaml:"timestamp"`
+	Sender              sdk.AccAddress   `json:"sender"  yaml:"sender"`
+	Recipient           sdk.AccAddress   `json:"recipient"  yaml:"recipient"`
+	SenderOtherChain    string           `json:"sender_other_chain"  yaml:"sender_other_chain"`
+	RecipientOtherChain string           `json:"recipient_other_chain"  yaml:"recipient_other_chain"`
+	ClosedBlock         int64            `json:"closed_block"  yaml:"closed_block"`
+	Status              SwapStatus       `json:"status"  yaml:"status"`
+	CrossChain          bool             `json:"cross_chain"  yaml:"cross_chain"`
+	Direction           SwapDirection    `json:"direction"  yaml:"direction"`
 }
 
 func NewAugmentedAtomicSwap(swap AtomicSwap) AugmentedAtomicSwap {
 	return AugmentedAtomicSwap{
-		ID:         swap.GetSwapID().String(),
-		AtomicSwap: swap,
+		ID:                  hex.EncodeToString(swap.GetSwapID()),
+		Amount:              swap.Amount,
+		RandomNumberHash:    swap.RandomNumberHash,
+		ExpireHeight:        swap.ExpireHeight,
+		Timestamp:           swap.Timestamp,
+		Sender:              swap.Sender,
+		Recipient:           swap.Recipient,
+		SenderOtherChain:    swap.SenderOtherChain,
+		RecipientOtherChain: swap.RecipientOtherChain,
+		ClosedBlock:         swap.ClosedBlock,
+		Status:              swap.Status,
+		CrossChain:          swap.CrossChain,
+		Direction:           swap.Direction,
 	}
 }
 

--- a/x/bep3/types/swap.go
+++ b/x/bep3/types/swap.go
@@ -264,3 +264,15 @@ func (direction SwapDirection) IsValid() bool {
 	}
 	return false
 }
+
+type AugmentedAtomicSwap struct {
+	ID         string `json:"id" yaml:"id"`
+	AtomicSwap `json:"swap" yaml:"swap"`
+}
+
+func NewAugmentedAtomicSwap(swap AtomicSwap) AugmentedAtomicSwap {
+	return AugmentedAtomicSwap{
+		ID:         swap.GetSwapID().String(),
+		AtomicSwap: swap,
+	}
+}


### PR DESCRIPTION
- **(Breaking)** The YAML output matches the REST JSON now.  Some field representations have changed.
- The `id` field was added to the REST API Output.
  - This was already in the swagger definition, so no change there.
- JSON CLI output is now fixed and also matches the REST JSON.
