### PR TITLE
Fix x/incentive claim cli help message

### DIFF
--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -35,8 +35,8 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 
 func getCmdClaim(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "claim [owner] [denom]",
-		Short: "claim rewards for owner and denom",
+		Use:   "claim [owner] [collateral-type] [multiplier]",
+		Short: "claim rewards for cdp owner and collateral-type",
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Claim any outstanding rewards owned by owner for the input collateral-type and multiplier,
 


### PR DESCRIPTION
Similar to #696, but updates the cli usage message to match numbr of args.

Feel free to close if this fix is included in another branch.