### PR TITLE
[R4R] fix: close expired auctions in init genesis

### DIFF
--- a/x/auction/genesis.go
+++ b/x/auction/genesis.go
@@ -35,6 +35,10 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper types.SupplyKeeper
 	if !moduleAcc.GetCoins().IsEqual(totalAuctionCoins) {
 		panic(fmt.Sprintf("total auction coins (%s) do not equal (%s) module account (%s) ", moduleAcc.GetCoins(), ModuleName, totalAuctionCoins))
 	}
+	err = keeper.CloseExpiredAuctions(ctx)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // ExportGenesis returns a GenesisState for a given context and keeper.

--- a/x/auction/genesis.go
+++ b/x/auction/genesis.go
@@ -35,7 +35,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper types.SupplyKeeper
 	if !moduleAcc.GetCoins().IsEqual(totalAuctionCoins) {
 		panic(fmt.Sprintf("total auction coins (%s) do not equal (%s) module account (%s) ", moduleAcc.GetCoins(), ModuleName, totalAuctionCoins))
 	}
-	err = keeper.CloseExpiredAuctions(ctx)
+	err := keeper.CloseExpiredAuctions(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/x/auction/genesis.go
+++ b/x/auction/genesis.go
@@ -35,10 +35,6 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, supplyKeeper types.SupplyKeeper
 	if !moduleAcc.GetCoins().IsEqual(totalAuctionCoins) {
 		panic(fmt.Sprintf("total auction coins (%s) do not equal (%s) module account (%s) ", moduleAcc.GetCoins(), ModuleName, totalAuctionCoins))
 	}
-	err := keeper.CloseExpiredAuctions(ctx)
-	if err != nil {
-		panic(err)
-	}
 }
 
 // ExportGenesis returns a GenesisState for a given context and keeper.

--- a/x/auction/keeper/invariants.go
+++ b/x/auction/keeper/invariants.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -59,15 +58,6 @@ func ValidAuctionInvariant(k Keeper) sdk.Invariant {
 			a, ok := auction.(types.GenesisAuction)
 			if !ok {
 				panic("stored auction type does not fulfill GenesisAuction interface")
-			}
-
-			currentTime := ctx.BlockTime()
-			if !currentTime.Equal(time.Time{}) { // this avoids a simulator bug where app.InitGenesis is called with blockTime=0 instead of the correct time
-				if a.GetEndTime().Before(currentTime) {
-					validationErr = fmt.Errorf("endTime before current block time (%s)", currentTime)
-					invalidAuction = a
-					return true
-				}
 			}
 
 			if err := a.Validate(); err != nil {


### PR DESCRIPTION
If an auction expires during migration, auction invariants will panic when the chain tries to restart. Fix is to close expired auctions in init genesis. 