### PR TITLE
[R4R] address potential panic in validator vesting

### DIFF
--- a/x/validator-vesting/keeper/keeper.go
+++ b/x/validator-vesting/keeper/keeper.go
@@ -185,6 +185,7 @@ func (k Keeper) HandleVestingDebt(ctx sdk.Context, addr sdk.AccAddress, blockTim
 		k.stakingKeeper.IterateDelegations(ctx, vv.Address, func(index int64, d stakingexported.DelegationI) (stop bool) {
 			_, err := k.stakingKeeper.Undelegate(ctx, d.GetDelegatorAddr(), d.GetValidatorAddr(), d.GetShares())
 			if err != nil {
+				// TODO what should we do instead of panic here?
 				panic(err)
 			}
 			return false

--- a/x/validator-vesting/types/errors.go
+++ b/x/validator-vesting/types/errors.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// DONTCOVER
+
+var (
+	// ErrFailedUndelegation error for delegations that fail to unbond
+	ErrFailedUndelegation = sdkerrors.Register(ModuleName, 2, "undelegation failed")
+)

--- a/x/validator-vesting/types/events.go
+++ b/x/validator-vesting/types/events.go
@@ -1,0 +1,9 @@
+package types
+
+// Event types for validator vesting module
+const (
+	EventTypeBeginBlockError = "begin_blocker_error"
+
+	AttributeValueCategory = "validator-vesting"
+	AttributeKeyError      = "error_message"
+)


### PR DESCRIPTION
In preparation for kava-4, as well as the fact that the failure case for validator vesting is going to be hit, I reviewed the code that handles failed vesting periods. Of note, it panics in the case where an undelegation fails.

```
k.stakingKeeper.IterateDelegations(ctx, vv.Address, func(index int64, d stakingexported.DelegationI) (stop bool) {
			_, err := k.stakingKeeper.Undelegate(ctx, d.GetDelegatorAddr(), d.GetValidatorAddr(), d.GetShares())
			if err != nil {
				panic(err)
			}
			return false
		})
```
 
I think it's possible for undelegation to fail due to invalid shares amount (caused by rounding?), which we have seen on mainnet: https://kava.mintscan.io/txs/6E2DF48C550CD8674B4C1049A55F9434B6B9D02E75B2998FE63F33953C30C56B

Because of thus, I believe there is a small but nonzero chance of a panic when a validator vesting account fails a vesting period and its tokens are unbonded. 

Options
* Leave as is
* Silently ignore error
* Emit error event
* Something else?
