### PR TITLE
Update link for CI url check

### DIFF
--- a/docs/communitytools.md
+++ b/docs/communitytools.md
@@ -29,7 +29,7 @@ Listed in alphabetical order.
 - [ATEAM](https://nodeateam.com/)
 - [B-Harvest](https://bharvest.io/)
 - [BNB48 Club](https://www.bnb48.club/)
-- [Binance Staking](https://www.binance.com/en/staking)
+- [Binance Staking](https://www.binance.com/en/earn)
 - [ChainLayer](https://www.chainlayer.io/)
 - [Chorus One](https://chorus.one/)
 - [Cosmostation](https://www.cosmostation.io/)


### PR DESCRIPTION
Update binance/staking to binance/earn as the site's url has changed.