### PR TITLE
Hard: investigate sdk.RelativePow runtime panic 

### DIFF
--- a/x/hard/keeper/interest_test.go
+++ b/x/hard/keeper/interest_test.go
@@ -289,14 +289,20 @@ func (suite *InterestTestSuite) TestCalculateBorrowInterestFactor() {
 				expectedValue:         sdk.MustNewDecFromStr("40628388.864535408465693310"),
 			},
 		},
-		// If we raise the per second interest rate too much we'll cause an integer overflow.
-		// For example, perSecondInterestRate: '1.000005555555' will cause a panic.
 		{
 			"1 year: highest interest rate",
 			args{
 				perSecondInterestRate: sdk.MustNewDecFromStr("1.000001555555"),
 				timeElapsed:           sdk.NewInt(oneYearInSeconds),
 				expectedValue:         sdk.MustNewDecFromStr("2017093013158200407564.613502861572552603"),
+			},
+		},
+		{
+			"largest per second interest rate with practical elapsed time",
+			args{
+				perSecondInterestRate: sdk.MustNewDecFromStr("18.445"), // Begins to panic at ~18.45 (1845%/second interest rate)
+				timeElapsed:           sdk.NewInt(30),
+				expectedValue:         sdk.MustNewDecFromStr("94702138679846565921082258202543002089.215969366091911769"),
 			},
 		},
 	}

--- a/x/hard/keeper/interest_test.go
+++ b/x/hard/keeper/interest_test.go
@@ -301,7 +301,7 @@ func (suite *InterestTestSuite) TestCalculateBorrowInterestFactor() {
 			"largest per second interest rate with practical elapsed time",
 			args{
 				perSecondInterestRate: sdk.MustNewDecFromStr("18.445"), // Begins to panic at ~18.45 (1845%/second interest rate)
-				timeElapsed:           sdk.NewInt(30),
+				timeElapsed:           sdk.NewInt(30),                  // Assume a 30 second period, longer than any expected individual block
 				expectedValue:         sdk.MustNewDecFromStr("94702138679846565921082258202543002089.215969366091911769"),
 			},
 		},


### PR DESCRIPTION
### Goal
Determine if `sdk.RelativePow` in the Hard module can panic during runtime. This PR addresses issue https://github.com/Kava-Labs/kava/issues/727. This PR does **not** address the incorrect values returned by `sdk.RelativePow` at the upper-bound as described [here](https://github.com/Kava-Labs/kava/pull/737#issuecomment-745426776).

### Findings
Due to proper param validation, the use of `sdk.RelativePow` in the Hard module cannot panic during runtime. 

### Investigation
The CalculateBorrowInterestFactor function calls `sdk.RelativePow`, which can panic due to integer overflow. CalculateBorrowInterestFactor is only called by AccrueInterest, which in turn is only called by the begin blocker. Assuming a max block time is 30 seconds, `sdk.RelativePow` begins to overflow at a per second interest rate of ~1845%/second (see test in changed files).

The per second interest rate argument to CalculateBorrowInterestFactor is output by the APYToSPY function. The APYToSPY function takes `MoneyMarket.InterestRateModel.BaseRateAPY` as a parameter and panics itself if the `BaseRateAPY` argument is above 177. Inputting a `BaseRateAPY` of 177 to the APYToSPY function is valid and returns 1.000002441641340532, well within the valid range of CalculateBorrowInterestFactor. So the APYToSPY function is our new constraint.

The InterestRateModel param's Validate function limits the max `BaseRateAPY` to 1.0, so APYToSPY will never panic or output a result that causes CalculateBorrowInterestFactor's `sdk.RelativePow` to panic during runtime.