### PR TITLE
CDP begin blocker optimization 1

### DIFF
--- a/x/cdp/abci_test.go
+++ b/x/cdp/abci_test.go
@@ -185,7 +185,7 @@ func BenchmarkBeginBlocker(b *testing.B) {
 
 	b.ResetTimer() // don't count the expensive cdp creation in the benchmark
 	for n := 0; n < b.N; n++ {
-		// Use a copy of the store in the begin blocker to discard any writes and avoid sequential runs interfering.
+		// Use a copy of the store in the begin blocker to discard any writes and avoid loop iterations interfering.
 		// Exclude this operation from the benchmark time
 		b.StopTimer()
 		cacheCtx, _ := ctx.CacheContext()

--- a/x/cdp/integration_test.go
+++ b/x/cdp/integration_test.go
@@ -106,7 +106,7 @@ func NewPricefeedGenStateMulti() app.GenesisState {
 func NewCDPGenStateMulti() app.GenesisState {
 	cdpGenesis := cdp.GenesisState{
 		Params: cdp.Params{
-			GlobalDebtLimit:              sdk.NewInt64Coin("usdx", 1000000000000),
+			GlobalDebtLimit:              sdk.NewInt64Coin("usdx", 10_000_000_000_000),
 			SurplusAuctionThreshold:      cdp.DefaultSurplusThreshold,
 			SurplusAuctionLot:            cdp.DefaultSurplusLot,
 			DebtAuctionThreshold:         cdp.DefaultDebtThreshold,
@@ -117,7 +117,7 @@ func NewCDPGenStateMulti() app.GenesisState {
 					Denom:               "xrp",
 					Type:                "xrp-a",
 					LiquidationRatio:    sdk.MustNewDecFromStr("2.0"),
-					DebtLimit:           sdk.NewInt64Coin("usdx", 500000000000),
+					DebtLimit:           sdk.NewInt64Coin("usdx", 5_000_000_000_000),
 					StabilityFee:        sdk.MustNewDecFromStr("1.000000001547125958"), // %5 apr
 					LiquidationPenalty:  d("0.05"),
 					AuctionSize:         i(7000000000),
@@ -130,7 +130,7 @@ func NewCDPGenStateMulti() app.GenesisState {
 					Denom:               "btc",
 					Type:                "btc-a",
 					LiquidationRatio:    sdk.MustNewDecFromStr("1.5"),
-					DebtLimit:           sdk.NewInt64Coin("usdx", 500000000000),
+					DebtLimit:           sdk.NewInt64Coin("usdx", 5_000_000_000_000),
 					StabilityFee:        sdk.MustNewDecFromStr("1.000000000782997609"), // %2.5 apr
 					LiquidationPenalty:  d("0.025"),
 					AuctionSize:         i(10000000),

--- a/x/cdp/keeper/fees.go
+++ b/x/cdp/keeper/fees.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/kava-labs/kava/x/cdp/types"
 )
@@ -33,10 +34,10 @@ func (k Keeper) UpdateFeesForAllCdps(ctx sdk.Context, collateralType string) err
 	var iterationErr error
 
 	// Load params outside the loop to speed up iterations.
-	// This is safe to do as params should be constant throughout the cdp begin blocker.
+	// This is safe as long as params are not updated during the loop.
 	collateralParam, found := k.GetCollateral(ctx, collateralType)
 	if !found {
-		panic("no collateral params")
+		return sdkerrors.Wrap(types.ErrCollateralNotSupported, collateralType)
 	}
 	debtParam := k.GetParams(ctx).DebtParam
 	feePerSecond := k.getFeeRate(ctx, collateralType)

--- a/x/cdp/keeper/fees.go
+++ b/x/cdp/keeper/fees.go
@@ -12,10 +12,14 @@ import (
 // CalculateFees returns the fees accumulated since fees were last calculated based on
 // the input amount of outstanding debt (principal) and the number of periods (seconds) that have passed
 func (k Keeper) CalculateFees(ctx sdk.Context, principal sdk.Coin, periods sdk.Int, collateralType string) sdk.Coin {
+	feePerSecond := k.getFeeRate(ctx, collateralType)
+	return calculateFees(principal, periods, feePerSecond)
+}
+
+func calculateFees(principal sdk.Coin, periods sdk.Int, feePerSecond sdk.Dec) sdk.Coin {
 	// how fees are calculated:
 	// feesAccumulated = (outstandingDebt * (feeRate^periods)) - outstandingDebt
 	// Note that since we can't do x^y using sdk.Decimal, we are converting to int and using RelativePow
-	feePerSecond := k.getFeeRate(ctx, collateralType)
 	scalar := sdk.NewInt(1000000000000000000)
 	feeRateInt := feePerSecond.Mul(sdk.NewDecFromInt(scalar)).TruncateInt()
 	accumulator := sdk.NewDecFromInt(types.RelativePow(feeRateInt, periods, scalar)).Mul(sdk.SmallestDec())
@@ -27,12 +31,22 @@ func (k Keeper) CalculateFees(ctx sdk.Context, principal sdk.Coin, periods sdk.I
 // UpdateFeesForAllCdps updates the fees for each of the CDPs
 func (k Keeper) UpdateFeesForAllCdps(ctx sdk.Context, collateralType string) error {
 	var iterationErr error
+
+	// Load params outside the loop to speed up iterations.
+	// This is safe to do as params should be constant throughout the cdp begin blocker.
+	collateralParam, found := k.GetCollateral(ctx, collateralType)
+	if !found {
+		panic("no collateral params")
+	}
+	debtParam := k.GetParams(ctx).DebtParam
+	feePerSecond := k.getFeeRate(ctx, collateralType)
+
 	k.IterateCdpsByCollateralType(ctx, collateralType, func(cdp types.CDP) bool {
-		oldCollateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Type, cdp.GetTotalPrincipal())
-		// periods = bblock timestamp - fees updated
+		oldCollateralToDebtRatio := calculateCollateralToDebtRatio(cdp.Collateral, collateralParam, cdp.GetTotalPrincipal(), debtParam)
+		// periods = block timestamp - fees updated
 		periods := sdk.NewInt(ctx.BlockTime().Unix()).Sub(sdk.NewInt(cdp.FeesUpdated.Unix()))
 
-		newFees := k.CalculateFees(ctx, cdp.Principal, periods, collateralType)
+		newFees := calculateFees(cdp.Principal, periods, feePerSecond)
 
 		// exit without updating fees if amount has rounded down to zero
 		// cdp will get updated next block when newFees, newFeesSavings, newFeesSurplus >0
@@ -86,7 +100,7 @@ func (k Keeper) UpdateFeesForAllCdps(ctx sdk.Context, collateralType string) err
 
 		// and set the fees updated time to the current block time since we just updated it
 		cdp.FeesUpdated = ctx.BlockTime()
-		collateralToDebtRatio := k.CalculateCollateralToDebtRatio(ctx, cdp.Collateral, cdp.Type, cdp.GetTotalPrincipal())
+		collateralToDebtRatio := calculateCollateralToDebtRatio(cdp.Collateral, collateralParam, cdp.GetTotalPrincipal(), debtParam)
 		k.RemoveCdpCollateralRatioIndex(ctx, cdp.Type, cdp.ID, oldCollateralToDebtRatio)
 		err = k.SetCdpAndCollateralRatioIndex(ctx, cdp, collateralToDebtRatio)
 		if err != nil {


### PR DESCRIPTION
This PR makes non breaking changes to the cdp BeginBlocker to increase speed.

Running the go profiler on the begin blocker showed a large portion of time was spent unmarshaling the cdp params.
They were being unmarshalled twice in `k.CalculateCollateralToDebtRatio` and once in `k.CalculateFees`.
However the param values should never change during the begin blocker. This PR refactors the code to read the params at the start of the loop and then reference those unmarshalled values within the loop.


Benchmark results running locally (with 2000 cdps):

    BenchmarkBeginBlocker-4                2        1737453770 ns/op
    BenchmarkBeginBlocker-4                2         760821978 ns/op
    BenchmarkBeginBlocker-4                1        1028420038 ns/op
    BenchmarkBeginBlocker-4                1        1178868937 ns/op
    BenchmarkBeginBlocker-4                1        1043643995 ns/op

average: 1.149841744 s

    BenchmarkBeginBlocker-4               28          45595337 ns/op
    BenchmarkBeginBlocker-4               26          44801298 ns/op
    BenchmarkBeginBlocker-4               25          42354691 ns/op
    BenchmarkBeginBlocker-4               27          42985697 ns/op
    BenchmarkBeginBlocker-4               27          54006477 ns/op
    BenchmarkBeginBlocker-4               18          64251118 ns/op
    BenchmarkBeginBlocker-4               31          39956663 ns/op

average: 0.047707326s

Recent profiling on mainnet showed the cdp begin blocker took 2.2s, harvest 0.8s, other modules combined < 0.2s.