### PR TITLE
Hard: delete borrow/deposit from store on 0 amount

### DIFF
--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -270,9 +270,9 @@ func (k Keeper) UpdateBorrowAndLtvIndex(ctx sdk.Context, borrow types.Borrow, ne
 	k.RemoveFromLtvIndex(ctx, oldLtv, borrow.Borrower)
 	if borrow.Amount.Empty() {
 		k.DeleteBorrow(ctx, borrow)
-	} else {
-		k.SetBorrow(ctx, borrow)
+		return
 	}
+	k.SetBorrow(ctx, borrow)
 	k.InsertIntoLtvIndex(ctx, newLtv, borrow.Borrower)
 }
 
@@ -281,9 +281,9 @@ func (k Keeper) UpdateDepositAndLtvIndex(ctx sdk.Context, deposit types.Deposit,
 	k.RemoveFromLtvIndex(ctx, oldLtv, deposit.Depositor)
 	if deposit.Amount.Empty() {
 		k.DeleteDeposit(ctx, deposit)
-	} else {
-		k.SetDeposit(ctx, deposit)
+		return
 	}
+	k.SetDeposit(ctx, deposit)
 	k.InsertIntoLtvIndex(ctx, newLtv, deposit.Depositor)
 }
 

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -268,14 +268,22 @@ func (k Keeper) IsWithinValidLtvRange(ctx sdk.Context, deposit types.Deposit, bo
 // UpdateBorrowAndLtvIndex updates a borrow and its LTV index value in the store
 func (k Keeper) UpdateBorrowAndLtvIndex(ctx sdk.Context, borrow types.Borrow, newLtv, oldLtv sdk.Dec) {
 	k.RemoveFromLtvIndex(ctx, oldLtv, borrow.Borrower)
-	k.SetBorrow(ctx, borrow)
+	if borrow.Amount.Empty() {
+		k.DeleteBorrow(ctx, borrow)
+	} else {
+		k.SetBorrow(ctx, borrow)
+	}
 	k.InsertIntoLtvIndex(ctx, newLtv, borrow.Borrower)
 }
 
 // UpdateDepositAndLtvIndex updates a deposit and its LTV index value in the store
 func (k Keeper) UpdateDepositAndLtvIndex(ctx sdk.Context, deposit types.Deposit, newLtv, oldLtv sdk.Dec) {
 	k.RemoveFromLtvIndex(ctx, oldLtv, deposit.Depositor)
-	k.SetDeposit(ctx, deposit)
+	if deposit.Amount.Empty() {
+		k.DeleteDeposit(ctx, deposit)
+	} else {
+		k.SetDeposit(ctx, deposit)
+	}
 	k.InsertIntoLtvIndex(ctx, newLtv, deposit.Depositor)
 }
 

--- a/x/hard/keeper/withdraw_test.go
+++ b/x/hard/keeper/withdraw_test.go
@@ -24,12 +24,12 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 		createDeposit             bool
 		expectedAccountBalance    sdk.Coins
 		expectedModAccountBalance sdk.Coins
-		depositExists             bool
 		finalDepositAmount        sdk.Coins
 	}
 	type errArgs struct {
-		expectPass bool
-		contains   string
+		expectPass   bool
+		expectDelete bool
+		contains     string
 	}
 	type withdrawTest struct {
 		name    string
@@ -47,12 +47,12 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				createDeposit:             true,
 				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(900)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(100))),
-				depositExists:             true,
 				finalDepositAmount:        sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(100))),
 			},
 			errArgs{
-				expectPass: true,
-				contains:   "",
+				expectPass:   true,
+				expectDelete: false,
+				contains:     "",
 			},
 		},
 		{
@@ -65,12 +65,12 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				createDeposit:             true,
 				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 				expectedModAccountBalance: sdk.Coins(nil),
-				depositExists:             false,
 				finalDepositAmount:        sdk.Coins{},
 			},
 			errArgs{
-				expectPass: true,
-				contains:   "",
+				expectPass:   true,
+				expectDelete: true,
+				contains:     "",
 			},
 		},
 		{
@@ -83,12 +83,12 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				createDeposit:             true,
 				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000)), sdk.NewCoin("btcb", sdk.NewInt(1000))),
 				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1000))),
-				depositExists:             false,
 				finalDepositAmount:        sdk.Coins{},
 			},
 			errArgs{
-				expectPass: true,
-				contains:   "",
+				expectPass:   true,
+				expectDelete: true,
+				contains:     "",
 			},
 		},
 		{
@@ -101,12 +101,12 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				createDeposit:             true,
 				expectedAccountBalance:    sdk.Coins{},
 				expectedModAccountBalance: sdk.Coins{},
-				depositExists:             false,
 				finalDepositAmount:        sdk.Coins{},
 			},
 			errArgs{
-				expectPass: false,
-				contains:   "no coins of this type deposited",
+				expectPass:   false,
+				expectDelete: false,
+				contains:     "no coins of this type deposited",
 			},
 		},
 	}
@@ -198,11 +198,11 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 				mAcc := suite.getModuleAccount(types.ModuleAccountName)
 				suite.Require().Equal(tc.args.expectedModAccountBalance, mAcc.GetCoins())
 				testDeposit, f := suite.keeper.GetDeposit(suite.ctx, tc.args.depositor)
-				if tc.args.depositExists {
+				if tc.errArgs.expectDelete {
+					suite.Require().False(f)
+				} else {
 					suite.Require().True(f)
 					suite.Require().Equal(tc.args.finalDepositAmount, testDeposit.Amount)
-				} else {
-					suite.Require().False(f)
 				}
 			} else {
 				suite.Require().Error(err)


### PR DESCRIPTION
This bug was introduced by the LTV refactor. The tests were comparing empty coins (nil) to empty borrow amount (nil) and passing, which is why they didn't catch it. Updated the tests to be more explicit.

- Should the user be removed from the LTV index if their borrow is deleted from the store? 
- Should the user be removed from the LTV index if their deposit is deleted from the store? 