### PR TITLE
Add harvest staking tests

### DIFF
--- a/docs/communitytools.md
+++ b/docs/communitytools.md
@@ -40,7 +40,6 @@ Listed in alphabetical order.
 - [OKEx Pool](https://www.okex.com/pool)
 - [P2P](https://p2p.org/)
 - [SNZ Pool](https://snzholding.com/pool.html)
-- [Sikka](https://www.sikka.tech/)
 - [StakeWith.Us](https://www.stakewith.us/)
 - [Staked](https://staked.us/)
 - [stake.fish](https://stake.fish/en/)

--- a/x/harvest/keeper/claim_test.go
+++ b/x/harvest/keeper/claim_test.go
@@ -243,8 +243,7 @@ func (suite *KeeperTestSuite) TestClaim() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			// create new app with one funded account
-			config := sdk.GetConfig()
-			app.SetBech32AddressPrefixes(config)
+
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tc.args.blockTime})

--- a/x/harvest/keeper/deposit_test.go
+++ b/x/harvest/keeper/deposit_test.go
@@ -111,8 +111,7 @@ func (suite *KeeperTestSuite) TestDeposit() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			// create new app with one funded account
-			config := sdk.GetConfig()
-			app.SetBech32AddressPrefixes(config)
+
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
@@ -279,8 +278,7 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			// create new app with one funded account
-			config := sdk.GetConfig()
-			app.SetBech32AddressPrefixes(config)
+
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})

--- a/x/harvest/keeper/keeper_test.go
+++ b/x/harvest/keeper/keeper_test.go
@@ -29,6 +29,9 @@ type KeeperTestSuite struct {
 
 // The default state used by each test
 func (suite *KeeperTestSuite) SetupTest() {
+	config := sdk.GetConfig()
+	app.SetBech32AddressPrefixes(config)
+
 	tApp := app.NewTestApp()
 	ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 	tApp.InitializeFromGenesisStates()

--- a/x/harvest/keeper/rewards.go
+++ b/x/harvest/keeper/rewards.go
@@ -129,7 +129,7 @@ func (k Keeper) ApplyDelegationRewards(ctx sdk.Context, denom string) {
 		if validator.GetStatus() != sdk.Bonded {
 			return false
 		}
-		sharesToTokens[validator.GetOperator().String()] = (validator.GetDelegatorShares()).Quo(sdk.NewDecFromInt(validator.GetTokens()))
+		sharesToTokens[validator.GetOperator().String()] = sdk.NewDecFromInt(validator.GetTokens()).Quo(validator.GetDelegatorShares())
 		return false
 	})
 

--- a/x/harvest/keeper/timelock_test.go
+++ b/x/harvest/keeper/timelock_test.go
@@ -6,10 +6,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
-	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/harvest/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/x/harvest/types"
 )
 
 func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
@@ -273,8 +274,7 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			// create new app with one funded account
-			config := sdk.GetConfig()
-			app.SetBech32AddressPrefixes(config)
+
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tc.args.blockTime})


### PR DESCRIPTION
This PR expands the tests for creating reward claims for kava delegations.
It also fixes a bug in calculating tokens from validator shares.

I ended up moving the delegation reward tests to their own test suite. I couldn't come up with a way to fit them all into a table test neatly.