### PR TITLE
Hard: LTV index refactor

### DIFF
--- a/x/hard/handler.go
+++ b/x/hard/handler.go
@@ -124,7 +124,7 @@ func handleMsgRepay(ctx sdk.Context, k keeper.Keeper, msg types.MsgRepay) (*sdk.
 }
 
 func handleMsgLiquidate(ctx sdk.Context, k keeper.Keeper, msg types.MsgLiquidate) (*sdk.Result, error) {
-	_, err := k.AttemptKeeperLiquidation(ctx, msg.Keeper, msg.Borrower)
+	err := k.AttemptKeeperLiquidation(ctx, msg.Keeper, msg.Borrower)
 	if err != nil {
 		return nil, err
 	}

--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -87,12 +87,12 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 
 	// Construct the user's new/updated borrow with amount and interest factors
 	borrow := types.NewBorrow(borrower, amount, borrowInterestFactors)
-	// Fetch the user's deposit from the store
+
+	// Calculate the new Loan-to-Value ratio of Deposit-to-Borrow
 	deposit, foundDeposit := k.GetDeposit(ctx, borrower)
 	if !foundDeposit {
 		return types.ErrDepositNotFound
 	}
-	// Calculate the new Loan-to-Value ratio of Deposit-to-Borrow
 	newLtv, err := k.CalculateLtv(ctx, deposit, borrow)
 	if err != nil {
 		return err

--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -23,7 +23,7 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 	}
 
 	// Get current stored LTV based on stored borrows/deposits
-	prevLtv, shouldRemoveIndex, err := k.GetStoreLTV(ctx, borrower)
+	prevLtv, err := k.GetStoreLTV(ctx, borrower)
 	if err != nil {
 		return err
 	}
@@ -85,11 +85,20 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 		amount = coins
 	}
 
-	// Update the borrower's amount and borrow interest factors in the store
+	// Construct the user's new/updated borrow with amount and interest factors
 	borrow := types.NewBorrow(borrower, amount, borrowInterestFactors)
-	k.SetBorrow(ctx, borrow)
+	// Fetch the user's deposit from the store
+	deposit, foundDeposit := k.GetDeposit(ctx, borrower)
+	if !foundDeposit {
+		return types.ErrDepositNotFound
+	}
+	// Calculate the new Loan-to-Value ratio of Deposit-to-Borrow
+	newLtv, err := k.CalculateLtv(ctx, deposit, borrow)
+	if err != nil {
+		return err
+	}
 
-	k.UpdateItemInLtvIndex(ctx, prevLtv, shouldRemoveIndex, borrower)
+	k.UpdateBorrowAndLtvIndex(ctx, borrow, newLtv, prevLtv)
 
 	// Update total borrowed amount by newly borrowed coins. Don't add user's pending interest as
 	// it has already been included in the total borrowed coins by the BeginBlocker.

--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -24,7 +24,7 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 	}
 
 	// Get current stored LTV based on stored borrows/deposits
-	prevLtv, shouldRemoveIndex, err := k.GetStoreLTV(ctx, depositor)
+	prevLtv, err := k.GetStoreLTV(ctx, depositor)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 	deposit := types.NewDeposit(depositor, amount, supplyInterestFactors)
 	k.SetDeposit(ctx, deposit)
 
-	k.UpdateItemInLtvIndex(ctx, prevLtv, shouldRemoveIndex, depositor)
+	k.UpdateItemInLtvIndex(ctx, prevLtv, depositor)
 
 	// Update total supplied amount by newly supplied coins. Don't add user's pending interest as
 	// it has already been included in the total supplied coins by the BeginBlocker.

--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -87,12 +87,17 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 	} else {
 		amount = coins
 	}
-
 	// Update the depositer's amount and supply interest factors in the store
 	deposit := types.NewDeposit(depositor, amount, supplyInterestFactors)
-	k.SetDeposit(ctx, deposit)
 
-	k.UpdateItemInLtvIndex(ctx, prevLtv, depositor)
+	// Calculate the new Loan-to-Value ratio of Deposit-to-Borrow
+	borrow, _ := k.GetBorrow(ctx, depositor)
+	newLtv, err := k.CalculateLtv(ctx, deposit, borrow)
+	if err != nil {
+		return err
+	}
+
+	k.UpdateDepositAndLtvIndex(ctx, deposit, newLtv, prevLtv)
 
 	// Update total supplied amount by newly supplied coins. Don't add user's pending interest as
 	// it has already been included in the total supplied coins by the BeginBlocker.

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -24,7 +24,7 @@ func (k Keeper) AttemptIndexLiquidations(ctx sdk.Context) error {
 	for _, borrower := range borrowers {
 		err := k.AttemptKeeperLiquidation(ctx, sdk.AccAddress(types.LiquidatorAccount), borrower)
 		if err != nil {
-			if !errors.Is(err, types.ErrBorrowNotLiquidatable) {
+			if !errors.Is(err, types.ErrBorrowNotLiquidatable) && !errors.Is(err, types.ErrBorrowNotFound) {
 				panic(err)
 			}
 		}

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -274,7 +274,7 @@ func (k Keeper) IsWithinValidLtvRange(ctx sdk.Context, deposit types.Deposit, bo
 	return true, nil
 }
 
-// UpdateBorrowAndLtvIndex updates a borrow and it's LTV index value in the store
+// UpdateBorrowAndLtvIndex updates a borrow and its LTV index value in the store
 func (k Keeper) UpdateBorrowAndLtvIndex(ctx sdk.Context, borrow types.Borrow, newLtv, oldLtv sdk.Dec) {
 	k.RemoveFromLtvIndex(ctx, oldLtv, borrow.Borrower)
 	k.SetBorrow(ctx, borrow)
@@ -287,12 +287,32 @@ func (k Keeper) DeleteBorrowAndLtvIndex(ctx sdk.Context, borrow types.Borrow, ol
 	k.DeleteBorrow(ctx, borrow)
 }
 
-// SetBorrowAndLtvIndex sets a borrow and current LTV index value in the store
+// SetBorrowAndLtvIndex sets a borrow and its current LTV index value in the store
 func (k Keeper) SetBorrowAndLtvIndex(ctx sdk.Context, borrow types.Borrow, newLtv sdk.Dec) {
 	k.SetBorrow(ctx, borrow)
 	k.InsertIntoLtvIndex(ctx, newLtv, borrow.Borrower)
 }
 
+// UpdateDepositAndLtvIndex updates a deposit and its LTV index value in the store
+func (k Keeper) UpdateDepositAndLtvIndex(ctx sdk.Context, deposit types.Deposit, newLtv, oldLtv sdk.Dec) {
+	k.RemoveFromLtvIndex(ctx, oldLtv, deposit.Depositor)
+	k.SetDeposit(ctx, deposit)
+	k.InsertIntoLtvIndex(ctx, newLtv, deposit.Depositor)
+}
+
+// DeleteDepositAndLtvIndex deletes an existing deposit in the store and removes its old LTV index value
+func (k Keeper) DeleteDepositAndLtvIndex(ctx sdk.Context, deposit types.Deposit, oldLtv sdk.Dec) {
+	k.RemoveFromLtvIndex(ctx, oldLtv, deposit.Depositor)
+	k.DeleteDeposit(ctx, deposit)
+}
+
+// SetDepositAndLtvIndex sets a deposit and its current LTV index value in the store
+func (k Keeper) SetDepositAndLtvIndex(ctx sdk.Context, deposit types.Deposit, newLtv sdk.Dec) {
+	k.SetDeposit(ctx, deposit)
+	k.InsertIntoLtvIndex(ctx, newLtv, deposit.Depositor)
+}
+
+// TODO: remove
 // UpdateItemInLtvIndex updates the key a borrower's address is stored under in the LTV index
 func (k Keeper) UpdateItemInLtvIndex(ctx sdk.Context, prevLtv sdk.Dec, borrower sdk.AccAddress) error {
 	currLtv, err := k.GetStoreLTV(ctx, borrower)

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -25,7 +25,7 @@ func (k Keeper) AttemptIndexLiquidations(ctx sdk.Context) error {
 		err := k.AttemptKeeperLiquidation(ctx, sdk.AccAddress(types.LiquidatorAccount), borrower)
 		if err != nil {
 			if !errors.Is(err, types.ErrBorrowNotLiquidatable) {
-				panic(err) // TODO: if the system only has deposits (no borrows) will this panic?
+				panic(err)
 			}
 		}
 	}
@@ -39,7 +39,6 @@ func (k Keeper) AttemptKeeperLiquidation(ctx sdk.Context, keeper sdk.AccAddress,
 		return err
 	}
 
-	// k.SyncSupplyInterest(ctx, borrower) // TODO: must add
 	k.SyncBorrowInterest(ctx, borrower)
 
 	deposit, found := k.GetDeposit(ctx, borrower)

--- a/x/hard/keeper/liquidation_test.go
+++ b/x/hard/keeper/liquidation_test.go
@@ -1358,9 +1358,8 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 			suite.Require().True(foundDepositBefore)
 
 			// Attempt to liquidate
-			liquidated, err := suite.keeper.AttemptKeeperLiquidation(liqCtx, tc.args.keeper, tc.args.borrower)
+			err = suite.keeper.AttemptKeeperLiquidation(liqCtx, tc.args.keeper, tc.args.borrower)
 			if tc.errArgs.expectPass {
-				suite.Require().True(liquidated)
 				suite.Require().NoError(err)
 
 				// Check borrow does not exist after liquidation
@@ -1383,7 +1382,6 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 				suite.Require().True(len(auctions) > 0)
 				suite.Require().Equal(tc.args.expectedAuctions, auctions)
 			} else {
-				suite.Require().False(liquidated)
 				suite.Require().Error(err)
 				suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
 

--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -10,7 +10,7 @@ import (
 // Repay borrowed funds
 func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) error {
 	// Get current stored LTV based on stored borrows/deposits
-	prevLtv, shouldRemoveIndex, err := k.GetStoreLTV(ctx, sender)
+	prevLtv, err := k.GetStoreLTV(ctx, sender)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) e
 	borrow.Amount = borrow.Amount.Sub(payment)
 	k.SetBorrow(ctx, borrow)
 
-	k.UpdateItemInLtvIndex(ctx, prevLtv, shouldRemoveIndex, sender)
+	k.UpdateItemInLtvIndex(ctx, prevLtv, sender)
 
 	// Update total borrowed amount
 	k.DecrementBorrowedCoins(ctx, payment)

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -10,7 +10,7 @@ import (
 // Withdraw returns some or all of a deposit back to original depositor
 func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coins) error {
 	// Get current stored LTV based on stored borrows/deposits
-	prevLtv, shouldRemoveIndex, err := k.GetStoreLTV(ctx, depositor)
+	prevLtv, err := k.GetStoreLTV(ctx, depositor)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 	deposit.Amount = deposit.Amount.Sub(amount)
 	k.SetDeposit(ctx, deposit)
 
-	k.UpdateItemInLtvIndex(ctx, prevLtv, shouldRemoveIndex, depositor)
+	k.UpdateItemInLtvIndex(ctx, prevLtv, depositor)
 
 	// Update total supplied amount
 	k.DecrementBorrowedCoins(ctx, amount)


### PR DESCRIPTION
Goal: Breakout Set/Update/Delete as separate functions for the LTV index.

The Hard LTV index is different than the CDP index as it's based upon two store objects (Borrow, Deposit) which can be updated individually as opposed to just one object (CDP), so the resulting implementation is not 1:1 with the goal. The methods added are:
- UpdateBorrowAndLtvIndex
- UpdateDepositAndLtvIndex
- DeleteDepositBorrowAndLtvIndex

Noticed some potential issues with attempted keeper liquidations that I created Asana cards for.