### PR TITLE
Module account permissions fix

### DIFF
--- a/x/bep3/abci.go
+++ b/x/bep3/abci.go
@@ -9,7 +9,7 @@ import (
 // BeginBlocker on every block expires outdated atomic swaps and removes closed
 // swap from long term storage (default storage time of 1 week)
 func BeginBlocker(ctx sdk.Context, k Keeper) {
-	if ctx.BlockHeight() == 24 { // TODO
+	if ctx.BlockTime().After(ModulePermissionsUpgradeTime) {
 		err := k.EnsureModuleAccountPermissions(ctx)
 		if err != nil {
 			k.Logger(ctx).Error(fmt.Sprintf("couldn't update module account permissions: %v", err))

--- a/x/bep3/abci.go
+++ b/x/bep3/abci.go
@@ -7,6 +7,12 @@ import (
 // BeginBlocker on every block expires outdated atomic swaps and removes closed
 // swap from long term storage (default storage time of 1 week)
 func BeginBlocker(ctx sdk.Context, k Keeper) {
+	if ctx.BlockHeight() == 999999999 { // TODO
+		err := k.EnsureModuleAccountPermissions(ctx)
+		if err != nil {
+			k.Logger(ctx).Error("%v", err)
+		}
+	}
 	k.UpdateTimeBasedSupplyLimits(ctx)
 	k.UpdateExpiredAtomicSwaps(ctx)
 	k.DeleteClosedAtomicSwapsFromLongtermStorage(ctx)

--- a/x/bep3/abci.go
+++ b/x/bep3/abci.go
@@ -1,16 +1,18 @@
 package bep3
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // BeginBlocker on every block expires outdated atomic swaps and removes closed
 // swap from long term storage (default storage time of 1 week)
 func BeginBlocker(ctx sdk.Context, k Keeper) {
-	if ctx.BlockHeight() == 999999999 { // TODO
+	if ctx.BlockHeight() == 24 { // TODO
 		err := k.EnsureModuleAccountPermissions(ctx)
 		if err != nil {
-			k.Logger(ctx).Error("%v", err)
+			k.Logger(ctx).Error(fmt.Sprintf("couldn't update module account permissions: %v", err))
 		}
 	}
 	k.UpdateTimeBasedSupplyLimits(ctx)

--- a/x/bep3/alias.go
+++ b/x/bep3/alias.go
@@ -121,6 +121,7 @@ var (
 	DefaultMinBlockLock             = types.DefaultMinBlockLock
 	DefaultMaxBlockLock             = types.DefaultMaxBlockLock
 	DefaultPreviousBlockTime        = types.DefaultPreviousBlockTime
+	ModulePermissionsUpgradeTime    = types.ModulePermissionsUpgradeTime
 )
 
 type (

--- a/x/bep3/keeper/integration_test.go
+++ b/x/bep3/keeper/integration_test.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 
 	"github.com/tendermint/tendermint/crypto"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -28,6 +30,11 @@ func i(in int64) sdk.Int                    { return sdk.NewInt(in) }
 func c(denom string, amount int64) sdk.Coin { return sdk.NewInt64Coin(denom, amount) }
 func cs(coins ...sdk.Coin) sdk.Coins        { return sdk.NewCoins(coins...) }
 func ts(minOffset int) int64                { return tmtime.Now().Add(time.Duration(minOffset) * time.Minute).Unix() }
+
+func NewAuthGenStateFromAccs(accounts ...authexported.GenesisAccount) app.GenesisState {
+	authGenesis := auth.NewGenesisState(auth.DefaultParams(), accounts)
+	return app.GenesisState{auth.ModuleName: auth.ModuleCdc.MustMarshalJSON(authGenesis)}
+}
 
 func NewBep3GenStateMulti(deputyAddress sdk.AccAddress) app.GenesisState {
 	bep3Genesis := types.GenesisState{

--- a/x/bep3/keeper/keeper.go
+++ b/x/bep3/keeper/keeper.go
@@ -50,7 +50,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // EnsureModuleAccountPermissions syncs the bep3 module account's permissions with those in the supply keeper.
 func (k Keeper) EnsureModuleAccountPermissions(ctx sdk.Context) error {
 	maccI := k.supplyKeeper.GetModuleAccount(ctx, types.ModuleName)
-	macc, ok := maccI.(supply.ModuleAccount)
+	macc, ok := maccI.(*supply.ModuleAccount)
 	if !ok {
 		return fmt.Errorf("expected %s account to be a module account type", types.ModuleName)
 	}

--- a/x/bep3/keeper/keeper.go
+++ b/x/bep3/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/params/subspace"
+	"github.com/cosmos/cosmos-sdk/x/supply"
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/kava-labs/kava/x/bep3/types"
@@ -44,6 +45,19 @@ func NewKeeper(cdc *codec.Codec, key sdk.StoreKey, sk types.SupplyKeeper, ak typ
 // Logger returns a module-specific logger.
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+// EnsureModuleAccountPermissions syncs the bep3 module account's permissions with those in the supply keeper.
+func (k Keeper) EnsureModuleAccountPermissions(ctx sdk.Context) error {
+	maccI := k.supplyKeeper.GetModuleAccount(ctx, types.ModuleName)
+	macc, ok := maccI.(supply.ModuleAccount)
+	if !ok {
+		return fmt.Errorf("expected %s account to be a module account type", types.ModuleName)
+	}
+	_, perms := k.supplyKeeper.GetModuleAddressAndPermissions(types.ModuleName)
+	macc.Permissions = perms
+	k.supplyKeeper.SetModuleAccount(ctx, macc)
+	return nil
 }
 
 // ------------------------------------------

--- a/x/bep3/types/expected_keepers.go
+++ b/x/bep3/types/expected_keepers.go
@@ -10,6 +10,8 @@ import (
 type SupplyKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
 	GetModuleAccount(ctx sdk.Context, moduleName string) supplyexported.ModuleAccountI
+	GetModuleAddressAndPermissions(moduleName string) (sdk.AccAddress, []string)
+	SetModuleAccount(ctx sdk.Context, macc supplyexported.ModuleAccountI)
 
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error

--- a/x/bep3/types/keys.go
+++ b/x/bep3/types/keys.go
@@ -29,7 +29,7 @@ const (
 // Key prefixes
 var (
 	// ModulePermissionsUpgradeTime is the block time after which the bep3 module account's permissions are synced with the supply module.
-	ModulePermissionsUpgradeTime time.Time = time.Date(2020, 11, 3, 14, 0, 0, 0, time.UTC)
+	ModulePermissionsUpgradeTime time.Time = time.Date(2020, 11, 3, 10, 0, 0, 0, time.UTC)
 
 	AtomicSwapKeyPrefix             = []byte{0x00} // prefix for keys that store AtomicSwaps
 	AtomicSwapByBlockPrefix         = []byte{0x01} // prefix for keys of the AtomicSwapsByBlock index

--- a/x/bep3/types/keys.go
+++ b/x/bep3/types/keys.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -26,6 +28,9 @@ const (
 
 // Key prefixes
 var (
+	// ModulePermissionsUpgradeTime is the block time after which the bep3 module account's permissions are synced with the supply module.
+	ModulePermissionsUpgradeTime time.Time = time.Date(2020, 11, 3, 14, 0, 0, 0, time.UTC)
+
 	AtomicSwapKeyPrefix             = []byte{0x00} // prefix for keys that store AtomicSwaps
 	AtomicSwapByBlockPrefix         = []byte{0x01} // prefix for keys of the AtomicSwapsByBlock index
 	AtomicSwapLongtermStoragePrefix = []byte{0x02} // prefix for keys of the AtomicSwapLongtermStorage index


### PR DESCRIPTION
In the bep3 begin blocker, add the correct permissions to the bep3 module account after an upgrade time.

For testing, there's a config in kvtool on this branch: https://github.com/Kava-Labs/kvtool/tree/ro-test-modacc-permission-fix that can be generated with `kvtool t gen-config kava deputy binance --kava.configTemplate mod-acc-fix`
