### PR TITLE
Add usdx incentives calculation test

### DIFF
--- a/x/incentive/keeper/rewards_test.go
+++ b/x/incentive/keeper/rewards_test.go
@@ -230,7 +230,6 @@ func TestRewardCalculation(t *testing.T) {
 		NewCDPGenStateHighInterest(),
 		NewIncentiveGenState(initialTime, initialTime.Add(oneYear), rewardPeriod),
 	)
-	fmt.Println("RUN INIT GENESIS")
 
 	// Create a CDP
 	cdpKeeper := tApp.GetCDPKeeper()

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -17,9 +17,9 @@ type SupplyKeeper interface {
 
 // CdpKeeper defines the expected cdp keeper for interacting with cdps
 type CdpKeeper interface {
-	IterateCdpsByCollateralType(ctx sdk.Context, collateralType string, cb func(cdp cdptypes.CDP) (stop bool))
 	GetTotalPrincipal(ctx sdk.Context, collateralType string, principalDenom string) (total sdk.Int)
 	GetCdpByOwnerAndCollateralType(ctx sdk.Context, owner sdk.AccAddress, collateralType string) (cdptypes.CDP, bool)
+	GetInterestFactor(ctx sdk.Context, collateralType string) (sdk.Dec, bool)
 }
 
 // AccountKeeper defines the expected keeper interface for interacting with account


### PR DESCRIPTION
This PR adds an `incentive` test to compares cdp rewards calculated using previous style (updated every block) to the current style (using rewardFactors).

The difference is noticable if the interest rate on the cdp is high enough. The test uses 500% APR, and 10 super long blocks (in total covering 1/5th of a year to get to large accumulated fees).

The second commit adds the expected calculation fix and the numbers get much closer, but not exact. I expect it's due to rounding somewhere but haven't tracked it down.

Optional TODOs
- why did the exising tests still pass when the calculation was changed?
- use `Suite` in the new test to keep style the same