### PR TITLE
Hard: repay insufficient balance error

### DIFF
--- a/x/harvest/keeper/repay.go
+++ b/x/harvest/keeper/repay.go
@@ -45,8 +45,10 @@ func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) e
 func (k Keeper) ValidateRepay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) error {
 	senderAcc := k.accountKeeper.GetAccount(ctx, sender)
 	senderCoins := senderAcc.GetCoins()
-	if coins.IsAnyGT(senderCoins) {
-		return sdkerrors.Wrapf(types.ErrInsufficientBalanceForRepay, "account can only repay up to %s", senderCoins)
+	for _, coin := range coins {
+		if senderCoins.AmountOf(coin.Denom).LT(coin.Amount) {
+			return sdkerrors.Wrapf(types.ErrInsufficientBalanceForRepay, "account can only repay up to %s%s", senderCoins.AmountOf(coin.Denom), coin.Denom)
+		}
 	}
 
 	borrow, found := k.GetBorrow(ctx, sender)

--- a/x/harvest/keeper/repay.go
+++ b/x/harvest/keeper/repay.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/kava-labs/kava/x/harvest/types"
 )
@@ -42,6 +43,12 @@ func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) e
 
 // ValidateRepay validates a requested loan repay
 func (k Keeper) ValidateRepay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) error {
+	senderAcc := k.accountKeeper.GetAccount(ctx, sender)
+	senderCoins := senderAcc.GetCoins()
+	if coins.IsAnyGT(senderCoins) {
+		return sdkerrors.Wrapf(types.ErrInsufficientBalanceForRepay, "account can only repay up to %s", senderCoins)
+	}
+
 	borrow, found := k.GetBorrow(ctx, sender)
 	if !found {
 		return types.ErrBorrowNotFound

--- a/x/harvest/keeper/repay_test.go
+++ b/x/harvest/keeper/repay_test.go
@@ -69,14 +69,29 @@ func (suite *KeeperTestSuite) TestRepay() {
 			},
 		},
 		{
-			"invalid: overpaid debt",
+			"invalid: insufficent balance for repay",
 			args{
 				borrower:             sdk.AccAddress(crypto.AddressHash([]byte("test"))),
 				initialBorrowerCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))),
 				initialModuleCoins:   sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000*KAVA_CF)), sdk.NewCoin("usdx", sdk.NewInt(1000*USDX_CF))),
 				depositCoins:         []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))},
 				borrowCoins:          sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))),
-				repayCoins:           sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(60*KAVA_CF))),
+				repayCoins:           sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(51*KAVA_CF))), // Exceeds user's KAVA balance
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "account can only repay up to",
+			},
+		},
+		{
+			"invalid: overpaid debt",
+			args{
+				borrower:             sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				initialBorrowerCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))),
+				initialModuleCoins:   sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000*KAVA_CF)), sdk.NewCoin("usdx", sdk.NewInt(1000*USDX_CF))),
+				depositCoins:         []sdk.Coin{sdk.NewCoin("ukava", sdk.NewInt(80*KAVA_CF))}, // Deposit less so user still has some KAVA
+				borrowCoins:          sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))),
+				repayCoins:           sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(60*KAVA_CF))), // Exceeds borrowed coins but not user's balance
 			},
 			errArgs{
 				expectPass: false,

--- a/x/harvest/types/errors.go
+++ b/x/harvest/types/errors.go
@@ -59,4 +59,6 @@ var (
 	ErrBorrowNotFound = sdkerrors.Register(ModuleName, 26, "borrow not found")
 	// ErrDebtOverpaid error for when a user attempts to overpay their loan's amount
 	ErrDebtOverpaid = sdkerrors.Register(ModuleName, 27, "repayment exceeds loan debt")
+	// ErrInsufficientBalanceForRepay error for when requested repay exceeds user's balance
+	ErrInsufficientBalanceForRepay = sdkerrors.Register(ModuleName, 28, "insufficient balance")
 )


### PR DESCRIPTION
Implement repay error message: "Insufficient balance: account can only repay up to [coin]". Funky coin/iteration and amount check instead of using `sdk.Coins.GT(...)` as it doesn't tell us which coin failed validation. Check the difference between the two commits in this PR to see what I'm referring to.

This PR is **BLOCKED** by https://github.com/Kava-Labs/kava/pull/725. The blocked tag will be removed once https://github.com/Kava-Labs/kava/pull/725 is merged and this PR's base branch will be updated to master.