### PR TITLE
Fix error response when an invalid owner address is given

### DIFF
--- a/x/harvest/client/rest/query.go
+++ b/x/harvest/client/rest/query.go
@@ -67,6 +67,7 @@ func queryDepositsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			depositOwner, err = sdk.AccAddressFromBech32(depositOwnerStr)
 			if err != nil {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("cannot parse address from deposit owner %s", depositOwnerStr))
+				return
 			}
 		}
 
@@ -125,6 +126,7 @@ func queryClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			claimOwner, err = sdk.AccAddressFromBech32(claimOwnerStr)
 			if err != nil {
 				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("cannot parse address from claim owner %s", claimOwnerStr))
+				return
 			}
 		}
 


### PR DESCRIPTION
Currently, the harvest claims and deposits endpoints are missing a return after writing an error response for an invalid owner address.  This results in an invalid JSON body.

Examples:
  - https://kava4.data.kava.io/harvest/claims?owner=notvalid
  - https://kava4.data.kava.io/harvest/deposits?owner=notvalid

This PR adds the missing returns after writing the error json.
