### PR TITLE
Harvest: borrows limited by global asset borrow limit

### DIFF
--- a/x/harvest/client/cli/query.go
+++ b/x/harvest/client/cli/query.go
@@ -308,3 +308,30 @@ func queryBorrowsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String(flagOwner, "", "(optional) filter for borrows by owner address")
 	return cmd
 }
+
+func queryBorrowedCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "borrowed",
+		Short: "get total current borrowed amount",
+		Long:  "get the total amount of coins currently borrowed for the Harvest protocol",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			// Query
+			route := fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetBorrowed)
+			res, height, err := cliCtx.QueryWithData(route, nil)
+			if err != nil {
+				return err
+			}
+			cliCtx = cliCtx.WithHeight(height)
+
+			// Decode and print results
+			var borrowedCoins sdk.Coins
+			if err := cdc.UnmarshalJSON(res, &borrowedCoins); err != nil {
+				return fmt.Errorf("failed to unmarshal borrowed coins: %w", err)
+			}
+			return cliCtx.PrintOutput(borrowedCoins)
+		},
+	}
+}

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -59,6 +59,10 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 
 // ValidateBorrow validates a borrow request against borrower and protocol requirements
 func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount sdk.Coins) error {
+	if amount.IsZero() {
+		return types.ErrBorrowEmptyCoins
+	}
+
 	// Get the proposed borrow USD value
 	moneyMarketCache := map[string]types.MoneyMarket{}
 	proprosedBorrowUSDValue := sdk.ZeroDec()

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -97,10 +97,9 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 		newProposedAssetTotalBorrowedUSDValue := assetTotalBorrowedUSDValue.Add(coinUSDValue)
 		if newProposedAssetTotalBorrowedUSDValue.GT(moneyMarket.BorrowLimit.MaximumLimitUSD) {
 			return sdkerrors.Wrapf(types.ErrGreaterThanAssetBorrowLimit,
-				"proposed borrow would result in %susdx borrowed for %s, but the maximum global asset borrow limit is %susdx",
+				"proposed borrow would result in %s USD value borrowed for %s, but the maximum global asset borrow limit is %s USD value",
 				newProposedAssetTotalBorrowedUSDValue, coin.Denom, moneyMarket.BorrowLimit.MaximumLimitUSD)
 		}
-
 		proprosedBorrowUSDValue = proprosedBorrowUSDValue.Add(coinUSDValue)
 	}
 

--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -90,15 +89,12 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 		if moneyMarket.BorrowLimit.HasMaxLimit {
 			var assetTotalBorrowedAmount sdk.Int
 			totalBorrowedCoins, found := k.GetBorrowedCoins(ctx)
-			fmt.Println("totalBorrowedCoins:", totalBorrowedCoins)
 			if !found {
 				assetTotalBorrowedAmount = sdk.ZeroInt()
 			} else {
 				assetTotalBorrowedAmount = totalBorrowedCoins.AmountOf(coin.Denom)
 			}
 			newProposedAssetTotalBorrowedAmount := sdk.NewDecFromInt(assetTotalBorrowedAmount.Add(coin.Amount))
-			fmt.Println("newProposedAssetTotalBorrowedAmount:", newProposedAssetTotalBorrowedAmount)
-			fmt.Println("MaximumLimit:", moneyMarket.BorrowLimit.MaximumLimit)
 			if newProposedAssetTotalBorrowedAmount.GT(moneyMarket.BorrowLimit.MaximumLimit) {
 				return sdkerrors.Wrapf(types.ErrGreaterThanAssetBorrowLimit,
 					"proposed borrow would result in %s borrowed, but the maximum global asset borrow limit is %s",

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -244,12 +244,12 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(100000000*USDX_CF), sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
-					types.NewMoneyMarket("busd", sdk.NewInt(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
-					types.NewMoneyMarket("btcb", sdk.NewInt(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),
-					types.NewMoneyMarket("bnb", sdk.NewInt(100000000*BNB_CF), tc.args.loanToValueBNB, "bnb:usd", sdk.NewInt(BNB_CF)),
-					types.NewMoneyMarket("xyz", sdk.NewInt(1), tc.args.loanToValueBNB, "xyz:usd", sdk.NewInt(1)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(100000000*USDX_CF), sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
+					types.NewMoneyMarket("busd", sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
+					types.NewMoneyMarket("btcb", sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),
+					types.NewMoneyMarket("bnb", sdk.NewDec(100000000*BNB_CF), tc.args.loanToValueBNB, "bnb:usd", sdk.NewInt(BNB_CF)),
+					types.NewMoneyMarket("xyz", sdk.NewDec(1), tc.args.loanToValueBNB, "xyz:usd", sdk.NewInt(1)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 
@@ -327,7 +327,11 @@ func (suite *KeeperTestSuite) TestBorrow() {
 
 			// Execute user's previous borrows
 			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.previousBorrowCoins)
-			suite.Require().NoError(err)
+			if tc.args.previousBorrowCoins.IsZero() {
+				suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))
+			} else {
+				suite.Require().NoError(err)
+			}
 
 			// Now that our state is properly set up, execute the last borrow
 			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.borrowCoins)

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -25,7 +25,7 @@ const (
 func (suite *KeeperTestSuite) TestBorrow() {
 
 	type args struct {
-		usdxBorrowLimitUSD        sdk.Dec
+		usdxBorrowLimit           sdk.Dec
 		priceKAVA                 sdk.Dec
 		loanToValueKAVA           sdk.Dec
 		priceBTCB                 sdk.Dec
@@ -52,7 +52,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -74,7 +74,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: loan-to-value limited",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -95,7 +95,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid: multiple deposits",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
 				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
@@ -116,7 +116,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: multiple deposits",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
 				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
@@ -137,7 +137,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid: multiple previous borrows",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -159,7 +159,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: over loan-to-value with multiple previous borrows",
 			args{
-				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -181,8 +181,11 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: no price for asset",
 			args{
-				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+				// priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+				// loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
 				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
 				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
@@ -258,12 +261,12 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", tc.args.usdxBorrowLimitUSD, sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
-					types.NewMoneyMarket("busd", sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
-					types.NewMoneyMarket("btcb", sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),
-					types.NewMoneyMarket("bnb", sdk.NewDec(100000000*BNB_CF), tc.args.loanToValueBNB, "bnb:usd", sdk.NewInt(BNB_CF)),
-					types.NewMoneyMarket("xyz", sdk.NewDec(1), tc.args.loanToValueBNB, "xyz:usd", sdk.NewInt(1)),
+					types.NewMoneyMarket("usdx", true, tc.args.usdxBorrowLimitUSD, sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
+					types.NewMoneyMarket("busd", false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
+					types.NewMoneyMarket("btcb", false, sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),
+					types.NewMoneyMarket("bnb", false, sdk.NewDec(100000000*BNB_CF), tc.args.loanToValueBNB, "bnb:usd", sdk.NewInt(BNB_CF)),
+					types.NewMoneyMarket("xyz", false, sdk.NewDec(1), tc.args.loanToValueBNB, "xyz:usd", sdk.NewInt(1)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -225,8 +225,6 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: over global asset borrow limit",
 			args{
-				// priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-				// loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
@@ -235,43 +233,15 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
 				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
 				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
+				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))},
 				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("xyz", sdk.NewInt(1))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdk.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdk.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdk.NewInt(1))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdk.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdk.NewInt(100*BUSD_CF))),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "no price found for market",
-			},
-		},
-		{
-			// 	"invalid: borrow exceed module account balance",
-			// 	args{
-			"invalid: over global asset borrow limit",
-			args{
-				usdxBorrowLimit:     sdk.MustNewDecFromStr("20"), // $20 USD limit
-				priceKAVA:           sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:     sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:           sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:     sdk.MustNewDecFromStr("0.01"),
-				priceBNB:            sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:      sdk.MustNewDecFromStr("0.01"),
-				borrower:            sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:        []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
-				previousBorrowCoins: sdk.NewCoins(),
-				borrowCoins:         sdk.NewCoins(sdk.NewCoin("busd", sdk.NewInt(101*BUSD_CF))),
-				// depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))},
-				// previousBorrowCoins:       sdk.NewCoins(),
-				// borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(25*USDX_CF))),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(25*USDX_CF))),
 				expectedAccountBalance:    sdk.NewCoins(),
 				expectedModAccountBalance: sdk.NewCoins(),
 			},
 			errArgs{
 				expectPass: false,
-				contains:   "exceeds module account balance:",
-				// contains:   "fails global asset borrow limit validation",
+				contains:   "fails global asset borrow limit validation",
 			},
 		},
 	}

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -25,6 +25,7 @@ const (
 func (suite *KeeperTestSuite) TestBorrow() {
 
 	type args struct {
+		usdxBorrowLimitUSD        sdk.Dec
 		priceKAVA                 sdk.Dec
 		loanToValueKAVA           sdk.Dec
 		priceBTCB                 sdk.Dec
@@ -51,6 +52,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -72,6 +74,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: loan-to-value limited",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -92,6 +95,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid: multiple deposits",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
 				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
@@ -112,6 +116,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: multiple deposits",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
 				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
@@ -132,6 +137,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"valid: multiple previous borrows",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -153,6 +159,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: over loan-to-value with multiple previous borrows",
 			args{
+				usdxBorrowLimitUSD:        sdk.MustNewDecFromStr("10000"), // $10,000 USD limit
 				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
@@ -193,24 +200,31 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			},
 		},
 		{
-			"invalid: borrow exceed module account balance",
+			// 	"invalid: borrow exceed module account balance",
+			// 	args{
+			"invalid: over global asset borrow limit",
 			args{
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdk.NewInt(101*BUSD_CF))),
+				usdxBorrowLimitUSD:  sdk.MustNewDecFromStr("20"), // $20 USD limit
+				priceKAVA:           sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:     sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:     sdk.MustNewDecFromStr("0.01"),
+				priceBNB:            sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:      sdk.MustNewDecFromStr("0.01"),
+				borrower:            sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:        []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
+				previousBorrowCoins: sdk.NewCoins(),
+				borrowCoins:         sdk.NewCoins(sdk.NewCoin("busd", sdk.NewInt(101*BUSD_CF))),
+				// depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))},
+				// previousBorrowCoins:       sdk.NewCoins(),
+				// borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(25*USDX_CF))),
 				expectedAccountBalance:    sdk.NewCoins(),
 				expectedModAccountBalance: sdk.NewCoins(),
 			},
 			errArgs{
 				expectPass: false,
 				contains:   "exceeds module account balance:",
+				// contains:   "fails global asset borrow limit validation",
 			},
 		},
 	}
@@ -244,7 +258,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(100000000*USDX_CF), sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
+					types.NewMoneyMarket("usdx", tc.args.usdxBorrowLimitUSD, sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
 					types.NewMoneyMarket("busd", sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
 					types.NewMoneyMarket("ukava", sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
 					types.NewMoneyMarket("btcb", sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -181,6 +181,50 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		{
 			"invalid: no price for asset",
 			args{
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
+				previousBorrowCoins:       sdk.NewCoins(),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("xyz", sdk.NewInt(1))),
+				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdk.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdk.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdk.NewInt(1))),
+				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdk.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdk.NewInt(100*BUSD_CF))),
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "no price found for market",
+			},
+		},
+		{
+			"invalid: borrow exceed module account balance",
+			args{
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
+				previousBorrowCoins:       sdk.NewCoins(),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdk.NewInt(101*BUSD_CF))),
+				expectedAccountBalance:    sdk.NewCoins(),
+				expectedModAccountBalance: sdk.NewCoins(),
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "exceeds module account balance:",
+			},
+		},
+		{
+			"invalid: over global asset borrow limit",
+			args{
 				// priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
 				// loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
 				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
@@ -207,7 +251,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			// 	args{
 			"invalid: over global asset borrow limit",
 			args{
-				usdxBorrowLimitUSD:  sdk.MustNewDecFromStr("20"), // $20 USD limit
+				usdxBorrowLimit:     sdk.MustNewDecFromStr("20"), // $20 USD limit
 				priceKAVA:           sdk.MustNewDecFromStr("2.00"),
 				loanToValueKAVA:     sdk.MustNewDecFromStr("0.8"),
 				priceBTCB:           sdk.MustNewDecFromStr("0.00"),
@@ -261,7 +305,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", true, tc.args.usdxBorrowLimitUSD, sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
+					types.NewMoneyMarket("usdx", true, tc.args.usdxBorrowLimit, sdk.MustNewDecFromStr("1"), "usdx:usd", sdk.NewInt(USDX_CF)),
 					types.NewMoneyMarket("busd", false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1"), "busd:usd", sdk.NewInt(BUSD_CF)),
 					types.NewMoneyMarket("ukava", false, sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA, "kava:usd", sdk.NewInt(KAVA_CF)),
 					types.NewMoneyMarket("btcb", false, sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB, "btcb:usd", sdk.NewInt(BTCB_CF)),

--- a/x/harvest/keeper/claim_test.go
+++ b/x/harvest/keeper/claim_test.go
@@ -265,8 +265,8 @@ func (suite *KeeperTestSuite) TestClaim() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/claim_test.go
+++ b/x/harvest/keeper/claim_test.go
@@ -265,8 +265,8 @@ func (suite *KeeperTestSuite) TestClaim() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/deposit_test.go
+++ b/x/harvest/keeper/deposit_test.go
@@ -128,8 +128,8 @@ func (suite *KeeperTestSuite) TestDeposit() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -300,8 +300,8 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/deposit_test.go
+++ b/x/harvest/keeper/deposit_test.go
@@ -128,8 +128,8 @@ func (suite *KeeperTestSuite) TestDeposit() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -300,8 +300,8 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/keeper.go
+++ b/x/harvest/keeper/keeper.go
@@ -237,3 +237,24 @@ func (k Keeper) IterateBorrows(ctx sdk.Context, cb func(borrow types.Borrow) (st
 		}
 	}
 }
+
+// ---------------------------
+
+// SetBorrowedCoins sets the total amount of coins currently borrowed in the store
+func (k Keeper) SetBorrowedCoins(ctx sdk.Context, borrowedCoins sdk.Coins) {
+	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowedCoinsPrefix)
+	bz := k.cdc.MustMarshalBinaryBare(borrowedCoins)
+	store.Set([]byte{}, bz)
+}
+
+// GetBorrowedCoins returns an sdk.Coins object from the store representing all currently borrowed coins
+func (k Keeper) GetBorrowedCoins(ctx sdk.Context) (sdk.Coins, bool) {
+	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowedCoinsPrefix)
+	bz := store.Get([]byte{})
+	if bz == nil {
+		return sdk.Coins{}, false
+	}
+	var borrowedCoins sdk.Coins
+	k.cdc.MustUnmarshalBinaryBare(bz, &borrowedCoins)
+	return borrowedCoins, true
+}

--- a/x/harvest/keeper/keeper.go
+++ b/x/harvest/keeper/keeper.go
@@ -238,8 +238,6 @@ func (k Keeper) IterateBorrows(ctx sdk.Context, cb func(borrow types.Borrow) (st
 	}
 }
 
-// ---------------------------
-
 // SetBorrowedCoins sets the total amount of coins currently borrowed in the store
 func (k Keeper) SetBorrowedCoins(ctx sdk.Context, borrowedCoins sdk.Coins) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.BorrowedCoinsPrefix)

--- a/x/harvest/keeper/rewards_test.go
+++ b/x/harvest/keeper/rewards_test.go
@@ -75,8 +75,8 @@ func (suite *KeeperTestSuite) TestApplyDepositRewards() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), tc.args.previousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -443,8 +443,8 @@ func harvestGenesisState(rewardRate sdk.Coin) app.GenesisState {
 				),
 			},
 			types.MoneyMarkets{
-				types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-				types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+				types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+				types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 			},
 		),
 		types.DefaultPreviousBlockTime,

--- a/x/harvest/keeper/rewards_test.go
+++ b/x/harvest/keeper/rewards_test.go
@@ -75,8 +75,8 @@ func (suite *KeeperTestSuite) TestApplyDepositRewards() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), tc.args.previousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})
@@ -443,8 +443,8 @@ func harvestGenesisState(rewardRate sdk.Coin) app.GenesisState {
 				),
 			},
 			types.MoneyMarkets{
-				types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-				types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+				types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+				types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 			},
 		),
 		types.DefaultPreviousBlockTime,

--- a/x/harvest/keeper/timelock_test.go
+++ b/x/harvest/keeper/timelock_test.go
@@ -291,8 +291,8 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", false, sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", false, sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/keeper/timelock_test.go
+++ b/x/harvest/keeper/timelock_test.go
@@ -291,8 +291,8 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 				),
 				},
 				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", sdk.NewInt(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
-					types.NewMoneyMarket("ukava", sdk.NewInt(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("usdx", sdk.NewDec(1000000000000000), loanToValue, "usdx:usd", sdk.NewInt(1000000)),
+					types.NewMoneyMarket("ukava", sdk.NewDec(1000000000000000), loanToValue, "kava:usd", sdk.NewInt(1000000)),
 				},
 			), types.DefaultPreviousBlockTime, types.DefaultDistributionTimes)
 			tApp.InitializeFromGenesisStates(authGS, app.GenesisState{types.ModuleName: types.ModuleCdc.MustMarshalJSON(harvestGS)})

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -47,4 +47,8 @@ var (
 	ErrPriceNotFound = sdkerrors.Register(ModuleName, 20, "no price found for market")
 	// ErrBorrowExceedsAvailableBalance for when a requested borrow exceeds available module acc balances
 	ErrBorrowExceedsAvailableBalance = sdkerrors.Register(ModuleName, 21, "exceeds module account balance")
+	// ErrBorrowedCoinsNotFound error for when the total amount of borrowed coins cannot be found
+	ErrBorrowedCoinsNotFound = sdkerrors.Register(ModuleName, 23, "no borrowed coins found")
+	// ErrNegativeBorrowedCoins error for when substracting coins from the total borrowed balance results in a negative amount
+	ErrNegativeBorrowedCoins = sdkerrors.Register(ModuleName, 24, "subtraction results in negative borrow amount")
 )

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -53,4 +53,6 @@ var (
 	ErrNegativeBorrowedCoins = sdkerrors.Register(ModuleName, 23, "subtraction results in negative borrow amount")
 	// ErrGreaterThanAssetBorrowLimit error for when a proposed borrow would increase borrowed amount over the asset's global borrow limit
 	ErrGreaterThanAssetBorrowLimit = sdkerrors.Register(ModuleName, 24, "fails global asset borrow limit validation")
+	// ErrBorrowEmptyCoins error for when you cannot borrow empty coins
+	ErrBorrowEmptyCoins = sdkerrors.Register(ModuleName, 25, "cannot borrow zero coins")
 )

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -48,7 +48,9 @@ var (
 	// ErrBorrowExceedsAvailableBalance for when a requested borrow exceeds available module acc balances
 	ErrBorrowExceedsAvailableBalance = sdkerrors.Register(ModuleName, 21, "exceeds module account balance")
 	// ErrBorrowedCoinsNotFound error for when the total amount of borrowed coins cannot be found
-	ErrBorrowedCoinsNotFound = sdkerrors.Register(ModuleName, 23, "no borrowed coins found")
+	ErrBorrowedCoinsNotFound = sdkerrors.Register(ModuleName, 22, "no borrowed coins found")
 	// ErrNegativeBorrowedCoins error for when substracting coins from the total borrowed balance results in a negative amount
-	ErrNegativeBorrowedCoins = sdkerrors.Register(ModuleName, 24, "subtraction results in negative borrow amount")
+	ErrNegativeBorrowedCoins = sdkerrors.Register(ModuleName, 23, "subtraction results in negative borrow amount")
+	// ErrGreaterThanAssetBorrowLimit error for when a proposed borrow would increase borrowed amount over the asset's global borrow limit
+	ErrGreaterThanAssetBorrowLimit = sdkerrors.Register(ModuleName, 24, "fails global asset borrow limit validation")
 )

--- a/x/harvest/types/keys.go
+++ b/x/harvest/types/keys.go
@@ -36,6 +36,7 @@ var (
 	DepositsKeyPrefix                 = []byte{0x03}
 	ClaimsKeyPrefix                   = []byte{0x04}
 	BorrowsKeyPrefix                  = []byte{0x05}
+	BorrowedCoinsPrefix               = []byte{0x06}
 	sep                               = []byte(":")
 )
 

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -223,12 +223,12 @@ type Multipliers []Multiplier
 
 // BorrowLimit enforces restrictions on a money market
 type BorrowLimit struct {
-	MaximumLimitUSD sdk.Int `json:"maximum_limit_usd" yaml:"maximum_limit_usd"`
+	MaximumLimitUSD sdk.Dec `json:"maximum_limit_usd" yaml:"maximum_limit_usd"`
 	LoanToValue     sdk.Dec `json:"loan_to_value" yaml:"loan_to_value"`
 }
 
 // NewBorrowLimit returns a new BorrowLimit
-func NewBorrowLimit(maximumLimitUSD sdk.Int, loanToValue sdk.Dec) BorrowLimit {
+func NewBorrowLimit(maximumLimitUSD, loanToValue sdk.Dec) BorrowLimit {
 	return BorrowLimit{
 		MaximumLimitUSD: maximumLimitUSD,
 		LoanToValue:     loanToValue,
@@ -258,7 +258,7 @@ type MoneyMarket struct {
 }
 
 // NewMoneyMarket returns a new MoneyMarket
-func NewMoneyMarket(denom string, maximumLimitUSD sdk.Int, loanToValue sdk.Dec,
+func NewMoneyMarket(denom string, maximumLimitUSD, loanToValue sdk.Dec,
 	spotMarketID string, conversionFactor sdk.Int) MoneyMarket {
 	return MoneyMarket{
 		Denom:            denom,

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -223,22 +223,24 @@ type Multipliers []Multiplier
 
 // BorrowLimit enforces restrictions on a money market
 type BorrowLimit struct {
-	MaximumLimitUSD sdk.Dec `json:"maximum_limit_usd" yaml:"maximum_limit_usd"`
-	LoanToValue     sdk.Dec `json:"loan_to_value" yaml:"loan_to_value"`
+	HasMaxLimit  bool    `json:"has_max_limit" yaml:"has_max_limit"`
+	MaximumLimit sdk.Dec `json:"maximum_limit" yaml:"maximum_limit"`
+	LoanToValue  sdk.Dec `json:"loan_to_value" yaml:"loan_to_value"`
 }
 
 // NewBorrowLimit returns a new BorrowLimit
-func NewBorrowLimit(maximumLimitUSD, loanToValue sdk.Dec) BorrowLimit {
+func NewBorrowLimit(hasMaxLimit bool, maximumLimit, loanToValue sdk.Dec) BorrowLimit {
 	return BorrowLimit{
-		MaximumLimitUSD: maximumLimitUSD,
-		LoanToValue:     loanToValue,
+		HasMaxLimit:  hasMaxLimit,
+		MaximumLimit: maximumLimit,
+		LoanToValue:  loanToValue,
 	}
 }
 
 // Validate BorrowLimit
 func (bl BorrowLimit) Validate() error {
-	if bl.MaximumLimitUSD.IsNegative() {
-		return fmt.Errorf("maximum limit USD cannot be negative: %s", bl.MaximumLimitUSD)
+	if bl.MaximumLimit.IsNegative() {
+		return fmt.Errorf("maximum limit USD cannot be negative: %s", bl.MaximumLimit)
 	}
 	if !bl.LoanToValue.IsPositive() {
 		return fmt.Errorf("loan-to-value must be a positive integer: %s", bl.LoanToValue)
@@ -258,11 +260,11 @@ type MoneyMarket struct {
 }
 
 // NewMoneyMarket returns a new MoneyMarket
-func NewMoneyMarket(denom string, maximumLimitUSD, loanToValue sdk.Dec,
+func NewMoneyMarket(denom string, hasMaxLimit bool, maximumLimit, loanToValue sdk.Dec,
 	spotMarketID string, conversionFactor sdk.Int) MoneyMarket {
 	return MoneyMarket{
 		Denom:            denom,
-		BorrowLimit:      NewBorrowLimit(maximumLimitUSD, loanToValue),
+		BorrowLimit:      NewBorrowLimit(hasMaxLimit, maximumLimit, loanToValue),
 		SpotMarketID:     spotMarketID,
 		ConversionFactor: conversionFactor,
 	}

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -223,22 +223,22 @@ type Multipliers []Multiplier
 
 // BorrowLimit enforces restrictions on a money market
 type BorrowLimit struct {
-	MaximumLimit sdk.Int `json:"maximum_limit" yaml:"maximum_limit"`
-	LoanToValue  sdk.Dec `json:"loan_to_value" yaml:"loan_to_value"`
+	MaximumLimitUSD sdk.Int `json:"maximum_limit_usd" yaml:"maximum_limit_usd"`
+	LoanToValue     sdk.Dec `json:"loan_to_value" yaml:"loan_to_value"`
 }
 
 // NewBorrowLimit returns a new BorrowLimit
-func NewBorrowLimit(maximumLimit sdk.Int, loanToValue sdk.Dec) BorrowLimit {
+func NewBorrowLimit(maximumLimitUSD sdk.Int, loanToValue sdk.Dec) BorrowLimit {
 	return BorrowLimit{
-		MaximumLimit: maximumLimit,
-		LoanToValue:  loanToValue,
+		MaximumLimitUSD: maximumLimitUSD,
+		LoanToValue:     loanToValue,
 	}
 }
 
 // Validate BorrowLimit
 func (bl BorrowLimit) Validate() error {
-	if bl.MaximumLimit.IsNegative() {
-		return fmt.Errorf("maximum limit cannot be negative: %s", bl.MaximumLimit)
+	if bl.MaximumLimitUSD.IsNegative() {
+		return fmt.Errorf("maximum limit USD cannot be negative: %s", bl.MaximumLimitUSD)
 	}
 	if !bl.LoanToValue.IsPositive() {
 		return fmt.Errorf("loan-to-value must be a positive integer: %s", bl.LoanToValue)
@@ -258,11 +258,11 @@ type MoneyMarket struct {
 }
 
 // NewMoneyMarket returns a new MoneyMarket
-func NewMoneyMarket(denom string, maximumLimit sdk.Int, loanToValue sdk.Dec,
+func NewMoneyMarket(denom string, maximumLimitUSD sdk.Int, loanToValue sdk.Dec,
 	spotMarketID string, conversionFactor sdk.Int) MoneyMarket {
 	return MoneyMarket{
 		Denom:            denom,
-		BorrowLimit:      NewBorrowLimit(maximumLimit, loanToValue),
+		BorrowLimit:      NewBorrowLimit(maximumLimitUSD, loanToValue),
 		SpotMarketID:     spotMarketID,
 		ConversionFactor: conversionFactor,
 	}

--- a/x/harvest/types/params.go
+++ b/x/harvest/types/params.go
@@ -316,7 +316,7 @@ func (p Params) String() string {
 	Active: %t
 	Liquidity Provider Distribution Schedules %s
 	Delegator Distribution Schedule %s
-	Money Markets %s`, p.Active, p.LiquidityProviderSchedules, p.DelegatorDistributionSchedules, p.MoneyMarkets)
+	Money Markets %v`, p.Active, p.LiquidityProviderSchedules, p.DelegatorDistributionSchedules, p.MoneyMarkets)
 }
 
 // ParamKeyTable Key declaration for parameters

--- a/x/harvest/types/querier.go
+++ b/x/harvest/types/querier.go
@@ -11,6 +11,7 @@ const (
 	QueryGetDeposits       = "deposits"
 	QueryGetClaims         = "claims"
 	QueryGetBorrows        = "borrows"
+	QueryGetBorrowed       = "borrowed"
 )
 
 // QueryDepositParams is the params for a filtered deposit query
@@ -84,5 +85,17 @@ func NewQueryBorrowParams(page, limit int, owner sdk.AccAddress, depositDenom st
 		Limit:       limit,
 		Owner:       owner,
 		BorrowDenom: depositDenom,
+	}
+}
+
+// QueryBorrowedParams is the params for a filtered borrowed coins query
+type QueryBorrowedParams struct {
+	Denom string `json:"denom" yaml:"denom"`
+}
+
+// NewQueryBorrowedParams creates a new QueryBorrowedParams
+func NewQueryBorrowedParams(denom string) QueryBorrowedParams {
+	return QueryBorrowedParams{
+		Denom: denom,
 	}
 }


### PR DESCRIPTION
This PR implements functionality for [this task](https://app.asana.com/0/1156716699555540/1198999905425415/f).

Changes:
- Add `BorrowedCoins` to store + querier
- Increment `BorrowedCoins` balance after each successful borrow
- Validate that proposed borrows won't exceed the asset's limit

The param is set in each asset's MoneyMarket.BorrowLimit.MaximumLimitUSD.