### PR TITLE
Update reward vesting length calculation

### DIFF
--- a/x/incentive/keeper/payout.go
+++ b/x/incentive/keeper/payout.go
@@ -178,8 +178,8 @@ func (k Keeper) addCoinsToVestingSchedule(ctx sdk.Context, addr sdk.AccAddress, 
 
 	// logic for inserting a new vesting period into the existing vesting schedule
 	remainingLength := vacc.EndTime - ctx.BlockTime().Unix()
-	proposedEndTime := ctx.BlockTime().Unix() + length // 1596497160 + 31536000 = 1628033160
-	if remainingLength < length {                      // false
+	proposedEndTime := ctx.BlockTime().Unix() + length
+	if remainingLength < length {
 		// in the case that the proposed length is longer than the remaining length of all vesting periods, create a new period with length equal to the difference between the proposed length and the previous total length
 		newPeriodLength := length - remainingLength
 		newPeriod := types.NewPeriod(amt, newPeriodLength)

--- a/x/incentive/keeper/payout.go
+++ b/x/incentive/keeper/payout.go
@@ -140,15 +140,6 @@ func (k Keeper) GetClaimsByAddressAndDenom(ctx sdk.Context, addr sdk.AccAddress,
 		claims = append(claims, c)
 		return false
 	})
-	id := k.GetNextClaimPeriodID(ctx, denom)
-	_, hasClaimPeriod := k.GetClaimPeriod(ctx, id, denom)
-	if !hasClaimPeriod {
-		c, hasClaim := k.GetClaim(ctx, addr, denom, id)
-		if hasClaim {
-			claims = append(claims, c)
-			found = true
-		}
-	}
 	return claims, found
 }
 

--- a/x/incentive/keeper/payout.go
+++ b/x/incentive/keeper/payout.go
@@ -24,9 +24,6 @@ func (k Keeper) PayoutClaim(ctx sdk.Context, addr sdk.AccAddress, denom string, 
 	if !found {
 		return sdkerrors.Wrapf(types.ErrClaimPeriodNotFound, "id: %d, denom: %s", id, denom)
 	}
-	fmt.Printf(`called send timelocked coins to account
-		length: %d
-		`, int64(claimPeriod.TimeLock.Seconds()))
 	err := k.SendTimeLockedCoinsToAccount(ctx, types.IncentiveMacc, addr, sdk.NewCoins(claim.Reward), int64(claimPeriod.TimeLock.Seconds()))
 	if err != nil {
 		return err
@@ -59,12 +56,8 @@ func (k Keeper) SendTimeLockedCoinsToAccount(ctx sdk.Context, senderModule strin
 	case *validatorvesting.ValidatorVestingAccount, supplyExported.ModuleAccountI:
 		return sdkerrors.Wrapf(types.ErrInvalidAccountType, "%T", acc)
 	case *vesting.PeriodicVestingAccount:
-		fmt.Printf(`called send locked coins to periodic vesting account
-		`)
 		return k.SendTimeLockedCoinsToPeriodicVestingAccount(ctx, senderModule, recipientAddr, amt, length)
 	case *auth.BaseAccount:
-		fmt.Printf(`called send locked coins to base account
-		`)
 		return k.SendTimeLockedCoinsToBaseAccount(ctx, senderModule, recipientAddr, amt, length)
 	default:
 		return sdkerrors.Wrapf(types.ErrInvalidAccountType, "%T", acc)

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -35,7 +35,7 @@ func (suite *KeeperTestSuite) setupChain() {
 	)
 	supplyKeeper := tApp.GetSupplyKeeper()
 	macc := supplyKeeper.GetModuleAccount(ctx, kavadist.ModuleName)
-	err := supplyKeeper.MintCoins(ctx, macc.GetName(), cs(c("ukava", 500)))
+	err := supplyKeeper.MintCoins(ctx, macc.GetName(), cs(c("ukava", 600)))
 	suite.Require().NoError(err)
 
 	// sets addrs[0] to be a periodic vesting account
@@ -222,6 +222,27 @@ func (suite *KeeperTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 			expectedEndTime:         int64(125),
 		},
 		vestingAccountTest{
+			name:      "add period to end of schedule",
+			blockTime: time.Unix(110, 0),
+			args:      args{coins: cs(c("ukava", 100)), length: 20},
+			errArgs:   errArgs{expectErr: false, errType: nil},
+			expectedPeriods: vesting.Periods{
+				vesting.Period{Length: int64(5), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(6), Amount: cs(c("ukava", 200))},
+				vesting.Period{Length: int64(2), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(2), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(6), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(5), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(1), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(8), Amount: cs(c("ukava", 100))},
+				vesting.Period{Length: int64(5), Amount: cs(c("ukava", 100))},
+			},
+			expectedOriginalVesting: cs(c("ukava", 1000)),
+			expectedCoins:           cs(c("ukava", 1000)),
+			expectedStartTime:       int64(90),
+			expectedEndTime:         int64(130),
+		},
+		vestingAccountTest{
 			name:                    "insufficient module account balance",
 			blockTime:               time.Unix(90, 0),
 			args:                    args{coins: cs(c("ukava", 1000)), length: 11},
@@ -288,6 +309,7 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 
 	// add 2 claims that correspond to an existing claim period and one claim that has no corresponding claim period
 	cp1 := types.NewClaimPeriod("bnb", 1, suite.ctx.BlockTime().Add(time.Hour*168), time.Hour*8766)
+	suite.T().Log(cp1)
 	suite.keeper.SetClaimPeriod(suite.ctx, cp1)
 	// valid claim for addrs[0]
 	c1 := types.NewClaim(suite.addrs[0], c("ukava", 100), "bnb", 1)
@@ -300,7 +322,7 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 	suite.keeper.SetClaim(suite.ctx, c3)
 
 	// existing claim with corresponding claim period successfully claimed by existing periodic vesting account
-	err := suite.keeper.PayoutClaim(suite.ctx, suite.addrs[0], "bnb", 1)
+	err := suite.keeper.PayoutClaim(suite.ctx.WithBlockTime(time.Unix(3700, 0)), suite.addrs[0], "bnb", 1)
 	suite.Require().NoError(err)
 	acc := suite.getAccount(suite.addrs[0])
 	// account is a periodic vesting account
@@ -308,6 +330,7 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 	suite.True(ok)
 	// vesting balance is correct
 	suite.Equal(cs(c("ukava", 500)), vacc.OriginalVesting)
+	suite.T().Log(vacc)
 
 	// existing claim with corresponding claim period successfully claimed by base account
 	err = suite.keeper.PayoutClaim(suite.ctx, suite.addrs[1], "bnb", 1)

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -323,6 +323,36 @@ func (suite *KeeperTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 				contains:  "insufficient funds",
 			},
 		},
+		{
+			name: "add large period mid schedule",
+			args: args{
+				accArgs: accountArgs{
+					periods: vesting.Periods{
+						vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+						vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+						vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+						vesting.Period{Length: 5, Amount: cs(c("ukava", 5))}},
+					origVestingCoins: cs(c("ukava", 20)),
+					startTime:        100,
+					endTime:          120,
+				},
+				period:              vesting.Period{Length: 50, Amount: cs(c("ukava", 6))},
+				ctxTime:             time.Unix(110, 0),
+				mintModAccountCoins: true,
+				expectedPeriods: vesting.Periods{
+					vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+					vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+					vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+					vesting.Period{Length: 5, Amount: cs(c("ukava", 5))},
+					vesting.Period{Length: 40, Amount: cs(c("ukava", 6))}},
+				expectedStartTime: 100,
+				expectedEndTime:   160,
+			},
+			errArgs: errArgs{
+				expectErr: false,
+				contains:  "",
+			},
+		},
 	}
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -309,7 +309,6 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 
 	// add 2 claims that correspond to an existing claim period and one claim that has no corresponding claim period
 	cp1 := types.NewClaimPeriod("bnb", 1, suite.ctx.BlockTime().Add(time.Hour*168), time.Hour*8766)
-	suite.T().Log(cp1)
 	suite.keeper.SetClaimPeriod(suite.ctx, cp1)
 	// valid claim for addrs[0]
 	c1 := types.NewClaim(suite.addrs[0], c("ukava", 100), "bnb", 1)
@@ -330,7 +329,6 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 	suite.True(ok)
 	// vesting balance is correct
 	suite.Equal(cs(c("ukava", 500)), vacc.OriginalVesting)
-	suite.T().Log(vacc)
 
 	// existing claim with corresponding claim period successfully claimed by base account
 	err = suite.keeper.PayoutClaim(suite.ctx, suite.addrs[1], "bnb", 1)


### PR DESCRIPTION
Fixes issue where rewards are added to the first reward period, rather than creating a new reward period 1 year in the future. 