### PR TITLE
Query total fees collected

### DIFF
--- a/x/cdp/alias.go
+++ b/x/cdp/alias.go
@@ -34,9 +34,11 @@ const (
 	QueryGetParams                          = types.QueryGetParams
 	QueryGetPreviousSavingsDistributionTime = types.QueryGetPreviousSavingsDistributionTime
 	QueryGetSavingsRateDistributed          = types.QueryGetSavingsRateDistributed
+	QueryGetFees                            = types.QueryGetFees
 	RestCollateralType                      = types.RestCollateralType
 	RestOwner                               = types.RestOwner
 	RestRatio                               = types.RestRatio
+	RestDenom                               = types.RestDenom
 	RouterKey                               = types.RouterKey
 	SavingsRateMacc                         = types.SavingsRateMacc
 	StoreKey                                = types.StoreKey
@@ -148,6 +150,7 @@ var (
 	PricefeedStatusKeyPrefix            = types.PricefeedStatusKeyPrefix
 	PrincipalKeyPrefix                  = types.PrincipalKeyPrefix
 	SavingsRateDistributedKey           = types.SavingsRateDistributedKey
+	FeesCollectedKey                    = types.FeesCollectedKey
 )
 
 type (

--- a/x/cdp/client/rest/rest.go
+++ b/x/cdp/client/rest/rest.go
@@ -15,6 +15,7 @@ const (
 	RestCollateralType = "collateral-type"
 	RestID             = "id"
 	RestRatio          = "ratio"
+	RestDenom          = "denom"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application

--- a/x/cdp/keeper/querier.go
+++ b/x/cdp/keeper/querier.go
@@ -36,6 +36,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryGetSavingsRateDistributed(ctx, req, keeper)
 		case types.QueryGetPreviousSavingsDistributionTime:
 			return queryGetPreviousSavingsDistributionTime(ctx, req, keeper)
+		case types.QueryGetFees:
+			return queryFees(ctx, req, keeper)
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint %s", types.ModuleName, path[0])
 		}
@@ -212,6 +214,23 @@ func queryGetPreviousSavingsDistributionTime(ctx sdk.Context, req abci.RequestQu
 
 	// Encode results
 	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, savingsRateDistTime)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+	return bz, nil
+}
+
+// query collected fees by fee coin denom
+func queryFees(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	var requestParams types.QueryFees
+	err := types.ModuleCdc.UnmarshalJSON(req.Data, &requestParams)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+	feesCollected := keeper.GetFeesCollected(ctx, requestParams.Denom)
+
+	// Encode results
+	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, feesCollected)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/cdp/types/keys.go
+++ b/x/cdp/types/keys.go
@@ -62,6 +62,7 @@ var (
 	PreviousDistributionTimeKey = []byte{0x08}
 	PricefeedStatusKeyPrefix    = []byte{0x09}
 	SavingsRateDistributedKey   = []byte{0x10}
+	FeesCollectedKey            = []byte{0x11}
 )
 
 // GetCdpIDBytes returns the byte representation of the cdpID

--- a/x/cdp/types/querier.go
+++ b/x/cdp/types/querier.go
@@ -15,9 +15,11 @@ const (
 	QueryGetAccounts                        = "accounts"
 	QueryGetSavingsRateDistributed          = "savings-rate-dist"
 	QueryGetPreviousSavingsDistributionTime = "savings-rate-dist-time"
+	QueryGetFees                            = "fees"
 	RestOwner                               = "owner"
 	RestCollateralType                      = "collateral-type"
 	RestRatio                               = "ratio"
+	RestDenom                               = "denom"
 )
 
 // QueryCdpParams params for query /cdp/cdp
@@ -93,5 +95,17 @@ func NewQueryCdpsByRatioParams(collateralType string, ratio sdk.Dec) QueryCdpsBy
 	return QueryCdpsByRatioParams{
 		CollateralType: collateralType,
 		Ratio:          ratio,
+	}
+}
+
+// QueryFees params for query /cdp/fees
+type QueryFees struct {
+	Denom string
+}
+
+// NewQueryFees returns QueryFees
+func NewQueryFees(denom string) QueryFees {
+	return QueryFees{
+		Denom: denom,
 	}
 }


### PR DESCRIPTION
Addresses a query from https://github.com/Kava-Labs/kava/issues/639 by adding CDP store key `FeesCollected` to track the total amount of fees repaid (CDP module revenue) and exposes an endpoint for querying the value.

```bash
kvcli q cdp fees usdx
```