### PR TITLE
feat: add function to initialize testApp with chain-id

### DIFF
--- a/app/test_common.go
+++ b/app/test_common.go
@@ -142,6 +142,34 @@ func (tApp TestApp) InitializeFromGenesisStatesWithTime(genTime time.Time, genes
 	return tApp
 }
 
+// InitializeFromGenesisStatesWithTimeAndChainID calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states and genesis Time
+func (tApp TestApp) InitializeFromGenesisStatesWithTimeAndChainID(genTime time.Time, chainID string, genesisStates ...GenesisState) TestApp {
+	// Create a default genesis state and overwrite with provided values
+	genesisState := NewDefaultGenesisState()
+	for _, state := range genesisStates {
+		for k, v := range state {
+			genesisState[k] = v
+		}
+	}
+
+	// Initialize the chain
+	stateBytes, err := codec.MarshalJSONIndent(tApp.cdc, genesisState)
+	if err != nil {
+		panic(err)
+	}
+	tApp.InitChain(
+		abci.RequestInitChain{
+			Time:          genTime,
+			Validators:    []abci.ValidatorUpdate{},
+			AppStateBytes: stateBytes,
+			ChainId:       chainID,
+		},
+	)
+	tApp.Commit()
+	tApp.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: tApp.LastBlockHeight() + 1, Time: genTime}})
+	return tApp
+}
+
 func (tApp TestApp) CheckBalance(t *testing.T, ctx sdk.Context, owner sdk.AccAddress, expectedCoins sdk.Coins) {
 	acc := tApp.GetAccountKeeper().GetAccount(ctx, owner)
 	require.NotNilf(t, acc, "account with address '%s' doesn't exist", owner)


### PR DESCRIPTION
Useful when validating a specific genesis file - for example, checking that a testnet genesis file is valid before publishing it