### PR TITLE
fix: use previous version of liche

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,8 @@ clean:
 # This tool checks local markdown links as well.
 # Set to exclude riot links as they trigger false positives
 link-check:
-	@go run github.com/raviqqe/liche -r . --exclude "^http://127.*|^https://riot.im/app*|^http://kava-testnet*|^https://testnet-dex*|^https://kava3.data.kava.io*|^https://ipfs.io*|^https://apps.apple.com*"
+	@go get -u github.com/raviqqe/liche@f57a5d1c5be4856454cb26de155a65a4fd856ee3
+	liche -r . --exclude "^http://127.*|^https://riot.im/app*|^http://kava-testnet*|^https://testnet-dex*|^https://kava3.data.kava.io*|^https://ipfs.io*|^https://apps.apple.com*"
 
 
 lint:


### PR DESCRIPTION
Liche introduced a broken go.mod, fixing it by reverting to previous commit until they patch. 