### PR TITLE
Supply-side interest acceptance criteria

### DIFF
--- a/x/hard/client/rest/query.go
+++ b/x/hard/client/rest/query.go
@@ -73,7 +73,7 @@ func queryDepositsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			}
 		}
 
-		params := types.NewQueryDepositParams(page, limit, depositDenom, depositOwner)
+		params := types.NewQueryDepositsParams(page, limit, depositDenom, depositOwner)
 
 		bz, err := cliCtx.Codec.MarshalJSON(params)
 		if err != nil {

--- a/x/hard/keeper/querier.go
+++ b/x/hard/keeper/querier.go
@@ -22,6 +22,8 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryGetModAccounts(ctx, req, k)
 		case types.QueryGetDeposits:
 			return queryGetDeposits(ctx, req, k)
+		case types.QueryGetDeposit:
+			return queryGetDeposit(ctx, req, k)
 		case types.QueryGetClaims:
 			return queryGetClaims(ctx, req, k)
 		case types.QueryGetBorrows:
@@ -79,7 +81,7 @@ func queryGetModAccounts(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]by
 
 func queryGetDeposits(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
 
-	var params types.QueryDepositParams
+	var params types.QueryDepositsParams
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
@@ -239,7 +241,6 @@ func queryGetClaims(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, e
 }
 
 func queryGetBorrows(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
-
 	var params types.QueryBorrowsParams
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
@@ -309,6 +310,26 @@ func queryGetBorrow(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, e
 	}
 
 	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, borrowBalance)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+
+	return bz, nil
+}
+
+func queryGetDeposit(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, error) {
+	var params types.QueryDepositParams
+	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+
+	var supplyBalance sdk.Coins
+	if len(params.Owner) > 0 {
+		supplyBalance = k.GetSupplyBalance(ctx, params.Owner)
+	}
+
+	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, supplyBalance)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/hard/types/querier.go
+++ b/x/hard/types/querier.go
@@ -9,6 +9,7 @@ const (
 	QueryGetParams         = "params"
 	QueryGetModuleAccounts = "accounts"
 	QueryGetDeposits       = "deposits"
+	QueryGetDeposit        = "deposit"
 	QueryGetClaims         = "claims"
 	QueryGetBorrows        = "borrows"
 	QueryGetBorrowed       = "borrowed"
@@ -17,15 +18,27 @@ const (
 
 // QueryDepositParams is the params for a filtered deposit query
 type QueryDepositParams struct {
+	Owner sdk.AccAddress `json:"owner" yaml:"owner"`
+}
+
+// NewQueryDepositParams creates a new QueryDepositParams
+func NewQueryDepositParams(owner sdk.AccAddress) QueryDepositParams {
+	return QueryDepositParams{
+		Owner: owner,
+	}
+}
+
+// QueryDepositsParams is the params for a filtered deposit query
+type QueryDepositsParams struct {
 	Page         int            `json:"page" yaml:"page"`
 	Limit        int            `json:"limit" yaml:"limit"`
 	DepositDenom string         `json:"deposit_denom" yaml:"deposit_denom"`
 	Owner        sdk.AccAddress `json:"owner" yaml:"owner"`
 }
 
-// NewQueryDepositParams creates a new QueryDepositParams
-func NewQueryDepositParams(page, limit int, depositDenom string, owner sdk.AccAddress) QueryDepositParams {
-	return QueryDepositParams{
+// NewQueryDepositsParams creates a new QueryDepositsParams
+func NewQueryDepositsParams(page, limit int, depositDenom string, owner sdk.AccAddress) QueryDepositsParams {
+	return QueryDepositsParams{
 		Page:         page,
 		Limit:        limit,
 		DepositDenom: depositDenom,


### PR DESCRIPTION
This PR is required for acceptance of the supply-side interest task.

It adds a querier for a user's deposit balance that includes outstanding supply interest. This will be refactored in the same way as borrows/borrow queries and is a short term solution to move the task through acceptance.