### PR TITLE
Harvest: deposit multiple assets supplying multiple assets

### DIFF
--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -9,8 +9,7 @@ import (
 
 // Borrow funds
 func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins) error {
-	// TODO: Here we assume borrower only has one coin. To be addressed in future card.
-	err := k.ValidateBorrow(ctx, borrower, coins[0])
+	err := k.ValidateBorrow(ctx, borrower, coins)
 	if err != nil {
 		return err
 	}
@@ -40,66 +39,109 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 }
 
 // ValidateBorrow validates a borrow request against borrower and protocol requirements
-func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coin) error {
-	proprosedBorrowUSDValue, err := k.calculateUSDValue(ctx, amount.Amount, amount.Denom)
-	if err != nil {
-		return err
+func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coins) error {
+	// Get the proposed borrow USD value
+	moneyMarketCache := map[string]types.MoneyMarket{}
+	proprosedBorrowUSDValue := sdk.ZeroDec()
+	for _, coin := range amount {
+		// Fetch money market and store in local cache
+		if moneyMarketCache[coin.Denom] == (types.MoneyMarket{}) {
+			newMoneyMarket, found := k.GetMoneyMarket(ctx, coin.Denom)
+			if !found {
+				return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", coin.Denom)
+			}
+			moneyMarketCache[coin.Denom] = newMoneyMarket
+		}
+
+		// Calculate this coin's USD value and add it borrow's total USD value
+		moneyMarket := moneyMarketCache[coin.Denom]
+		assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+		if err != nil {
+			return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+		}
+		coinUSDValue := sdk.NewDecFromInt(coin.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
+		proprosedBorrowUSDValue = proprosedBorrowUSDValue.Add(coinUSDValue)
 	}
 
-	// Get the total value of the user's deposits
+	// Get the total borrowable USD amount at user's existing deposits
 	deposits := k.GetDepositsByUser(ctx, borrower)
 	if len(deposits) == 0 {
 		return sdkerrors.Wrapf(types.ErrDepositsNotFound, "no deposits found for %s", borrower)
 	}
 	totalBorrowableAmount := sdk.ZeroDec()
 	for _, deposit := range deposits {
-		borrowableAmountForDeposit, err := k.getBorrowableAmountForDeposit(ctx, deposit)
-		if err != nil {
-			return err
+		// Fetch money market and store in local cache
+		if moneyMarketCache[deposit.Amount.Denom] == (types.MoneyMarket{}) {
+			newMoneyMarket, found := k.GetMoneyMarket(ctx, deposit.Amount.Denom)
+			if !found {
+				return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", deposit.Amount.Denom)
+			}
+			moneyMarketCache[deposit.Amount.Denom] = newMoneyMarket
 		}
+
+		// Calculate the borrowable amount and add it to the user's total borrowable amount
+		moneyMarket := moneyMarketCache[deposit.Amount.Denom]
+		assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+		if err != nil {
+			sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+		}
+		borrowableAmountForDeposit := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
 		totalBorrowableAmount = totalBorrowableAmount.Add(borrowableAmountForDeposit)
 	}
 
-	previousBorrowsUSDValue := sdk.ZeroDec()
-	previousBorrows, found := k.GetBorrow(ctx, borrower)
+	// Get the total USD value of user's existing borrows
+	existingBorrowUSDValue := sdk.ZeroDec()
+	existingBorrow, found := k.GetBorrow(ctx, borrower)
 	if found {
-		// TODO: here we're assuming that the user only has 1 previous borrow. To be addressed in future cards.
-		previousBorrow := previousBorrows.Amount[0]
-		previousBorrowUSDValue, err := k.calculateUSDValue(ctx, previousBorrow.Amount, previousBorrow.Denom)
-		if err != nil {
-			return err
+		for _, borrowedCoin := range existingBorrow.Amount {
+			// Fetch money market and store in local cache
+			if moneyMarketCache[borrowedCoin.Denom] == (types.MoneyMarket{}) {
+				newMoneyMarket, found := k.GetMoneyMarket(ctx, borrowedCoin.Denom)
+				if !found {
+					return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", borrowedCoin.Denom)
+				}
+				moneyMarketCache[borrowedCoin.Denom] = newMoneyMarket
+			}
+
+			// Calculate this borrow coin's USD value and add it to the total previous borrowed USD value
+			moneyMarket := moneyMarketCache[borrowedCoin.Denom]
+			assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+			if err != nil {
+				return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+			}
+			coinUSDValue := sdk.NewDecFromInt(borrowedCoin.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
+			existingBorrowUSDValue = existingBorrowUSDValue.Add(coinUSDValue)
 		}
-		previousBorrowsUSDValue = previousBorrowsUSDValue.Add(previousBorrowUSDValue)
 	}
 
 	// Validate that the proposed borrow's USD value is within user's borrowable limit
-	if proprosedBorrowUSDValue.GT(totalBorrowableAmount.Sub(previousBorrowsUSDValue)) {
+	if proprosedBorrowUSDValue.GT(totalBorrowableAmount.Sub(existingBorrowUSDValue)) {
 		return sdkerrors.Wrapf(types.ErrInsufficientLoanToValue, "requested borrow %s is greater than maximum valid borrow", amount)
 	}
 	return nil
 }
 
-func (k Keeper) calculateUSDValue(ctx sdk.Context, amount sdk.Int, denom string) (sdk.Dec, error) {
-	moneyMarket, found := k.GetMoneyMarket(ctx, denom)
-	if !found {
-		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", denom)
-	}
-	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
-	if err != nil {
-		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
-	}
-	return sdk.NewDecFromInt(amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price), nil
-}
+// func (k Keeper) calculateUSDValue(ctx sdk.Context, amount sdk.Int, denom string) (sdk.Dec, error) {
+// 	moneyMarket, found := k.GetMoneyMarket(ctx, denom)
+// 	if !found {
+// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", denom)
+// 	}
+// 	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+// 	if err != nil {
+// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+// 	}
+// 	return sdk.NewDecFromInt(amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price), nil
+// }
 
-func (k Keeper) getBorrowableAmountForDeposit(ctx sdk.Context, deposit types.Deposit) (sdk.Dec, error) {
-	moneyMarket, found := k.GetMoneyMarket(ctx, deposit.Amount.Denom)
-	if !found {
-		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", deposit.Amount.Denom)
-	}
-	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
-	if err != nil {
-		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
-	}
-	usdValue := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
-	return usdValue.Mul(moneyMarket.BorrowLimit.LoanToValue), nil
-}
+// func (k Keeper) getBorrowableAmountForDeposit(ctx sdk.Context, deposit types.Deposit) (sdk.Dec, error) {
+// 	moneyMarket, found := k.GetMoneyMarket(ctx, deposit.Amount.Denom)
+// 	if !found {
+// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", deposit.Amount.Denom)
+// 	}
+// 	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+// 	if err != nil {
+// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+// 	}
+// 	usdValue := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
+// 	return usdValue.Mul(moneyMarket.BorrowLimit.LoanToValue), nil
+// }

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -121,28 +121,3 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 	}
 	return nil
 }
-
-// func (k Keeper) calculateUSDValue(ctx sdk.Context, amount sdk.Int, denom string) (sdk.Dec, error) {
-// 	moneyMarket, found := k.GetMoneyMarket(ctx, denom)
-// 	if !found {
-// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", denom)
-// 	}
-// 	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
-// 	if err != nil {
-// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
-// 	}
-// 	return sdk.NewDecFromInt(amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price), nil
-// }
-
-// func (k Keeper) getBorrowableAmountForDeposit(ctx sdk.Context, deposit types.Deposit) (sdk.Dec, error) {
-// 	moneyMarket, found := k.GetMoneyMarket(ctx, deposit.Amount.Denom)
-// 	if !found {
-// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", deposit.Amount.Denom)
-// 	}
-// 	assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
-// 	if err != nil {
-// 		return sdk.ZeroDec(), sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
-// 	}
-// 	usdValue := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
-// 	return usdValue.Mul(moneyMarket.BorrowLimit.LoanToValue), nil
-// }

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -85,7 +85,8 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 		if err != nil {
 			sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
 		}
-		borrowableAmountForDeposit := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
+		depositUSDValue := sdk.NewDecFromInt(deposit.Amount.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
+		borrowableAmountForDeposit := depositUSDValue.Mul(moneyMarket.BorrowLimit.LoanToValue)
 		totalBorrowableAmount = totalBorrowableAmount.Add(borrowableAmountForDeposit)
 	}
 


### PR DESCRIPTION
This PR implements functionality required to meet the acceptance criteria of https://app.asana.com/0/1156716699555540/1198904860690582/f.
- Support borrowing multiple assets in a single `Borrow` transaction
- Subtract value previously borrowed from user's current borrowable amount

Additional changes
- Introduce local cache for MoneyMarket params to reduce param reads
