### PR TITLE
Harvest: borrows capped by utilization

### DIFF
--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -210,7 +210,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			},
 			errArgs{
 				expectPass: false,
-				contains:   "exceeds module account balance: the requested borrow amount exceeds the total amount of",
+				contains:   "exceeds module account balance:",
 			},
 		},
 	}

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -192,6 +192,27 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				contains:   "no price found for market",
 			},
 		},
+		{
+			"invalid: borrow exceed module account balance",
+			args{
+				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
+				previousBorrowCoins:       sdk.NewCoins(),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdk.NewInt(101*BUSD_CF))),
+				expectedAccountBalance:    sdk.NewCoins(),
+				expectedModAccountBalance: sdk.NewCoins(),
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "exceeds module account balance: the requested borrow amount exceeds the total amount of",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -45,4 +45,6 @@ var (
 	ErrMarketNotFound = sdkerrors.Register(ModuleName, 19, "no market found for denom")
 	// ErrPriceNotFound error for when a price for the input market is not found
 	ErrPriceNotFound = sdkerrors.Register(ModuleName, 20, "no price found for market")
+	// ErrBorrowExceedsAvailableBalance for when a requested borrow exceeds available module acc balances
+	ErrBorrowExceedsAvailableBalance = sdkerrors.Register(ModuleName, 21, "exceeds module account balance")
 )


### PR DESCRIPTION
This PR addresses the [borrows capped by utilization task](https://app.asana.com/0/1156716699555540/1198904860690586/f) by catching and wrapping the "out of funds" error thrown when attempting to transfer coins from the module account which it does not have.

~~This PR is BLOCKED by https://github.com/Kava-Labs/kava/pull/713 and shouldn't be merged until https://github.com/Kava-Labs/kava/pull/713 is merged first.~~