### PR TITLE
Harvest basic borrow functionality

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -102,9 +102,9 @@ var (
 		bep3.ModuleName:             {supply.Minter, supply.Burner},
 		kavadist.ModuleName:         {supply.Minter},
 		issuance.ModuleAccountName:  {supply.Minter, supply.Burner},
-		harvest.LPAccount:               {supply.Minter, supply.Burner},
-		harvest.DelegatorAccount:        {supply.Minter, supply.Burner},
-		harvest.ModuleAccountName:       {supply.Minter, supply.Burner},
+		harvest.LPAccount:           {supply.Minter, supply.Burner},
+		harvest.DelegatorAccount:    {supply.Minter, supply.Burner},
+		harvest.ModuleAccountName:   {supply.Minter, supply.Burner},
 	}
 
 	// module accounts that are allowed to receive tokens
@@ -376,7 +376,8 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		harvestSubspace,
 		app.accountKeeper,
 		app.supplyKeeper,
-		&stakingKeeper)
+		&stakingKeeper,
+		app.pricefeedKeeper)
 
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
@@ -407,7 +408,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		incentive.NewAppModule(app.incentiveKeeper, app.accountKeeper, app.supplyKeeper),
 		committee.NewAppModule(app.committeeKeeper, app.accountKeeper),
 		issuance.NewAppModule(app.issuanceKeeper, app.accountKeeper, app.supplyKeeper),
-		harvest.NewAppModule(app.harvestKeeper, app.supplyKeeper),
+		harvest.NewAppModule(app.harvestKeeper, app.supplyKeeper, app.pricefeedKeeper),
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -460,7 +461,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 		incentive.NewAppModule(app.incentiveKeeper, app.accountKeeper, app.supplyKeeper),
 		committee.NewAppModule(app.committeeKeeper, app.accountKeeper),
 		issuance.NewAppModule(app.issuanceKeeper, app.accountKeeper, app.supplyKeeper),
-		harvest.NewAppModule(app.harvestKeeper, app.supplyKeeper),
+		harvest.NewAppModule(app.harvestKeeper, app.supplyKeeper, app.pricefeedKeeper),
 	)
 
 	app.sm.RegisterStoreDecoders()

--- a/migrate/v0_11/migrate.go
+++ b/migrate/v0_11/migrate.go
@@ -129,7 +129,7 @@ func MigrateAppState(v0_9AppState v39_genutil.AppMap) v39_genutil.AppMap {
 		delete(v0_9AppState, v0_9pricefeed.ModuleName)
 		v0_11AppState[v0_9pricefeed.ModuleName] = v0_11Codec.MustMarshalJSON(MigratePricefeed(pricefeedGenState))
 	}
-	v0_11AppState[v0_11harvest.ModuleName] = v0_11Codec.MustMarshalJSON(MigrateHarvest())
+	// v0_11AppState[v0_11harvest.ModuleName] = v0_11Codec.MustMarshalJSON(MigrateHarvest())
 	v0_11AppState[v0_11issuance.ModuleName] = v0_11Codec.MustMarshalJSON(v0_11issuance.DefaultGenesisState())
 	return v0_11AppState
 }
@@ -633,29 +633,34 @@ func MigrateGov(oldGenState v39_1gov.GenesisState) v39_1gov.GenesisState {
 	return oldGenState
 }
 
-// MigrateHarvest initializes the harvest genesis state for kava-4
-func MigrateHarvest() v0_11harvest.GenesisState {
-	// total HARD per second for lps (week one): 633761
-	// HARD per second for delegators (week one): 1267522
-	incentiveGoLiveDate := time.Date(2020, 10, 16, 14, 0, 0, 0, time.UTC)
-	incentiveEndDate := time.Date(2024, 10, 16, 14, 0, 0, 0, time.UTC)
-	claimEndDate := time.Date(2025, 10, 16, 14, 0, 0, 0, time.UTC)
-	harvestGS := v0_11harvest.NewGenesisState(v0_11harvest.NewParams(
-		true,
-		v0_11harvest.DistributionSchedules{
-			v0_11harvest.NewDistributionSchedule(true, "usdx", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(310543)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
-			v0_11harvest.NewDistributionSchedule(true, "hard", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(285193)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
-			v0_11harvest.NewDistributionSchedule(true, "bnb", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(12675)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
-			v0_11harvest.NewDistributionSchedule(true, "ukava", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(25350)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
-		},
-		v0_11harvest.DelegatorDistributionSchedules{v0_11harvest.NewDelegatorDistributionSchedule(
-			v0_11harvest.NewDistributionSchedule(true, "ukava", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(1267522)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
-			time.Hour*24,
-		),
-		},
-	), v0_11harvest.DefaultPreviousBlockTime, v0_11harvest.DefaultDistributionTimes)
-	return harvestGS
-}
+// // MigrateHarvest initializes the harvest genesis state for kava-4
+// func MigrateHarvest() v0_11harvest.GenesisState {
+// 	// total HARD per second for lps (week one): 633761
+// 	// HARD per second for delegators (week one): 1267522
+// 	incentiveGoLiveDate := time.Date(2020, 10, 16, 14, 0, 0, 0, time.UTC)
+// 	incentiveEndDate := time.Date(2024, 10, 16, 14, 0, 0, 0, time.UTC)
+// 	claimEndDate := time.Date(2025, 10, 16, 14, 0, 0, 0, time.UTC)
+// 	harvestGS := v0_11harvest.NewGenesisState(v0_11harvest.NewParams(
+// 		true,
+// 		v0_11harvest.DistributionSchedules{
+// 			v0_11harvest.NewDistributionSchedule(true, "usdx", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(310543)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
+// 			v0_11harvest.NewDistributionSchedule(true, "hard", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(285193)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
+// 			v0_11harvest.NewDistributionSchedule(true, "bnb", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(12675)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
+// 			v0_11harvest.NewDistributionSchedule(true, "ukava", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(25350)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
+// 		},
+// 		v0_11harvest.DelegatorDistributionSchedules{v0_11harvest.NewDelegatorDistributionSchedule(
+// 			v0_11harvest.NewDistributionSchedule(true, "ukava", incentiveGoLiveDate, incentiveEndDate, sdk.NewCoin("hard", sdk.NewInt(1267522)), claimEndDate, v0_11harvest.Multipliers{v0_11harvest.NewMultiplier(v0_11harvest.Small, 1, sdk.MustNewDecFromStr("0.33")), v0_11harvest.NewMultiplier(v0_11harvest.Large, 12, sdk.OneDec())}),
+// 			time.Hour*24,
+// 		),
+// 		},
+// 		v0_11harvest.BlockLimits{
+// 			v0_11harvest.NewBlockLimit("usdx", sdk.Dec(0.9)),
+// 			v0_11harvest.NewBlockLimit("ukava", sdk.Dec(0.6)),
+// 			v0_11harvest.NewBlockLimit("bnb", sdk.Dec(0.9)),
+// 		},
+// 	), v0_11harvest.DefaultPreviousBlockTime, v0_11harvest.DefaultDistributionTimes)
+// 	return harvestGS
+// }
 
 // MigrateCDP migrates from a v0.9 (or v0.10) cdp genesis state to a v0.11 cdp genesis state
 func MigrateCDP(oldGenState v0_9cdp.GenesisState) v0_11cdp.GenesisState {

--- a/x/harvest/alias.go
+++ b/x/harvest/alias.go
@@ -111,8 +111,8 @@ type (
 	Keeper                         = keeper.Keeper
 	AccountKeeper                  = types.AccountKeeper
 	Borrow                         = types.Borrow
-	BorrowLimit                    = types.BorrowLimit
-	BorrowLimits                   = types.BorrowLimits
+	MoneyMarket                    = types.MoneyMarket
+	MoneyMarkets                   = types.MoneyMarkets
 	DelegatorDistributionSchedule  = types.DelegatorDistributionSchedule
 	DelegatorDistributionSchedules = types.DelegatorDistributionSchedules
 	Deposit                        = types.Deposit

--- a/x/harvest/alias.go
+++ b/x/harvest/alias.go
@@ -74,6 +74,7 @@ var (
 	RegisterCodec                    = types.RegisterCodec
 
 	// variable aliases
+	BorrowsKeyPrefix                  = types.BorrowsKeyPrefix
 	ClaimsKeyPrefix                   = types.ClaimsKeyPrefix
 	DefaultActive                     = types.DefaultActive
 	DefaultDelegatorSchedules         = types.DefaultDelegatorSchedules
@@ -109,7 +110,9 @@ var (
 type (
 	Keeper                         = keeper.Keeper
 	AccountKeeper                  = types.AccountKeeper
-	Claim                          = types.Claim
+	Borrow                         = types.Borrow
+	BorrowLimit                    = types.BorrowLimit
+	BorrowLimits                   = types.BorrowLimits
 	DelegatorDistributionSchedule  = types.DelegatorDistributionSchedule
 	DelegatorDistributionSchedules = types.DelegatorDistributionSchedules
 	Deposit                        = types.Deposit

--- a/x/harvest/client/cli/query.go
+++ b/x/harvest/client/cli/query.go
@@ -21,7 +21,6 @@ import (
 const (
 	flagName         = "name"
 	flagDepositDenom = "deposit-denom"
-	flagBorrowDenom  = "borrow-denom"
 	flagOwner        = "owner"
 	flagDepositType  = "deposit-type"
 )
@@ -307,6 +306,5 @@ func queryBorrowsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().Int(flags.FlagPage, 1, "pagination page to query for")
 	cmd.Flags().Int(flags.FlagLimit, 100, "pagination limit (max 100)")
 	cmd.Flags().String(flagOwner, "", "(optional) filter for borrows by owner address")
-	cmd.Flags().String(flagBorrowDenom, "", "(optional) filter for borrows by denom")
 	return cmd
 }

--- a/x/harvest/client/cli/tx.go
+++ b/x/harvest/client/cli/tx.go
@@ -137,7 +137,7 @@ func getCmdBorrow(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgBorrow(cliCtx.GetFromAddress(), coins[0])
+			msg := types.NewMsgBorrow(cliCtx.GetFromAddress(), coins)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/harvest/client/cli/tx.go
+++ b/x/harvest/client/cli/tx.go
@@ -33,6 +33,7 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		getCmdDeposit(cdc),
 		getCmdWithdraw(cdc),
 		getCmdClaimReward(cdc),
+		getCmdBorrow(cdc),
 	)...)
 
 	return harvestTxCmd
@@ -109,6 +110,34 @@ func getCmdClaimReward(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 			msg := types.NewMsgClaimReward(cliCtx.GetFromAddress(), receiver, args[1], args[2], args[3])
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+}
+
+func getCmdBorrow(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "borrow [1000000000ukava]",
+		Short: "borrow tokens from the harvest protocol",
+		Long:  strings.TrimSpace(`borrows tokens from the harvest protocol`),
+		Args:  cobra.ExactArgs(1),
+		Example: fmt.Sprintf(
+			`%s tx %s borrow 1000000000ukava --from <key>`, version.ClientName, types.ModuleName,
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			coins, err := sdk.ParseCoins(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgBorrow(cliCtx.GetFromAddress(), coins[0])
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/harvest/handler.go
+++ b/x/harvest/handler.go
@@ -21,6 +21,8 @@ func NewHandler(k Keeper) sdk.Handler {
 			return handleMsgDeposit(ctx, k, msg)
 		case types.MsgWithdraw:
 			return handleMsgWithdraw(ctx, k, msg)
+		case types.MsgBorrow:
+			return handleMsgBorrow(ctx, k, msg)
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
@@ -74,6 +76,24 @@ func handleMsgWithdraw(ctx sdk.Context, k keeper.Keeper, msg types.MsgWithdraw) 
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Depositor.String()),
+		),
+	)
+	return &sdk.Result{
+		Events: ctx.EventManager().Events(),
+	}, nil
+}
+
+func handleMsgBorrow(ctx sdk.Context, k keeper.Keeper, msg types.MsgBorrow) (*sdk.Result, error) {
+	err := k.Borrow(ctx, msg.Borrower, msg.Amount)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Borrower.String()),
 		),
 	)
 	return &sdk.Result{

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -59,7 +59,11 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 
 func (k Keeper) validateBorrowUser(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin) error {
 	// Get requested borrow amount's value
-	borrowAssetPrice, err := k.pricefeedKeeper.GetCurrentPrice(ctx, amount.Denom)
+	borrowMarketID, found := k.pricefeedKeeper.GetLiveMarketIDByDenom(ctx, amount.Denom)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for %s", amount.Denom)
+	}
+	borrowAssetPrice, err := k.pricefeedKeeper.GetCurrentPrice(ctx, borrowMarketID)
 	if err != nil {
 		return err
 	}
@@ -79,7 +83,7 @@ func (k Keeper) validateBorrowUser(ctx sdk.Context, borrower sdk.AccAddress, amo
 		} else {
 			marketID, found := k.pricefeedKeeper.GetLiveMarketIDByDenom(ctx, deposit.Amount.Denom)
 			if !found {
-				return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for %s", deposit.Amount.Denom)
+				return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for %s", deposit.Amount.Denom)
 			}
 			depositAssetPrice, err := k.pricefeedKeeper.GetCurrentPrice(ctx, marketID)
 			if err != nil {
@@ -99,7 +103,7 @@ func (k Keeper) validateBorrowUser(ctx sdk.Context, borrower sdk.AccAddress, amo
 		} else {
 			marketID, found := k.pricefeedKeeper.GetLiveMarketIDByDenom(ctx, borrow.Amount.Denom)
 			if !found {
-				return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for %s", borrow.Amount.Denom)
+				return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for %s", borrow.Amount.Denom)
 			}
 			borrowAssetPrice, err := k.pricefeedKeeper.GetCurrentPrice(ctx, marketID)
 			if err != nil {

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/kava-labs/kava/x/harvest/types"
 )
@@ -12,12 +11,7 @@ const USDX = "usdx"
 
 // Borrow funds
 func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin) error {
-	err := k.ValidateBorrow(ctx, borrower, amount)
-	if err != nil {
-		return err
-	}
-
-	err = k.supplyKeeper.SendCoinsFromAccountToModule(ctx, borrower, types.ModuleAccountName, sdk.NewCoins(amount))
+	err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, borrower, types.ModuleAccountName, sdk.NewCoins(amount))
 	if err != nil {
 		return err
 	}
@@ -41,90 +35,4 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin
 	)
 
 	return nil
-}
-
-// ValidateBorrow validates a borrow request against borrower and protocol requirements
-func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin) error {
-	var proprosedBorrowUSDValue sdk.Dec
-	if amount.Denom == USDX {
-		moneyMarket, found := k.GetMoneyMarket(ctx, amount.Denom)
-		if !found {
-			return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", amount.Denom)
-		}
-		proprosedBorrowUSDValue = sdk.NewDecFromInt(amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor))
-	} else {
-		price, conversionFactor, err := k.getAssetPrice(ctx, amount.Denom)
-		if err != nil {
-			return err
-		}
-		proprosedBorrowUSDValue = sdk.NewDecFromInt(amount.Amount).Quo(sdk.NewDecFromInt(conversionFactor).Mul(price))
-	}
-
-	// Get the total value of the user's deposits
-	deposits := k.GetDepositsByUser(ctx, borrower)
-	totalUSDValueDeposits := sdk.ZeroDec()
-	for _, deposit := range deposits {
-		if deposit.Amount.Denom == USDX {
-			totalUSDValueDeposits = totalUSDValueDeposits.Add(sdk.NewDecFromInt(deposit.Amount.Amount))
-		} else {
-			price, conversionFactor, err := k.getAssetPrice(ctx, deposit.Amount.Denom)
-			if err != nil {
-				return err
-			}
-			depositUSDValue := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(conversionFactor).Mul(price))
-			totalUSDValueDeposits = totalUSDValueDeposits.Add(depositUSDValue)
-		}
-	}
-
-	// Get the total value of the user's borrows
-	borrows := k.GetBorrowsByUser(ctx, borrower)
-	totalUSDValuePreviousBorrows := sdk.ZeroDec()
-	for _, borrow := range borrows {
-		if borrow.Amount.Denom == USDX {
-			totalUSDValuePreviousBorrows = totalUSDValuePreviousBorrows.Add(sdk.NewDecFromInt(borrow.Amount.Amount))
-		} else {
-			price, conversionFactor, err := k.getAssetPrice(ctx, borrow.Amount.Denom)
-			if err != nil {
-				return err
-			}
-			borrowUSDValue := sdk.NewDecFromInt(borrow.Amount.Amount).Quo(sdk.NewDecFromInt(conversionFactor).Mul(price))
-			totalUSDValuePreviousBorrows = totalUSDValuePreviousBorrows.Add(borrowUSDValue)
-		}
-	}
-
-	if len(deposits) == 0 {
-		return sdkerrors.Wrapf(types.ErrDepositsNotFound, "no deposits found for %s", borrower)
-	}
-
-	// Value of borrow cannot be greater than:
-	// (total value of user's deposits * the borrow asset denom's LTV ratio) - funds already borrowed
-	moneyMarket, found := k.GetMoneyMarket(ctx, amount.Denom)
-	if !found { // Sanity check
-		sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", amount.Denom)
-	}
-	borrowValueLimit := totalUSDValueDeposits.Mul(moneyMarket.BorrowLimit.LoanToValue).Sub(totalUSDValuePreviousBorrows)
-	if proprosedBorrowUSDValue.GT(borrowValueLimit) {
-		// Here we get the price so that we can return a helpful error to the user
-		price, _, err := k.getAssetPrice(ctx, amount.Denom)
-		if err != nil {
-			return err
-		}
-		return sdkerrors.Wrapf(types.ErrInsufficientLoanToValue,
-			"requested borrow %s is greater than maximum valid borrow %s",
-			amount, sdk.NewCoin(amount.Denom, borrowValueLimit.Quo(price).TruncateInt()))
-	}
-
-	return nil
-}
-
-func (k Keeper) getAssetPrice(ctx sdk.Context, denom string) (sdk.Dec, sdk.Int, error) {
-	moneyMarket, found := k.GetMoneyMarket(ctx, denom)
-	if !found {
-		return sdk.ZeroDec(), sdk.ZeroInt(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", denom)
-	}
-	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
-	if err != nil {
-		return sdk.ZeroDec(), moneyMarket.ConversionFactor, sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
-	}
-	return assetPriceInfo.Price, moneyMarket.ConversionFactor, nil
 }

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -1,0 +1,47 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/harvest/types"
+)
+
+// Borrow funds
+func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin) error {
+
+	// 1. Is this borrow valid for the user
+	//    - Check user collective LTV ratio
+
+	// 2. Is this borrow valid for the protocol
+	//    - Check module account balances
+
+	// err := k.ValidateBorrow(ctx, coin)
+	// if err != nil {
+	// 	return err
+	// }
+
+	err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, borrower, sdk.NewCoins(amount))
+	if err != nil {
+		return err
+	}
+
+	borrow, found := k.GetBorrow(ctx, borrower, amount.Denom)
+	if !found {
+		borrow = types.NewBorrow(borrower, amount)
+	} else {
+		borrow.Amount = borrow.Amount.Add(amount)
+	}
+
+	k.SetBorrow(ctx, borrow)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeHarvestBorrow,
+			sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
+			sdk.NewAttribute(types.AttributeKeyBorrower, borrow.Borrower.String()),
+			sdk.NewAttribute(types.AttributeKeyBorrowDenom, borrow.Amount.Denom),
+		),
+	)
+
+	return nil
+}

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -115,14 +115,14 @@ func (k Keeper) validateBorrowUser(ctx sdk.Context, borrower sdk.AccAddress, amo
 	}
 
 	// Get the borrow asset's LTV param
-	borrowLimit, found := k.GetBorrowLimit(ctx, amount.Denom)
+	moneyMarket, found := k.GetMoneyMarket(ctx, amount.Denom)
 	if !found {
-		return sdkerrors.Wrapf(types.ErrBorrowLimitNotFound, "no borrow limit found for %s", amount.Denom)
+		return sdkerrors.Wrapf(types.ErrMoneyMarketNotFound, "no money market found for %s", amount.Denom)
 	}
 
 	// Value of borrow cannot be greater than:
 	// (total value of user's deposits * the borrow asset denom's LTV ratio) - funds already borrowed
-	borrowValueLimit := totalValueDeposits.Mul(borrowLimit.LoanToValue).Sub(totalValueBorrows)
+	borrowValueLimit := totalValueDeposits.Mul(moneyMarket.BorrowLimit.LoanToValue).Sub(totalValueBorrows)
 	if borrowUSDValue.GT(borrowValueLimit) {
 		return sdkerrors.Wrapf(types.ErrInsufficientLoanToValue,
 			"requested borrow %s is greater than maximum valid borrow %s",

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -34,9 +34,9 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			"valid",
 			args{
 				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				coins:                     sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(900)), sdk.NewCoin("usdx", sdk.NewInt(1000))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100))),
+				coins:                     sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(50))),
+				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(150))),
+				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(950))),
 			},
 			errArgs{
 				expectPass: true,
@@ -51,7 +51,9 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
-			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.borrower}, []sdk.Coins{sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(1000)), sdk.NewCoin("ukava", sdk.NewInt(1000)))})
+			authGS := app.NewAuthGenState(
+				[]sdk.AccAddress{tc.args.borrower},
+				[]sdk.Coins{sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100)))})
 			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
@@ -71,6 +73,8 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
 			keeper := tApp.GetHarvestKeeper()
+			supplyKeeper := tApp.GetSupplyKeeper()
+			supplyKeeper.MintCoins(ctx, types.ModuleAccountName, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000))))
 			suite.app = tApp
 			suite.ctx = ctx
 			suite.keeper = keeper

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -16,7 +16,7 @@ import (
 func (suite *KeeperTestSuite) TestBorrow() {
 	type args struct {
 		borrower                  sdk.AccAddress
-		amount                    sdk.Coin
+		coins                     sdk.Coins
 		expectedAccountBalance    sdk.Coins
 		expectedModAccountBalance sdk.Coins
 	}
@@ -34,7 +34,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			"valid",
 			args{
 				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				amount:                    sdk.NewCoin("ukava", sdk.NewInt(100)),
+				coins:                     sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100))),
 				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(900)), sdk.NewCoin("usdx", sdk.NewInt(1000))),
 				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100))),
 			},
@@ -77,7 +77,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 
 			// run the test
 			var err error
-			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.amount)
+			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.coins)
 
 			// verify results
 			if tc.errArgs.expectPass {
@@ -86,7 +86,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				suite.Require().Equal(tc.args.expectedAccountBalance, acc.GetCoins())
 				mAcc := suite.getModuleAccount(types.ModuleAccountName)
 				suite.Require().Equal(tc.args.expectedModAccountBalance, mAcc.GetCoins())
-				_, f := suite.keeper.GetBorrow(suite.ctx, tc.args.borrower, tc.args.amount.Denom)
+				_, f := suite.keeper.GetBorrow(suite.ctx, tc.args.borrower)
 				suite.Require().True(f)
 			} else {
 				suite.Require().Error(err)

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -54,7 +54,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			authGS := app.NewAuthGenState(
 				[]sdk.AccAddress{tc.args.borrower},
 				[]sdk.Coins{sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100)))})
-			loanToValue, _ := sdk.NewDecFromStr("0.6")
+			loanToValue := sdk.MustNewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -1,0 +1,97 @@
+package keeper_test
+
+import (
+	"strings"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto"
+	tmtime "github.com/tendermint/tendermint/types/time"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/x/harvest/types"
+)
+
+func (suite *KeeperTestSuite) TestBorrow() {
+	type args struct {
+		borrower                  sdk.AccAddress
+		amount                    sdk.Coin
+		expectedAccountBalance    sdk.Coins
+		expectedModAccountBalance sdk.Coins
+	}
+	type errArgs struct {
+		expectPass bool
+		contains   string
+	}
+	type borrowTest struct {
+		name    string
+		args    args
+		errArgs errArgs
+	}
+	testCases := []borrowTest{
+		{
+			"valid",
+			args{
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				amount:                    sdk.NewCoin("ukava", sdk.NewInt(100)),
+				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(900)), sdk.NewCoin("usdx", sdk.NewInt(1000))),
+				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100))),
+			},
+			errArgs{
+				expectPass: true,
+				contains:   "",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			// create new app with one funded account
+
+			// Initialize test app and set context
+			tApp := app.NewTestApp()
+			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.borrower}, []sdk.Coins{sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(1000)), sdk.NewCoin("ukava", sdk.NewInt(1000)))})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
+			harvestGS := types.NewGenesisState(types.NewParams(
+				true,
+				types.DistributionSchedules{
+					types.NewDistributionSchedule(true, "usdx", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2020, 11, 22, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(5000)), time.Date(2021, 11, 22, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Medium, 24, sdk.OneDec())}),
+					types.NewDistributionSchedule(true, "ukava", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2020, 11, 22, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(5000)), time.Date(2021, 11, 22, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Medium, 24, sdk.OneDec())}),
+				},
+				types.DelegatorDistributionSchedules{types.NewDelegatorDistributionSchedule(
+					types.NewDistributionSchedule(true, "usdx", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(500)), time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Medium, 24, sdk.OneDec())}),
+					time.Hour*24,
+				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+				},
+			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
+			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
+			keeper := tApp.GetHarvestKeeper()
+			suite.app = tApp
+			suite.ctx = ctx
+			suite.keeper = keeper
+
+			// run the test
+			var err error
+			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.amount)
+
+			// verify results
+			if tc.errArgs.expectPass {
+				suite.Require().NoError(err)
+				acc := suite.getAccount(tc.args.borrower)
+				suite.Require().Equal(tc.args.expectedAccountBalance, acc.GetCoins())
+				mAcc := suite.getModuleAccount(types.ModuleAccountName)
+				suite.Require().Equal(tc.args.expectedModAccountBalance, mAcc.GetCoins())
+				_, f := suite.keeper.GetBorrow(suite.ctx, tc.args.borrower, tc.args.amount.Denom)
+				suite.Require().True(f)
+			} else {
+				suite.Require().Error(err)
+				suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
+			}
+		})
+	}
+}

--- a/x/harvest/keeper/claim_test.go
+++ b/x/harvest/keeper/claim_test.go
@@ -253,7 +253,7 @@ func (suite *KeeperTestSuite) TestClaim() {
 					sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 					sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 				})
-			loanToValue, _ := sdk.NewDecFromStr("0.6")
+			loanToValue := sdk.MustNewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{

--- a/x/harvest/keeper/claim_test.go
+++ b/x/harvest/keeper/claim_test.go
@@ -253,6 +253,7 @@ func (suite *KeeperTestSuite) TestClaim() {
 					sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 					sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 				})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{
@@ -262,6 +263,10 @@ func (suite *KeeperTestSuite) TestClaim() {
 					types.NewDistributionSchedule(true, "bnb", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(500)), time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Large, 24, sdk.OneDec())}),
 					time.Hour*24,
 				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/deposit_test.go
+++ b/x/harvest/keeper/deposit_test.go
@@ -116,6 +116,7 @@ func (suite *KeeperTestSuite) TestDeposit() {
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.depositor}, []sdk.Coins{sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000)))})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{
@@ -125,6 +126,10 @@ func (suite *KeeperTestSuite) TestDeposit() {
 					types.NewDistributionSchedule(true, "bnb", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(500)), time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Medium, 24, sdk.OneDec())}),
 					time.Hour*24,
 				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -283,6 +288,7 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.depositor}, []sdk.Coins{sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000)))})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{
@@ -292,6 +298,10 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 					types.NewDistributionSchedule(true, "bnb", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(500)), time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Medium, 24, sdk.OneDec())}),
 					time.Hour*24,
 				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/deposit_test.go
+++ b/x/harvest/keeper/deposit_test.go
@@ -288,7 +288,7 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.depositor}, []sdk.Coins{sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000)))})
-			loanToValue, _ := sdk.NewDecFromStr("0.6")
+			loanToValue := sdk.MustNewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{

--- a/x/harvest/keeper/keeper.go
+++ b/x/harvest/keeper/keeper.go
@@ -237,15 +237,3 @@ func (k Keeper) IterateBorrows(ctx sdk.Context, cb func(borrow types.Borrow) (st
 		}
 	}
 }
-
-// // GetBorrowsByUser gets all borrows for an individual user
-// func (k Keeper) GetBorrowsByUser(ctx sdk.Context, user sdk.AccAddress) []types.Borrow {
-// 	var borrows []types.Borrow
-// 	k.IterateBorrows(ctx, func(borrow types.Borrow) (stop bool) {
-// 		if borrow.Borrower.Equals(user) {
-// 			borrows = append(borrows, borrow)
-// 		}
-// 		return false
-// 	})
-// 	return borrows
-// }

--- a/x/harvest/keeper/keeper.go
+++ b/x/harvest/keeper/keeper.go
@@ -200,9 +200,9 @@ func (k Keeper) BondDenom(ctx sdk.Context) string {
 }
 
 // GetBorrow returns a Borrow from the store for a particular borrower address and borrow denom
-func (k Keeper) GetBorrow(ctx sdk.Context, borrower sdk.AccAddress, denom string) (types.Borrow, bool) {
+func (k Keeper) GetBorrow(ctx sdk.Context, borrower sdk.AccAddress) (types.Borrow, bool) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowsKeyPrefix)
-	bz := store.Get(types.BorrowKey(borrower, denom))
+	bz := store.Get(borrower)
 	if bz == nil {
 		return types.Borrow{}, false
 	}
@@ -215,13 +215,13 @@ func (k Keeper) GetBorrow(ctx sdk.Context, borrower sdk.AccAddress, denom string
 func (k Keeper) SetBorrow(ctx sdk.Context, borrow types.Borrow) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowsKeyPrefix)
 	bz := k.cdc.MustMarshalBinaryBare(borrow)
-	store.Set(types.BorrowKey(borrow.Borrower, borrow.Amount.Denom), bz)
+	store.Set(borrow.Borrower, bz)
 }
 
 // DeleteBorrow deletes a borrow from the store
 func (k Keeper) DeleteBorrow(ctx sdk.Context, borrow types.Borrow) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowsKeyPrefix)
-	store.Delete(types.BorrowKey(borrow.Borrower, borrow.Amount.Denom))
+	store.Delete(borrow.Borrower)
 }
 
 // IterateBorrows iterates over all borrow objects in the store and performs a callback function
@@ -238,14 +238,14 @@ func (k Keeper) IterateBorrows(ctx sdk.Context, cb func(borrow types.Borrow) (st
 	}
 }
 
-// GetBorrowsByUser gets all borrows for an individual user
-func (k Keeper) GetBorrowsByUser(ctx sdk.Context, user sdk.AccAddress) []types.Borrow {
-	var borrows []types.Borrow
-	k.IterateBorrows(ctx, func(borrow types.Borrow) (stop bool) {
-		if borrow.Borrower.Equals(user) {
-			borrows = append(borrows, borrow)
-		}
-		return false
-	})
-	return borrows
-}
+// // GetBorrowsByUser gets all borrows for an individual user
+// func (k Keeper) GetBorrowsByUser(ctx sdk.Context, user sdk.AccAddress) []types.Borrow {
+// 	var borrows []types.Borrow
+// 	k.IterateBorrows(ctx, func(borrow types.Borrow) (stop bool) {
+// 		if borrow.Borrower.Equals(user) {
+// 			borrows = append(borrows, borrow)
+// 		}
+// 		return false
+// 	})
+// 	return borrows
+// }

--- a/x/harvest/keeper/params.go
+++ b/x/harvest/keeper/params.go
@@ -40,13 +40,13 @@ func (k Keeper) GetDelegatorSchedule(ctx sdk.Context, denom string) (types.Deleg
 	return types.DelegatorDistributionSchedule{}, false
 }
 
-// GetBorrowLimit returns the corresponding Borrow Limit param for a specific denom
-func (k Keeper) GetBorrowLimit(ctx sdk.Context, denom string) (types.BorrowLimit, bool) {
+// GetMoneyMarket returns the corresponding Money Market param for a specific denom
+func (k Keeper) GetMoneyMarket(ctx sdk.Context, denom string) (types.MoneyMarket, bool) {
 	params := k.GetParams(ctx)
-	for _, bl := range params.BorrowLimits {
-		if bl.Denom == denom {
-			return bl, true
+	for _, mm := range params.MoneyMarkets {
+		if mm.Denom == denom {
+			return mm, true
 		}
 	}
-	return types.BorrowLimit{}, false
+	return types.MoneyMarket{}, false
 }

--- a/x/harvest/keeper/params.go
+++ b/x/harvest/keeper/params.go
@@ -18,6 +18,7 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSubspace.SetParamSet(ctx, &params)
 }
 
+// GetLPSchedule gets the LP's schedule
 func (k Keeper) GetLPSchedule(ctx sdk.Context, denom string) (types.DistributionSchedule, bool) {
 	params := k.GetParams(ctx)
 	for _, lps := range params.LiquidityProviderSchedules {
@@ -28,6 +29,7 @@ func (k Keeper) GetLPSchedule(ctx sdk.Context, denom string) (types.Distribution
 	return types.DistributionSchedule{}, false
 }
 
+// GetDelegatorSchedule gets the Delgator's schedule
 func (k Keeper) GetDelegatorSchedule(ctx sdk.Context, denom string) (types.DelegatorDistributionSchedule, bool) {
 	params := k.GetParams(ctx)
 	for _, dds := range params.DelegatorDistributionSchedules {
@@ -36,4 +38,15 @@ func (k Keeper) GetDelegatorSchedule(ctx sdk.Context, denom string) (types.Deleg
 		}
 	}
 	return types.DelegatorDistributionSchedule{}, false
+}
+
+// GetBorrowLimit returns the corresponding Borrow Limit param for a specific denom
+func (k Keeper) GetBorrowLimit(ctx sdk.Context, denom string) (types.BorrowLimit, bool) {
+	params := k.GetParams(ctx)
+	for _, bl := range params.BorrowLimits {
+		if bl.Denom == denom {
+			return bl, true
+		}
+	}
+	return types.BorrowLimit{}, false
 }

--- a/x/harvest/keeper/rewards_test.go
+++ b/x/harvest/keeper/rewards_test.go
@@ -63,6 +63,7 @@ func (suite *KeeperTestSuite) TestApplyDepositRewards() {
 			// Initialize test app and set context
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tc.args.blockTime})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{
@@ -72,6 +73,10 @@ func (suite *KeeperTestSuite) TestApplyDepositRewards() {
 					types.NewDistributionSchedule(true, "bnb", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), tc.args.rewardRate, time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Large, 24, sdk.OneDec())}),
 					time.Hour*24,
 				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), tc.args.previousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -400,6 +405,7 @@ func (suite *DelegatorRewardsTestSuite) kavaClaimExists(ctx sdk.Context, owner s
 }
 
 func harvestGenesisState(rewardRate sdk.Coin) app.GenesisState {
+	loanToValue, _ := sdk.NewDecFromStr("0.6")
 	genState := types.NewGenesisState(
 		types.NewParams(
 			true,
@@ -435,6 +441,10 @@ func harvestGenesisState(rewardRate sdk.Coin) app.GenesisState {
 					),
 					time.Hour*24,
 				),
+			},
+			types.MoneyMarkets{
+				types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+				types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 			},
 		),
 		types.DefaultPreviousBlockTime,

--- a/x/harvest/keeper/rewards_test.go
+++ b/x/harvest/keeper/rewards_test.go
@@ -405,7 +405,7 @@ func (suite *DelegatorRewardsTestSuite) kavaClaimExists(ctx sdk.Context, owner s
 }
 
 func harvestGenesisState(rewardRate sdk.Coin) app.GenesisState {
-	loanToValue, _ := sdk.NewDecFromStr("0.6")
+	loanToValue := sdk.MustNewDecFromStr("0.6")
 	genState := types.NewGenesisState(
 		types.NewParams(
 			true,

--- a/x/harvest/keeper/timelock_test.go
+++ b/x/harvest/keeper/timelock_test.go
@@ -279,6 +279,7 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tc.args.blockTime})
 			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.accArgs.addr}, []sdk.Coins{tc.args.accArgs.coins})
+			loanToValue, _ := sdk.NewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{
@@ -288,6 +289,10 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 					types.NewDistributionSchedule(true, "bnb", time.Date(2020, 10, 8, 14, 0, 0, 0, time.UTC), time.Date(2025, 10, 8, 14, 0, 0, 0, time.UTC), sdk.NewCoin("hard", sdk.NewInt(500)), time.Date(2026, 10, 8, 14, 0, 0, 0, time.UTC), types.Multipliers{types.NewMultiplier(types.Small, 0, sdk.MustNewDecFromStr("0.33")), types.NewMultiplier(types.Medium, 6, sdk.MustNewDecFromStr("0.5")), types.NewMultiplier(types.Large, 24, sdk.OneDec())}),
 					time.Hour*24,
 				),
+				},
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/timelock_test.go
+++ b/x/harvest/keeper/timelock_test.go
@@ -279,7 +279,7 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 			tApp := app.NewTestApp()
 			ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tc.args.blockTime})
 			authGS := app.NewAuthGenState([]sdk.AccAddress{tc.args.accArgs.addr}, []sdk.Coins{tc.args.accArgs.coins})
-			loanToValue, _ := sdk.NewDecFromStr("0.6")
+			loanToValue := sdk.MustNewDecFromStr("0.6")
 			harvestGS := types.NewGenesisState(types.NewParams(
 				true,
 				types.DistributionSchedules{

--- a/x/harvest/module.go
+++ b/x/harvest/module.go
@@ -77,16 +77,18 @@ func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper       Keeper
-	supplyKeeper types.SupplyKeeper
+	keeper          Keeper
+	supplyKeeper    types.SupplyKeeper
+	pricefeedKeeper types.PricefeedKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(keeper Keeper, supplyKeeper types.SupplyKeeper) AppModule {
+func NewAppModule(keeper Keeper, supplyKeeper types.SupplyKeeper, pricefeedKeeper types.PricefeedKeeper) AppModule {
 	return AppModule{
-		AppModuleBasic: AppModuleBasic{},
-		keeper:         keeper,
-		supplyKeeper:   supplyKeeper,
+		AppModuleBasic:  AppModuleBasic{},
+		keeper:          keeper,
+		supplyKeeper:    supplyKeeper,
+		pricefeedKeeper: pricefeedKeeper,
 	}
 }
 

--- a/x/harvest/types/borrow.go
+++ b/x/harvest/types/borrow.go
@@ -7,11 +7,11 @@ import (
 // Borrow defines an amount of coins borrowed from a harvest module account
 type Borrow struct {
 	Borrower sdk.AccAddress `json:"borrower" yaml:"borrower"`
-	Amount   sdk.Coin       `json:"amount" yaml:"amount"`
+	Amount   sdk.Coins      `json:"amount" yaml:"amount"`
 }
 
 // NewBorrow returns a new Borrow instance
-func NewBorrow(borrower sdk.AccAddress, amount sdk.Coin) Borrow {
+func NewBorrow(borrower sdk.AccAddress, amount sdk.Coins) Borrow {
 	return Borrow{
 		Borrower: borrower,
 		Amount:   amount,

--- a/x/harvest/types/borrow.go
+++ b/x/harvest/types/borrow.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Borrow defines an amount of coins borrowed from a harvest module account
+type Borrow struct {
+	Borrower sdk.AccAddress `json:"borrower" yaml:"borrower"`
+	Amount   sdk.Coin       `json:"amount" yaml:"amount"`
+}
+
+// NewBorrow returns a new Borrow instance
+func NewBorrow(borrower sdk.AccAddress, amount sdk.Coin) Borrow {
+	return Borrow{
+		Borrower: borrower,
+		Amount:   amount,
+	}
+}

--- a/x/harvest/types/codec.go
+++ b/x/harvest/types/codec.go
@@ -17,5 +17,6 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgClaimReward{}, "harvest/MsgClaimReward", nil)
 	cdc.RegisterConcrete(MsgDeposit{}, "harvest/MsgDeposit", nil)
 	cdc.RegisterConcrete(MsgWithdraw{}, "harvest/MsgWithdraw", nil)
+	cdc.RegisterConcrete(MsgBorrow{}, "harvest/MsgBorrow", nil)
 	cdc.RegisterConcrete(DistributionSchedule{}, "harvest/DistributionSchedule", nil)
 }

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -35,4 +35,12 @@ var (
 	ErrClaimExpired = sdkerrors.Register(ModuleName, 14, "claim period expired")
 	// ErrInvalidReceiver error for when sending and receiving accounts don't match
 	ErrInvalidReceiver = sdkerrors.Register(ModuleName, 15, "receiver account must match sender account")
+	// ErrBorrowLimitNotFound error for borrow limit param not found
+	ErrBorrowLimitNotFound = sdkerrors.Register(ModuleName, 16, "no borrow limit found")
+	// ErrDepositsNotFound error for no deposits found
+	ErrDepositsNotFound = sdkerrors.Register(ModuleName, 17, "no deposits found")
+	// ErrInsufficientLoanToValue error for when an attempted borrow exceeds maximum loan-to-value
+	ErrInsufficientLoanToValue = sdkerrors.Register(ModuleName, 18, "total deposited value is insufficient for borrow request")
+	// ErrPriceNotFound error for when a price for the input denom is not found
+	ErrPriceNotFound = sdkerrors.Register(ModuleName, 19, "no price found for asset")
 )

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -41,6 +41,6 @@ var (
 	ErrDepositsNotFound = sdkerrors.Register(ModuleName, 17, "no deposits found")
 	// ErrInsufficientLoanToValue error for when an attempted borrow exceeds maximum loan-to-value
 	ErrInsufficientLoanToValue = sdkerrors.Register(ModuleName, 18, "total deposited value is insufficient for borrow request")
-	// ErrPriceNotFound error for when a price for the input denom is not found
-	ErrPriceNotFound = sdkerrors.Register(ModuleName, 19, "no price found for asset")
+	// ErrMarketNotFound error for when a market for the input denom is not found
+	ErrMarketNotFound = sdkerrors.Register(ModuleName, 19, "no market found for denom")
 )

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -43,4 +43,6 @@ var (
 	ErrInsufficientLoanToValue = sdkerrors.Register(ModuleName, 18, "total deposited value is insufficient for borrow request")
 	// ErrMarketNotFound error for when a market for the input denom is not found
 	ErrMarketNotFound = sdkerrors.Register(ModuleName, 19, "no market found for denom")
+	// ErrPriceNotFound error for when a price for the input market is not found
+	ErrPriceNotFound = sdkerrors.Register(ModuleName, 20, "no price found for market")
 )

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -35,8 +35,8 @@ var (
 	ErrClaimExpired = sdkerrors.Register(ModuleName, 14, "claim period expired")
 	// ErrInvalidReceiver error for when sending and receiving accounts don't match
 	ErrInvalidReceiver = sdkerrors.Register(ModuleName, 15, "receiver account must match sender account")
-	// ErrBorrowLimitNotFound error for borrow limit param not found
-	ErrBorrowLimitNotFound = sdkerrors.Register(ModuleName, 16, "no borrow limit found")
+	// ErrMoneyMarketNotFound error for money market param not found
+	ErrMoneyMarketNotFound = sdkerrors.Register(ModuleName, 16, "no money market found")
 	// ErrDepositsNotFound error for no deposits found
 	ErrDepositsNotFound = sdkerrors.Register(ModuleName, 17, "no deposits found")
 	// ErrInsufficientLoanToValue error for when an attempted borrow exceeds maximum loan-to-value

--- a/x/harvest/types/events.go
+++ b/x/harvest/types/events.go
@@ -8,6 +8,7 @@ const (
 	EventTypeDeleteHarvestDeposit         = "delete_harvest_deposit"
 	EventTypeHarvestWithdrawal            = "harvest_withdrawal"
 	EventTypeClaimHarvestReward           = "claim_harvest_reward"
+	EventTypeHarvestBorrow                = "harvest_borrow"
 	AttributeValueCategory                = ModuleName
 	AttributeKeyBlockHeight               = "block_height"
 	AttributeKeyRewardsDistribution       = "rewards_distributed"
@@ -18,4 +19,7 @@ const (
 	AttributeKeyClaimHolder               = "claim_holder"
 	AttributeKeyClaimAmount               = "claim_amount"
 	AttributeKeyClaimMultiplier           = "claim_multiplier"
+	AttributeKeyBorrow                    = "borrow"
+	AttributeKeyBorrower                  = "borrower"
+	AttributeKeyBorrowDenom               = "borrow_denom"
 )

--- a/x/harvest/types/events.go
+++ b/x/harvest/types/events.go
@@ -21,5 +21,5 @@ const (
 	AttributeKeyClaimMultiplier           = "claim_multiplier"
 	AttributeKeyBorrow                    = "borrow"
 	AttributeKeyBorrower                  = "borrower"
-	AttributeKeyBorrowDenom               = "borrow_denom"
+	AttributeKeyBorrowCoins               = "borrow_coins"
 )

--- a/x/harvest/types/expected_keepers.go
+++ b/x/harvest/types/expected_keepers.go
@@ -6,6 +6,8 @@ import (
 	stakingexported "github.com/cosmos/cosmos-sdk/x/staking/exported"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/supply/exported"
+
+	pftypes "github.com/kava-labs/kava/x/pricefeed/types"
 )
 
 // SupplyKeeper defines the expected supply keeper
@@ -32,4 +34,10 @@ type StakingKeeper interface {
 	IterateAllDelegations(ctx sdk.Context, cb func(delegation stakingtypes.Delegation) (stop bool))
 	GetBondedPool(ctx sdk.Context) (bondedPool exported.ModuleAccountI)
 	BondDenom(ctx sdk.Context) (res string)
+}
+
+// PricefeedKeeper defines the expected interface for the pricefeed
+type PricefeedKeeper interface {
+	GetCurrentPrice(sdk.Context, string) (pftypes.CurrentPrice, error)
+	GetLiveMarketIDByDenom(sdk.Context, string) (string, bool)
 }

--- a/x/harvest/types/expected_keepers.go
+++ b/x/harvest/types/expected_keepers.go
@@ -39,5 +39,4 @@ type StakingKeeper interface {
 // PricefeedKeeper defines the expected interface for the pricefeed
 type PricefeedKeeper interface {
 	GetCurrentPrice(sdk.Context, string) (pftypes.CurrentPrice, error)
-	GetLiveMarketIDByDenom(sdk.Context, string) (string, bool)
 }

--- a/x/harvest/types/keys.go
+++ b/x/harvest/types/keys.go
@@ -54,10 +54,10 @@ func ClaimKey(depositType DepositType, denom string, owner sdk.AccAddress) []byt
 	return createKey([]byte(depositType), sep, []byte(denom), sep, owner)
 }
 
-// BorrowKey key of a specific borrow in the store
-func BorrowKey(borrower sdk.AccAddress, denom string) []byte {
-	return createKey(borrower, sep, []byte(denom))
-}
+// // BorrowKey key of a specific borrow in the store
+// func BorrowKey(borrower sdk.AccAddress, denom string) []byte {
+// 	return createKey(borrower, sep, []byte(denom))
+// }
 
 func createKey(bytes ...[]byte) (r []byte) {
 	for _, b := range bytes {

--- a/x/harvest/types/keys.go
+++ b/x/harvest/types/keys.go
@@ -35,6 +35,7 @@ var (
 	PreviousDelegationDistributionKey = []byte{0x02}
 	DepositsKeyPrefix                 = []byte{0x03}
 	ClaimsKeyPrefix                   = []byte{0x04}
+	BorrowsKeyPrefix                  = []byte{0x05}
 	sep                               = []byte(":")
 )
 
@@ -51,6 +52,11 @@ func DepositTypeIteratorKey(depositType DepositType, denom string) []byte {
 // ClaimKey key of a specific deposit in the store
 func ClaimKey(depositType DepositType, denom string, owner sdk.AccAddress) []byte {
 	return createKey([]byte(depositType), sep, []byte(denom), sep, owner)
+}
+
+// BorrowKey key of a specific borrow in the store
+func BorrowKey(borrower sdk.AccAddress, denom string) []byte {
+	return createKey(borrower, sep, []byte(denom))
 }
 
 func createKey(bytes ...[]byte) (r []byte) {

--- a/x/harvest/types/keys.go
+++ b/x/harvest/types/keys.go
@@ -54,11 +54,6 @@ func ClaimKey(depositType DepositType, denom string, owner sdk.AccAddress) []byt
 	return createKey([]byte(depositType), sep, []byte(denom), sep, owner)
 }
 
-// // BorrowKey key of a specific borrow in the store
-// func BorrowKey(borrower sdk.AccAddress, denom string) []byte {
-// 	return createKey(borrower, sep, []byte(denom))
-// }
-
 func createKey(bytes ...[]byte) (r []byte) {
 	for _, b := range bytes {
 		r = append(r, b...)

--- a/x/harvest/types/msg.go
+++ b/x/harvest/types/msg.go
@@ -53,6 +53,7 @@ var (
 	_ sdk.Msg = &MsgClaimReward{}
 	_ sdk.Msg = &MsgDeposit{}
 	_ sdk.Msg = &MsgWithdraw{}
+	_ sdk.Msg = &MsgBorrow{}
 )
 
 // MsgDeposit deposit collateral to the harvest module.
@@ -213,4 +214,56 @@ func (msg MsgClaimReward) GetSignBytes() []byte {
 // GetSigners returns the addresses of signers that must sign.
 func (msg MsgClaimReward) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
+}
+
+// ---------------------------------------
+
+// MsgBorrow borrows funds from the harvest module.
+type MsgBorrow struct {
+	Borrower sdk.AccAddress `json:"borrower" yaml:"borrower"`
+	Amount   sdk.Coin       `json:"amount" yaml:"amount"`
+}
+
+// NewMsgBorrow returns a new MsgBorrow
+func NewMsgBorrow(borrower sdk.AccAddress, amount sdk.Coin) MsgBorrow {
+	return MsgBorrow{
+		Borrower: borrower,
+		Amount:   amount,
+	}
+}
+
+// Route return the message type used for routing the message.
+func (msg MsgBorrow) Route() string { return RouterKey }
+
+// Type returns a human-readable string for the message, intended for utilization within tags.
+func (msg MsgBorrow) Type() string { return "harvest_borrow" } // TODO: or just 'borrow'
+
+// ValidateBasic does a simple validation check that doesn't require access to any other information.
+func (msg MsgBorrow) ValidateBasic() error {
+	if msg.Borrower.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "sender address cannot be empty")
+	}
+	if !msg.Amount.IsValid() || msg.Amount.IsZero() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "borrow amount %s", msg.Amount)
+	}
+	return nil
+}
+
+// GetSignBytes gets the canonical byte representation of the Msg.
+func (msg MsgBorrow) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// GetSigners returns the addresses of signers that must sign.
+func (msg MsgBorrow) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Borrower}
+}
+
+// String implements the Stringer interface
+func (msg MsgBorrow) String() string {
+	return fmt.Sprintf(`Borrow Message:
+	Borrower:         %s
+	Amount:   %s
+`, msg.Borrower, msg.Amount)
 }

--- a/x/harvest/types/msg.go
+++ b/x/harvest/types/msg.go
@@ -221,11 +221,11 @@ func (msg MsgClaimReward) GetSigners() []sdk.AccAddress {
 // MsgBorrow borrows funds from the harvest module.
 type MsgBorrow struct {
 	Borrower sdk.AccAddress `json:"borrower" yaml:"borrower"`
-	Amount   sdk.Coin       `json:"amount" yaml:"amount"`
+	Amount   sdk.Coins      `json:"amount" yaml:"amount"`
 }
 
 // NewMsgBorrow returns a new MsgBorrow
-func NewMsgBorrow(borrower sdk.AccAddress, amount sdk.Coin) MsgBorrow {
+func NewMsgBorrow(borrower sdk.AccAddress, amount sdk.Coins) MsgBorrow {
 	return MsgBorrow{
 		Borrower: borrower,
 		Amount:   amount,

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -243,8 +243,8 @@ func (bl BorrowLimit) Validate() error {
 	if !bl.LoanToValue.IsPositive() {
 		return fmt.Errorf("loan-to-value must be a positive integer: %s", bl.LoanToValue)
 	}
-	if bl.LoanToValue.GT(sdk.NewDec(100)) {
-		return fmt.Errorf("loan-to-value cannot be greater than 100: %s", bl.LoanToValue)
+	if bl.LoanToValue.GT(sdk.OneDec()) {
+		return fmt.Errorf("loan-to-value cannot be greater than 1.0: %s", bl.LoanToValue)
 	}
 	return nil
 }

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -235,7 +235,6 @@ func NewBorrowLimit(denom string, loanToValue sdk.Dec) BorrowLimit {
 	}
 }
 
-// TODO:
 // Validate BorrowLimit param
 func (bl BorrowLimit) Validate() error {
 	if err := sdk.ValidateDenom(bl.Denom); err != nil {

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -30,7 +30,7 @@ type Params struct {
 	Active                         bool                           `json:"active" yaml:"active"`
 	LiquidityProviderSchedules     DistributionSchedules          `json:"liquidity_provider_schedules" yaml:"liquidity_provider_schedules"`
 	DelegatorDistributionSchedules DelegatorDistributionSchedules `json:"delegator_distribution_schedules" yaml:"delegator_distribution_schedules"`
-	MoneyMarkets                   MoneyMarkets                   `json:"borrow_limits" yaml:"borrow_limits"`
+	MoneyMarkets                   MoneyMarkets                   `json:"money_markets" yaml:"money_markets"`
 }
 
 // DistributionSchedule distribution schedule for liquidity providers
@@ -253,7 +253,7 @@ func (bl BorrowLimit) Validate() error {
 type MoneyMarket struct {
 	Denom        string      `json:"denom" yaml:"denom"`
 	BorrowLimit  BorrowLimit `json:"borrow_limit" yaml:"borrow_limit"`
-	SpotMarketID string      `json:"sport_market_id" yaml:"sport_market_id"`
+	SpotMarketID string      `json:"spot_market_id" yaml:"spot_market_id"`
 }
 
 // NewMoneyMarket returns a new MoneyMarket
@@ -265,7 +265,7 @@ func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec, spo
 	}
 }
 
-// Validate BorrowLimit param
+// Validate MoneyMarket param
 func (mm MoneyMarket) Validate() error {
 	if err := sdk.ValidateDenom(mm.Denom); err != nil {
 		return err

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -251,17 +251,20 @@ func (bl BorrowLimit) Validate() error {
 
 // MoneyMarket is a money market for an individual asset
 type MoneyMarket struct {
-	Denom        string      `json:"denom" yaml:"denom"`
-	BorrowLimit  BorrowLimit `json:"borrow_limit" yaml:"borrow_limit"`
-	SpotMarketID string      `json:"spot_market_id" yaml:"spot_market_id"`
+	Denom            string      `json:"denom" yaml:"denom"`
+	BorrowLimit      BorrowLimit `json:"borrow_limit" yaml:"borrow_limit"`
+	SpotMarketID     string      `json:"spot_market_id" yaml:"spot_market_id"`
+	ConversionFactor sdk.Int     `json:"conversion_factor" yaml:"conversion_factor"`
 }
 
 // NewMoneyMarket returns a new MoneyMarket
-func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec, spotMarketID string) MoneyMarket {
+func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec,
+	spotMarketID string, conversionFactor sdk.Int) MoneyMarket {
 	return MoneyMarket{
-		Denom:        denom,
-		BorrowLimit:  NewBorrowLimit(maximumLimit, loanToValue),
-		SpotMarketID: spotMarketID,
+		Denom:            denom,
+		BorrowLimit:      NewBorrowLimit(maximumLimit, loanToValue),
+		SpotMarketID:     spotMarketID,
+		ConversionFactor: conversionFactor,
 	}
 }
 

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -251,15 +251,17 @@ func (bl BorrowLimit) Validate() error {
 
 // MoneyMarket is a money market for an individual asset
 type MoneyMarket struct {
-	Denom       string      `json:"denom" yaml:"denom"`
-	BorrowLimit BorrowLimit `json:"borrow_limit" yaml:"borrow_limit"`
+	Denom        string      `json:"denom" yaml:"denom"`
+	BorrowLimit  BorrowLimit `json:"borrow_limit" yaml:"borrow_limit"`
+	SpotMarketID string      `json:"sport_market_id" yaml:"sport_market_id"`
 }
 
 // NewMoneyMarket returns a new MoneyMarket
-func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec) MoneyMarket {
+func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec, spotMarketID string) MoneyMarket {
 	return MoneyMarket{
-		Denom:       denom,
-		BorrowLimit: NewBorrowLimit(maximumLimit, loanToValue),
+		Denom:        denom,
+		BorrowLimit:  NewBorrowLimit(maximumLimit, loanToValue),
+		SpotMarketID: spotMarketID,
 	}
 }
 
@@ -375,10 +377,10 @@ func validateDelegatorParams(i interface{}) error {
 }
 
 func validateMoneyMarketParams(i interface{}) error {
-	bl, ok := i.(MoneyMarkets)
+	mm, ok := i.(MoneyMarkets)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	return bl.Validate()
+	return mm.Validate()
 }

--- a/x/harvest/types/querier.go
+++ b/x/harvest/types/querier.go
@@ -10,6 +10,7 @@ const (
 	QueryGetModuleAccounts = "accounts"
 	QueryGetDeposits       = "deposits"
 	QueryGetClaims         = "claims"
+	QueryGetBorrows        = "borrows"
 )
 
 // QueryDepositParams is the params for a filtered deposit query
@@ -65,5 +66,23 @@ func NewQueryAccountParams(page, limit int, name string) QueryAccountParams {
 		Page:  page,
 		Limit: limit,
 		Name:  name,
+	}
+}
+
+// QueryBorrowParams is the params for a filtered borrow query
+type QueryBorrowParams struct {
+	Page        int            `json:"page" yaml:"page"`
+	Limit       int            `json:"limit" yaml:"limit"`
+	Owner       sdk.AccAddress `json:"owner" yaml:"owner"`
+	BorrowDenom string         `json:"borrow_denom" yaml:"borrow_denom"`
+}
+
+// NewQueryBorrowParams creates a new QueryBorrowParams
+func NewQueryBorrowParams(page, limit int, owner sdk.AccAddress, depositDenom string) QueryBorrowParams {
+	return QueryBorrowParams{
+		Page:        page,
+		Limit:       limit,
+		Owner:       owner,
+		BorrowDenom: depositDenom,
 	}
 }

--- a/x/pricefeed/keeper/params.go
+++ b/x/pricefeed/keeper/params.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"strings"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -60,19 +58,4 @@ func (k Keeper) GetMarket(ctx sdk.Context, marketID string) (types.Market, bool)
 		}
 	}
 	return types.Market{}, false
-}
-
-// GetLiveMarketIDByDenom gets the live market ID by denom, selecting 'bnb:usd' over 'bnb:usd:30' for input 'bnb'
-func (k Keeper) GetLiveMarketIDByDenom(ctx sdk.Context, denom string) (string, bool) {
-	markets := k.GetMarkets(ctx)
-	for _, market := range markets {
-		splitMarketID := strings.Split(market.MarketID, ":")
-		// Here we accept 'bnb:usd' but not 'bnb:usd:30'
-		if len(splitMarketID) == 2 {
-			if splitMarketID[0] == denom {
-				return market.MarketID, true
-			}
-		}
-	}
-	return "", false
 }

--- a/x/pricefeed/keeper/params.go
+++ b/x/pricefeed/keeper/params.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -58,5 +60,19 @@ func (k Keeper) GetMarket(ctx sdk.Context, marketID string) (types.Market, bool)
 		}
 	}
 	return types.Market{}, false
+}
 
+// GetLiveMarketIDByDenom gets the live market ID by denom, selecting 'bnb:usd' over 'bnb:usd:30' for input 'bnb'
+func (k Keeper) GetLiveMarketIDByDenom(ctx sdk.Context, denom string) (string, bool) {
+	markets := k.GetMarkets(ctx)
+	for _, market := range markets {
+		splitMarketID := strings.Split(market.MarketID, ":")
+		// Here we accept 'bnb:usd' but not 'bnb:usd:30'
+		if len(splitMarketID) == 2 {
+			if splitMarketID[0] == denom {
+				return market.MarketID, true
+			}
+		}
+	}
+	return "", false
 }

--- a/x/pricefeed/types/market.go
+++ b/x/pricefeed/types/market.go
@@ -11,7 +11,6 @@ import (
 
 // Market an asset in the pricefeed
 type Market struct {
-	// TODO: rename to ID
 	MarketID   string           `json:"market_id" yaml:"market_id"`
 	BaseAsset  string           `json:"base_asset" yaml:"base_asset"`
 	QuoteAsset string           `json:"quote_asset" yaml:"quote_asset"`


### PR DESCRIPTION
This PR contains basic harvest functionality.

General borrow steps:
```bash
kvcli tx pricefeed postprice usdx 100 99999999999 --from [oracle-addr]
kvcli tx harvest deposit 1000000usdx lp --from [usdx-holder-addr]
kvcli tx harvest borrow 1000000usdx --from [usdx-holder-addr]
```

My local borrow steps to successfully deposit USDX and borrow KAVA:
```
# Set asset prices in price feed
kvcli tx pricefeed postprice usdx:usd 1 99999999999 --from validator
kvcli tx pricefeed postprice kava:usd 10 99999999999 --from validator
kvcli tx pricefeed postprice bnb:usd 100 99999999999 --from validator
kvcli tx pricefeed postprice bnb:usd:30 100 99999999999 --from validator

# Load USDX onto testing account by creating a CDP
kvcli tx cdp create 1000000000bnb 100000000usdx bnb-a --from kava1g0qywkx6mt5jmvefv6hs7c7h333qas5ks63a6t --gas 500000

# Load KAVA into Harvest module account (required in order to borrow from Harvest module account)
kvcli tx harvest deposit 10000000ukava lp --from kava1g0qywkx6mt5jmvefv6hs7c7h333qas5ks63a6t

# Deposit USDX and borrow KAVA
kvcli tx harvest deposit 10000000usdx lp --from kava1g0qywkx6mt5jmvefv6hs7c7h333qas5ks63a6t
kvcli tx harvest borrow 1000000ukava --from kava1g0qywkx6mt5jmvefv6hs7c7h333qas5ks63a6t
```


