### PR TITLE
Add CDP GetTotalPrincipal Method

### DIFF
--- a/x/cdp/genesis.go
+++ b/x/cdp/genesis.go
@@ -72,9 +72,9 @@ func InitGenesis(ctx sdk.Context, k Keeper, pk types.PricefeedKeeper, sk types.S
 			panic(fmt.Sprintf("error setting cdp: %v", err))
 		}
 		k.IndexCdpByOwner(ctx, cdp)
-		ratio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+		ratio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 		k.IndexCdpByCollateralRatio(ctx, cdp.Collateral.Denom, cdp.ID, ratio)
-		k.IncrementTotalPrincipal(ctx, cdp.Collateral.Denom, cdp.Principal.Add(cdp.AccumulatedFees))
+		k.IncrementTotalPrincipal(ctx, cdp.Collateral.Denom, cdp.GetTotalPrincipal())
 	}
 
 	k.SetNextCdpID(ctx, gs.StartingCdpID)

--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -437,7 +437,7 @@ func (k Keeper) LoadAugmentedCDP(ctx sdk.Context, cdp types.CDP) types.Augmented
 		return types.AugmentedCDP{CDP: cdp}
 	}
 	// convert collateral value to debt coin
-	totalDebt := cdp.Principal.Amount.Add(cdp.AccumulatedFees.Amount)
+	totalDebt := cdp.GetTotalPrincipal().Amount
 	collateralValueInDebtDenom := sdk.NewDecFromInt(totalDebt).Mul(collateralizationRatio)
 	collateralValueInDebt := sdk.NewCoin(cdp.Principal.Denom, collateralValueInDebtDenom.RoundInt())
 	// create new augmuented cdp

--- a/x/cdp/keeper/deposit.go
+++ b/x/cdp/keeper/deposit.go
@@ -42,11 +42,11 @@ func (k Keeper) DepositCollateral(ctx sdk.Context, owner, depositor sdk.AccAddre
 
 	k.SetDeposit(ctx, deposit)
 
-	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 	k.RemoveCdpCollateralRatioIndex(ctx, cdp.Collateral.Denom, cdp.ID, oldCollateralToDebtRatio)
 
 	cdp.Collateral = cdp.Collateral.Add(collateral)
-	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 	return k.SetCdpAndCollateralRatioIndex(ctx, cdp, collateralToDebtRatio)
 }
 
@@ -88,11 +88,11 @@ func (k Keeper) WithdrawCollateral(ctx sdk.Context, owner, depositor sdk.AccAddr
 	if err != nil {
 		panic(err)
 	}
-	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 	k.RemoveCdpCollateralRatioIndex(ctx, cdp.Collateral.Denom, cdp.ID, oldCollateralToDebtRatio)
 
 	cdp.Collateral = cdp.Collateral.Sub(collateral)
-	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 	err = k.SetCdpAndCollateralRatioIndex(ctx, cdp, collateralToDebtRatio)
 	if err != nil {
 		return err

--- a/x/cdp/keeper/fees.go
+++ b/x/cdp/keeper/fees.go
@@ -26,7 +26,7 @@ func (k Keeper) CalculateFees(ctx sdk.Context, principal sdk.Coin, periods sdk.I
 func (k Keeper) UpdateFeesForAllCdps(ctx sdk.Context, collateralDenom string) error {
 	var iterationErr error
 	k.IterateCdpsByDenom(ctx, collateralDenom, func(cdp types.CDP) bool {
-		oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+		oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 		// periods = bblock timestamp - fees updated
 		periods := sdk.NewInt(ctx.BlockTime().Unix()).Sub(sdk.NewInt(cdp.FeesUpdated.Unix()))
 
@@ -84,7 +84,7 @@ func (k Keeper) UpdateFeesForAllCdps(ctx sdk.Context, collateralDenom string) er
 
 		// and set the fees updated time to the current block time since we just updated it
 		cdp.FeesUpdated = ctx.BlockTime()
-		collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+		collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 		k.RemoveCdpCollateralRatioIndex(ctx, cdp.Collateral.Denom, cdp.ID, oldCollateralToDebtRatio)
 		err = k.SetCdpAndCollateralRatioIndex(ctx, cdp, collateralToDebtRatio)
 		if err != nil {

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -17,11 +17,11 @@ import (
 // (this is the equivalent of saying that fees are no longer accumulated by a cdp once it gets liquidated)
 func (k Keeper) SeizeCollateral(ctx sdk.Context, cdp types.CDP) error {
 	// Calculate the previous collateral ratio
-	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Principal.Add(cdp.AccumulatedFees))
+	oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.GetTotalPrincipal())
 
 	// Move debt coins from cdp to liquidator account
 	deposits := k.GetDeposits(ctx, cdp.ID)
-	debt := cdp.Principal.Amount.Add(cdp.AccumulatedFees.Amount)
+	debt := cdp.GetTotalPrincipal().Amount
 	modAccountDebt := k.getModAccountDebt(ctx, types.ModuleName)
 	debt = sdk.MinInt(debt, modAccountDebt)
 	debtCoin := sdk.NewCoin(k.GetDebtDenom(ctx), debt)
@@ -54,7 +54,7 @@ func (k Keeper) SeizeCollateral(ctx sdk.Context, cdp types.CDP) error {
 	}
 
 	// Decrement total principal for this collateral type
-	coinsToDecrement := cdp.Principal.Add(cdp.AccumulatedFees)
+	coinsToDecrement := cdp.GetTotalPrincipal()
 	k.DecrementTotalPrincipal(ctx, cdp.Collateral.Denom, coinsToDecrement)
 
 	// Delete CDP from state

--- a/x/cdp/types/cdp.go
+++ b/x/cdp/types/cdp.go
@@ -76,6 +76,11 @@ func (cdp CDP) Validate() error {
 	return nil
 }
 
+// GetTotalPrinciple returns the total principle for the cdp
+func (cdp CDP) GetTotalPrincipal() sdk.Coin {
+	return cdp.Principal.Add(cdp.AccumulatedFees)
+}
+
 // CDPs a collection of CDP objects
 type CDPs []CDP
 

--- a/x/cdp/types/cdp_test.go
+++ b/x/cdp/types/cdp_test.go
@@ -157,7 +157,15 @@ func (suite *CdpValidationSuite) TestDepositValidation() {
 			}
 		})
 	}
+}
 
+func (suite *CdpValidationSuite) TestCdpGetTotalPrinciple() {
+	principal := sdk.Coin{"usdx", sdk.NewInt(100500)}
+	acummulatedFees := sdk.Coin{"usdx", sdk.NewInt(25000)}
+
+	cdp := types.CDP{Principal: principal, AccumulatedFees: acummulatedFees}
+
+	suite.Require().Equal(cdp.GetTotalPrincipal(), principal.Add(acummulatedFees))
 }
 
 func TestCdpValidationSuite(t *testing.T) {

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -73,7 +73,7 @@ func (k Keeper) ApplyRewardsToCdps(ctx sdk.Context) {
 		rewardsThisPeriod := rp.Reward.Amount.Mul(timeElapsed)
 		id := k.GetNextClaimPeriodID(ctx, rp.Denom)
 		k.cdpKeeper.IterateCdpsByDenom(ctx, rp.Denom, func(cdp cdptypes.CDP) bool {
-			rewardsShare := sdk.NewDecFromInt(cdp.Principal.Amount.Add(cdp.AccumulatedFees.Amount)).Quo(sdk.NewDecFromInt(totalPrincipal))
+			rewardsShare := sdk.NewDecFromInt(cdp.GetTotalPrincipal().Amount).Quo(sdk.NewDecFromInt(totalPrincipal))
 			// sanity check - don't create zero claims
 			if rewardsShare.IsZero() {
 				return false


### PR DESCRIPTION
- Add `GetTotalPrincipal()` method to `CDP` type
- Update code to use `cdp.GetTotalPrincipal()` instead of `cdp.Principal.Add(cdp.AccumulatedFees)`
- Update code to use `cdp.GetTotalPrinciple().Amount` instead of `cdp.Principal.Amount(cdp.AccumulatedFees.Amount)`

