### PR TITLE
Add Kava Ledger App usage guide to docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -20,6 +20,15 @@ module.exports = {
           ]
         },
         {
+          title: "Platform",
+          children: [
+            {
+              title: "Kava Ledger App",
+              path: "/platform/ledger.html"
+            }
+          ]
+        },
+        {
           title: "Kava Tools",
           children: [
             {

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -1,0 +1,77 @@
+<!---
+parent:
+  order: false
+--->
+# Kava Ledger App
+
+[Ledger Nano S](https://www.ledger.com/products/ledger-nano-s) is a hardware wallet that enables users to securely access and use cryptocurrencies. Hardware wallets are considered very secure for the storage of a user’s private keys in the blockchain world. Your digital assets are safe even when using an infected (or untrusted) PC.
+
+## Before you begin
+1. [Initialize](https://support.ledgerwallet.com/hc/en-us/articles/360000613793) your Ledger Nano S.
+2. Update your Ledger device to the latest [firmware](https://support.ledgerwallet.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware).
+3. [Install](https://support.ledger.com/hc/en-us/articles/360006395553) Ledger Live.
+4. Install Google Chrome.
+
+## Install the Kava app on your Ledger Device
+1. Open the Manager in Ledger Live.
+2. Connect and unlock your Ledger Nano S.
+3. If asked, allow the Manager on your device by pressing the right button.
+4. Find Kava in the app catalog.
+5. Click the Install button of the Kava app.
+6. Search for Binance in the app catalog.
+7. Click the Install button of the Binance app.
+
+## Using Ledger device with Kava Web App
+
+Kava's web application available at [app.kava.io](https://app.kava.io/) supports ledger interaction with the Kava blockchain.
+1. Open and unlock the Kava ledger app using your pin.
+2. From the Connect Wallet display, click Ledger.
+3. Confirm your ledger address by clicking Show on device.
+4. View balances by clicking Balances.
+
+### Loading funds onto Kava
+1. From the Balances display, click Load.
+2. Close the Kava ledger app and open the Binance ledger app.
+3. Click Connect Binance App.
+4. On the Fund Account screen enter the amount and recipient.
+5. Click Fund.
+6. Review and sign the transaction on your ledger device.
+
+### Opening a CDP
+1. Click the Borrow USDX button.
+2. On the Borrow USDX screen enter the collateral amount and principal amount.
+3. Click Borrow.
+4. Review and sign the transaction on your ledger device.
+
+### Depositing collateral into a CDP
+1. Click Lock, opening the Lock BNB screen.
+2. Enter the collateral amount.
+3. Click Lock.
+4. Review and sign the transaction on your ledger device.
+
+### Withdrawing collateral from a CDP
+1. Click Withdraw, opening the Withdraw BNB screen.
+2. Enter the collateral amount.
+3. Click Withdraw.
+4. Review and sign the transaction on your ledger device.
+
+### Borrow USDX from a CDP
+1. Click Borrow, opening the Borrow USDX screen.
+2. Enter the principal amount.
+3. Click Borrow.
+4. Review and sign the transaction on your ledger device.
+
+## Repay USDX to a CDP
+1. Click Repay, opening the Repay USDX screen.
+2. Enter the principal amount.
+3. Click Repay.
+4. Review and sign the transaction on your ledger device.
+
+### Returning funds to Binance Chain
+1. From the Balances display, click Unload.
+2. On the Return Assets screen enter the amount and recipient.
+3. Click Send.
+4. Review and sign the transaction on your ledger device.
+
+## Support
+If you encounter any issue with your Ledger device or using the web application reach out through our [Discord](https://discord.com/invite/kQzh3Uv) channel or send us an email at support@kava.io.

--- a/docs/post.sh
+++ b/docs/post.sh
@@ -4,6 +4,9 @@
 rm -rf Modules
 
 # JavaScript SDK docs
+ rm -rf platform
+
+# JavaScript SDK docs
  rm -rf building
 
  # Kava Tools docs

--- a/docs/pre.sh
+++ b/docs/pre.sh
@@ -10,16 +10,20 @@ for D in ../x/*; do
   fi
 done
 
-baseGitUrl="https://raw.githubusercontent.com/Kava-Labs"
+# Platform docs (Web application, Ledger, etc.)
+platformDir="platform"
+mkdir -p "./${platformDir}"
+cp ./ledger.md "./${platformDir}/ledger.md"
 
 # Client docs (JavaScript SDK)
+baseGitUrl="https://raw.githubusercontent.com/Kava-Labs"
 clientGitRepo="javascript-sdk"
 clientDir="building"
 
 mkdir -p "./${clientDir}"
 curl "${baseGitUrl}/${clientGitRepo}/master/README.md" -o "./${clientDir}/${clientGitRepo}.md"
 echo "---
-parent: 
+parent:
   order: false
 ---" > "./${clientDir}/readme.md"
 
@@ -36,6 +40,6 @@ for T in ${toolDocs[@]}; do
   curl "${baseGitUrl}/${toolsGitRepo}/master/${T}/README.md" -o "./${toolsDir}/${T}.md"
 done
 echo "---
-parent: 
+parent:
   order: false
 ---" > "./${toolsDir}/readme.md"


### PR DESCRIPTION
Adds Kava Ledger App usage guide to docs.kava.io under new section 'Platform'.

If there's interest a 'Kava Web App' usage guide can be added to the Platform section in a future PR.
