### PR TITLE
Harvest: update LTV error text

### DIFF
--- a/x/harvest/keeper/borrow.go
+++ b/x/harvest/keeper/borrow.go
@@ -160,7 +160,7 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 
 	// Validate that the proposed borrow's USD value is within user's borrowable limit
 	if proprosedBorrowUSDValue.GT(totalBorrowableAmount.Sub(existingBorrowUSDValue)) {
-		return sdkerrors.Wrapf(types.ErrInsufficientLoanToValue, "requested borrow %s is greater than maximum valid borrow", amount)
+		return sdkerrors.Wrapf(types.ErrInsufficientLoanToValue, "requested borrow %s exceeds the allowable amount as determined by the collateralization ratio", amount)
 	}
 	return nil
 }

--- a/x/harvest/keeper/borrow_test.go
+++ b/x/harvest/keeper/borrow_test.go
@@ -175,7 +175,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			},
 			errArgs{
 				expectPass: false,
-				contains:   "requested borrow 1000000usdx is greater than maximum valid borrow",
+				contains:   "requested borrow 1000000usdx exceeds the allowable amount as determined by the collateralization ratio",
 			},
 		},
 		{

--- a/x/harvest/keeper/params.go
+++ b/x/harvest/keeper/params.go
@@ -48,5 +48,6 @@ func (k Keeper) GetMoneyMarket(ctx sdk.Context, denom string) (types.MoneyMarket
 			return mm, true
 		}
 	}
+
 	return types.MoneyMarket{}, false
 }

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -40,7 +40,7 @@ var (
 	// ErrDepositsNotFound error for no deposits found
 	ErrDepositsNotFound = sdkerrors.Register(ModuleName, 17, "no deposits found")
 	// ErrInsufficientLoanToValue error for when an attempted borrow exceeds maximum loan-to-value
-	ErrInsufficientLoanToValue = sdkerrors.Register(ModuleName, 18, "total deposited value is insufficient for borrow request")
+	ErrInsufficientLoanToValue = sdkerrors.Register(ModuleName, 18, "not enough collateral supplied by account")
 	// ErrMarketNotFound error for when a market for the input denom is not found
 	ErrMarketNotFound = sdkerrors.Register(ModuleName, 19, "no market found for denom")
 	// ErrPriceNotFound error for when a price for the input market is not found


### PR DESCRIPTION
Updates the error text of `ErrInsufficientLoanToValue`.

For some reason, the borrow tests are failing locally for me (everything's passing as if there was no validation). Since the same tests are working on branch `dm-harvest-interest-rate-model` which includes a lot of changes I'm holding this PR as a draft until that one is merged in so I can rebase this onto the most up-to-date version of the codebase.