### PR TITLE
Use OS specific build directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 all: install
 
 build: go.sum
-ifeq ($(OS), windows)
+ifeq ($(OS), Windows_NT)
 	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvd.exe ./cmd/kvd
 	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvcli.exe ./cmd/kvcli
 else

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,18 @@
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
-
+ifeq ($(DETECTED_OS),)
+  ifeq ($(OS),Windows_NT)
+	  DETECTED_OS := windows
+  else
+	  UNAME_S = $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+	    DETECTED_OS := mac
+	  else
+	    DETECTED_OS := linux
+	  endif
+  endif
+endif
 export GO111MODULE = on
 
 # process build tags
@@ -64,16 +75,16 @@ BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 all: install
 
 build: go.sum
-ifeq ($(OS),Windows_NT)
-	go build -mod=readonly $(BUILD_FLAGS) -o build/kvd.exe ./cmd/kvd
-	go build -mod=readonly $(BUILD_FLAGS) -o build/kvcli.exe ./cmd/kvcli
+ifeq ($(OS), windows)
+	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvd.exe ./cmd/kvd
+	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvcli.exe ./cmd/kvcli
 else
-	go build -mod=readonly $(BUILD_FLAGS) -o build/kvd ./cmd/kvd
-	go build -mod=readonly $(BUILD_FLAGS) -o build/kvcli ./cmd/kvcli
+	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvd ./cmd/kvd
+	go build -mod=readonly $(BUILD_FLAGS) -o build/$(DETECTED_OS)/kvcli ./cmd/kvcli
 endif
 
 build-linux: go.sum
-	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build
+	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 DETECTED_OS=linux $(MAKE) build
 
 install: go.sum
 	go install -mod=readonly $(BUILD_FLAGS) ./cmd/kvd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ID=0
       - LOG=${LOG:-kvd.log}
     volumes:
-      - ./build:/kvd:Z
+      - ./build/linux:/kvd:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.2
@@ -24,7 +24,7 @@ services:
       - ID=1
       - LOG=${LOG:-kvd.log}
     volumes:
-      - ./build:/kvd:Z
+      - ./build/linux:/kvd:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.3
@@ -38,7 +38,7 @@ services:
     ports:
       - "26661-26662:26656-26657"
     volumes:
-      - ./build:/kvd:Z
+      - ./build/linux:/kvd:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.4
@@ -52,7 +52,7 @@ services:
     ports:
       - "26663-26664:26656-26657"
     volumes:
-      - ./build:/kvd:Z
+      - ./build/linux:/kvd:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.5

--- a/networks/local/kavanode/wrapper.sh
+++ b/networks/local/kavanode/wrapper.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-BINARY=/kvd/${BINARY:-kvd}
+BINARY=/kvd/linux/${BINARY:-kvd}
+echo "binary: ${BINARY}"
 ID=${ID:-0}
 LOG=${LOG:-kvd.log}
 


### PR DESCRIPTION
Changes `make build` to output to `windows`, `linux`, or `mac` directory. Auto-detection can be bypassed by passing in `DETECTED_OS` env variable - this was necessary to allow mac to build a linux binary. 