### PR TITLE
Incentive PR 4: claim Hard rewards via the Incentive module

### DIFF
--- a/x/incentive/alias.go
+++ b/x/incentive/alias.go
@@ -23,7 +23,8 @@ const (
 	ModuleName                 = types.ModuleName
 	QuerierRoute               = types.QuerierRoute
 	QueryGetClaimPeriods       = types.QueryGetClaimPeriods
-	QueryGetClaims             = types.QueryGetClaims
+	QueryGetCdpClaims          = types.QueryGetCdpClaims
+	QueryGetHardClaims         = types.QueryGetHardClaims
 	QueryGetParams             = types.QueryGetParams
 	QueryGetRewardPeriods      = types.QueryGetRewardPeriods
 	RestClaimCollateralType    = types.RestClaimCollateralType
@@ -47,7 +48,8 @@ var (
 	NewMultiplier                = types.NewMultiplier
 	NewParams                    = types.NewParams
 	NewPeriod                    = types.NewPeriod
-	NewQueryClaimsParams         = types.NewQueryClaimsParams
+	NewQueryCdpClaimsParams      = types.NewQueryCdpClaimsParams
+	NewQueryHardClaimsParams     = types.NewQueryHardClaimsParams
 	NewRewardIndex               = types.NewRewardIndex
 	NewRewardPeriod              = types.NewRewardPeriod
 	NewUSDXMintingClaim          = types.NewUSDXMintingClaim
@@ -99,7 +101,8 @@ type (
 	Multipliers               = types.Multipliers
 	Params                    = types.Params
 	PostClaimReq              = types.PostClaimReq
-	QueryClaimsParams         = types.QueryClaimsParams
+	QueryCdpClaimsParams      = types.QueryCdpClaimsParams
+	QueryHardClaimsParams     = types.QueryHardClaimsParams
 	RewardIndex               = types.RewardIndex
 	RewardIndexes             = types.RewardIndexes
 	RewardPeriod              = types.RewardPeriod

--- a/x/incentive/alias.go
+++ b/x/incentive/alias.go
@@ -36,25 +36,27 @@ const (
 
 var (
 	// function aliases
-	CalculateTimeElapsed         = keeper.CalculateTimeElapsed
-	NewKeeper                    = keeper.NewKeeper
-	NewQuerier                   = keeper.NewQuerier
-	DefaultGenesisState          = types.DefaultGenesisState
-	DefaultParams                = types.DefaultParams
-	GetTotalVestingPeriodLength  = types.GetTotalVestingPeriodLength
-	NewGenesisAccumulationTime   = types.NewGenesisAccumulationTime
-	NewGenesisState              = types.NewGenesisState
-	NewMsgClaimUSDXMintingReward = types.NewMsgClaimUSDXMintingReward
-	NewMultiplier                = types.NewMultiplier
-	NewParams                    = types.NewParams
-	NewPeriod                    = types.NewPeriod
-	NewQueryCdpClaimsParams      = types.NewQueryCdpClaimsParams
-	NewQueryHardClaimsParams     = types.NewQueryHardClaimsParams
-	NewRewardIndex               = types.NewRewardIndex
-	NewRewardPeriod              = types.NewRewardPeriod
-	NewUSDXMintingClaim          = types.NewUSDXMintingClaim
-	ParamKeyTable                = types.ParamKeyTable
-	RegisterCodec                = types.RegisterCodec
+	CalculateTimeElapsed                   = keeper.CalculateTimeElapsed
+	NewKeeper                              = keeper.NewKeeper
+	NewQuerier                             = keeper.NewQuerier
+	DefaultGenesisState                    = types.DefaultGenesisState
+	DefaultParams                          = types.DefaultParams
+	GetTotalVestingPeriodLength            = types.GetTotalVestingPeriodLength
+	NewGenesisAccumulationTime             = types.NewGenesisAccumulationTime
+	NewGenesisState                        = types.NewGenesisState
+	NewMsgClaimUSDXMintingReward           = types.NewMsgClaimUSDXMintingReward
+	NewMsgClaimHardLiquidityProviderReward = types.NewMsgClaimHardLiquidityProviderReward
+	NewMultiplier                          = types.NewMultiplier
+	NewParams                              = types.NewParams
+	NewPeriod                              = types.NewPeriod
+	NewQueryCdpClaimsParams                = types.NewQueryCdpClaimsParams
+	NewQueryHardClaimsParams               = types.NewQueryHardClaimsParams
+	NewRewardIndex                         = types.NewRewardIndex
+	NewRewardPeriod                        = types.NewRewardPeriod
+	NewUSDXMintingClaim                    = types.NewUSDXMintingClaim
+	NewHardLiquidityProviderClaim          = types.NewHardLiquidityProviderClaim
+	ParamKeyTable                          = types.ParamKeyTable
+	RegisterCodec                          = types.RegisterCodec
 
 	// variable aliases
 	PreviousUSDXMintingRewardAccrualTimeKeyPrefix = types.PreviousUSDXMintingRewardAccrualTimeKeyPrefix

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -26,22 +26,23 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	}
 
 	incentiveTxCmd.AddCommand(flags.PostCommands(
-		getCmdClaim(cdc),
+		getCmdClaimCdp(cdc),
+		getCmdClaimHard(cdc),
 	)...)
 
 	return incentiveTxCmd
 
 }
 
-func getCmdClaim(cdc *codec.Codec) *cobra.Command {
+func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "claim [owner] [multiplier]",
-		Short: "claim rewards for cdp owner and collateral-type",
+		Use:   "claim-cdp [owner] [multiplier]",
+		Short: "claim CDP rewards for cdp owner and collateral-type",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Claim any outstanding rewards owned by owner for the input collateral-type and multiplier,
+			fmt.Sprintf(`Claim any outstanding CDP rewards owned by owner for the input collateral-type and multiplier,
 
 			Example:
-			$ %s tx %s claim kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
+			$ %s tx %s claim-cdp kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
 		`, version.ClientName, types.ModuleName),
 		),
 		Args: cobra.ExactArgs(2),
@@ -55,6 +56,37 @@ func getCmdClaim(cdc *codec.Codec) *cobra.Command {
 			}
 
 			msg := types.NewMsgClaimUSDXMintingReward(owner, args[1])
+			err = msg.ValidateBasic()
+			if err != nil {
+				return err
+			}
+			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+		},
+	}
+}
+
+func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "claim-hard [owner] [multiplier]",
+		Short: "claim Hard rewards for deposit/borrow and delegating",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Claim owner's outstanding Hard rewards using given multiplier multiplier,
+
+			Example:
+			$ %s tx %s claim-hard kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
+		`, version.ClientName, types.ModuleName),
+		),
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)
+			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
+			owner, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgClaimHardLiquidityProviderReward(owner, args[1])
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/incentive/client/rest/query.go
+++ b/x/incentive/client/rest/query.go
@@ -15,11 +15,12 @@ import (
 )
 
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
-	r.HandleFunc(fmt.Sprintf("/%s/claims", types.ModuleName), queryClaimsHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/cdp-claims", types.ModuleName), queryCdpClaimsHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/hard-claims", types.ModuleName), queryHardClaimsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/parameters", types.ModuleName), queryParamsHandlerFn(cliCtx)).Methods("GET")
 }
 
-func queryClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+func queryCdpClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, page, limit, err := rest.ParseHTTPArgsWithLimit(r, 0)
 		if err != nil {
@@ -49,6 +50,46 @@ func queryClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetCdpClaims), bz)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+func queryHardClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, page, limit, err := rest.ParseHTTPArgsWithLimit(r, 0)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		var owner sdk.AccAddress
+		if x := r.URL.Query().Get(types.RestClaimOwner); len(x) != 0 {
+			ownerStr := strings.ToLower(strings.TrimSpace(x))
+			owner, err = sdk.AccAddressFromBech32(ownerStr)
+			if err != nil {
+				rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("cannot parse address from claim owner %s", ownerStr))
+				return
+			}
+		}
+
+		queryParams := types.NewQueryHardClaimsParams(page, limit, owner)
+		bz, err := cliCtx.Codec.MarshalJSON(queryParams)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
+			return
+		}
+
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetHardClaims), bz)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/x/incentive/client/rest/query.go
+++ b/x/incentive/client/rest/query.go
@@ -41,14 +41,14 @@ func queryClaimsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			}
 		}
 
-		queryParams := types.NewQueryClaimsParams(page, limit, owner)
+		queryParams := types.NewQueryCdpClaimsParams(page, limit, owner)
 		bz, err := cliCtx.Codec.MarshalJSON(queryParams)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 			return
 		}
 
-		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetClaims), bz)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetCdpClaims), bz)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/x/incentive/handler.go
+++ b/x/incentive/handler.go
@@ -23,7 +23,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 
 func handleMsgClaimUSDXMintingReward(ctx sdk.Context, k keeper.Keeper, msg types.MsgClaimUSDXMintingReward) (*sdk.Result, error) {
 
-	err := k.ClaimReward(ctx, msg.Sender, types.MultiplierName(msg.MultiplierName))
+	err := k.ClaimUSDXMintingReward(ctx, msg.Sender, types.MultiplierName(msg.MultiplierName))
 	if err != nil {
 		return nil, err
 	}

--- a/x/incentive/handler.go
+++ b/x/incentive/handler.go
@@ -15,6 +15,8 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		case types.MsgClaimUSDXMintingReward:
 			return handleMsgClaimUSDXMintingReward(ctx, k, msg)
+		case types.MsgClaimHardLiquidityProviderReward:
+			return handleMsgClaimHardLiquidityProviderReward(ctx, k, msg)
 		default:
 			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
@@ -24,6 +26,17 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 func handleMsgClaimUSDXMintingReward(ctx sdk.Context, k keeper.Keeper, msg types.MsgClaimUSDXMintingReward) (*sdk.Result, error) {
 
 	err := k.ClaimUSDXMintingReward(ctx, msg.Sender, types.MultiplierName(msg.MultiplierName))
+	if err != nil {
+		return nil, err
+	}
+	return &sdk.Result{
+		Events: ctx.EventManager().Events(),
+	}, nil
+}
+
+func handleMsgClaimHardLiquidityProviderReward(ctx sdk.Context, k keeper.Keeper, msg types.MsgClaimHardLiquidityProviderReward) (*sdk.Result, error) {
+
+	err := k.ClaimHardReward(ctx, msg.Sender, types.MultiplierName(msg.MultiplierName))
 	if err != nil {
 		return nil, err
 	}

--- a/x/incentive/handler_test.go
+++ b/x/incentive/handler_test.go
@@ -63,7 +63,34 @@ func (suite *HandlerTestSuite) SetupTest() {
 	suite.ctx = ctx
 }
 
-func (suite *HandlerTestSuite) addClaim() {
+func (suite *HandlerTestSuite) TestMsgUSDXMintingClaimReward() {
+	suite.addUSDXMintingClaim()
+	msg := incentive.NewMsgClaimUSDXMintingReward(suite.addrs[0], "small")
+	res, err := suite.handler(suite.ctx, msg)
+	suite.NoError(err)
+	suite.Require().NotNil(res)
+}
+
+func (suite *HandlerTestSuite) TestMsgHardLiquidityProviderClaimReward() {
+	suite.addHardLiquidityProviderClaim()
+	msg := incentive.NewMsgClaimHardLiquidityProviderReward(suite.addrs[0], "small")
+	res, err := suite.handler(suite.ctx, msg)
+	suite.NoError(err)
+	suite.Require().NotNil(res)
+}
+
+func (suite *HandlerTestSuite) addHardLiquidityProviderClaim() {
+	sk := suite.app.GetSupplyKeeper()
+	err := sk.MintCoins(suite.ctx, kavadist.ModuleName, cs(c("ukava", 1000000000000)))
+	suite.Require().NoError(err)
+	rewardPeriod := types.RewardIndexes{types.NewRewardIndex("bnb-s", sdk.ZeroDec())}
+	c1 := incentive.NewHardLiquidityProviderClaim(suite.addrs[0], c("ukava", 1000000), rewardPeriod, rewardPeriod, rewardPeriod)
+	suite.NotPanics(func() {
+		suite.keeper.SetHardLiquidityProviderClaim(suite.ctx, c1)
+	})
+}
+
+func (suite *HandlerTestSuite) addUSDXMintingClaim() {
 	sk := suite.app.GetSupplyKeeper()
 	err := sk.MintCoins(suite.ctx, kavadist.ModuleName, cs(c("ukava", 1000000000000)))
 	suite.Require().NoError(err)
@@ -73,13 +100,6 @@ func (suite *HandlerTestSuite) addClaim() {
 	})
 }
 
-func (suite *HandlerTestSuite) TestMsgClaimReward() {
-	suite.addClaim()
-	msg := incentive.NewMsgClaimUSDXMintingReward(suite.addrs[0], "small")
-	res, err := suite.handler(suite.ctx, msg)
-	suite.NoError(err)
-	suite.Require().NotNil(res)
-}
 func TestHandlerTestSuite(t *testing.T) {
 	suite.Run(t, new(HandlerTestSuite))
 }

--- a/x/incentive/keeper/payout.go
+++ b/x/incentive/keeper/payout.go
@@ -52,8 +52,9 @@ func (k Keeper) ClaimUSDXMintingReward(ctx sdk.Context, addr sdk.AccAddress, mul
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeClaim,
-			sdk.NewAttribute(types.AttributeKeyClaimedBy, addr.String()),
-			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.Reward.String()),
+			sdk.NewAttribute(types.AttributeKeyClaimedBy, claim.GetOwner().String()),
+			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.GetReward().String()),
+			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.GetType()),
 		),
 	)
 	return nil
@@ -101,8 +102,9 @@ func (k Keeper) ClaimHardReward(ctx sdk.Context, addr sdk.AccAddress, multiplier
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeClaim,
-			sdk.NewAttribute(types.AttributeKeyClaimedBy, addr.String()),
-			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.Reward.String()),
+			sdk.NewAttribute(types.AttributeKeyClaimedBy, claim.GetOwner().String()),
+			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.GetReward().String()),
+			sdk.NewAttribute(types.AttributeKeyClaimType, claim.GetType()),
 		),
 	)
 	return nil

--- a/x/incentive/keeper/payout.go
+++ b/x/incentive/keeper/payout.go
@@ -12,8 +12,8 @@ import (
 	validatorvesting "github.com/kava-labs/kava/x/validator-vesting"
 )
 
-// ClaimReward sends the reward amount to the input address and zero's out the claim in the store
-func (k Keeper) ClaimReward(ctx sdk.Context, addr sdk.AccAddress, multiplierName types.MultiplierName) error {
+// ClaimUSDXMintingReward sends the reward amount to the input address and zero's out the claim in the store
+func (k Keeper) ClaimUSDXMintingReward(ctx sdk.Context, addr sdk.AccAddress, multiplierName types.MultiplierName) error {
 	claim, found := k.GetUSDXMintingClaim(ctx, addr)
 	if !found {
 		return sdkerrors.Wrapf(types.ErrClaimNotFound, "address: %s", addr)
@@ -30,7 +30,7 @@ func (k Keeper) ClaimReward(ctx sdk.Context, addr sdk.AccAddress, multiplierName
 		return sdkerrors.Wrapf(types.ErrClaimExpired, "block time %s > claim end time %s", ctx.BlockTime(), claimEnd)
 	}
 
-	claim, err := k.SynchronizeClaim(ctx, claim)
+	claim, err := k.SynchronizeUSDXMintingClaim(ctx, claim)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,56 @@ func (k Keeper) ClaimReward(ctx sdk.Context, addr sdk.AccAddress, multiplierName
 		return err
 	}
 
-	k.ZeroClaim(ctx, claim)
+	k.ZeroUSDXMintingClaim(ctx, claim)
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeClaim,
+			sdk.NewAttribute(types.AttributeKeyClaimedBy, addr.String()),
+			sdk.NewAttribute(types.AttributeKeyClaimAmount, claim.Reward.String()),
+		),
+	)
+	return nil
+}
+
+// ClaimHardReward sends the reward amount to the input address and zero's out the claim in the store
+func (k Keeper) ClaimHardReward(ctx sdk.Context, addr sdk.AccAddress, multiplierName types.MultiplierName) error {
+	_, found := k.GetHardLiquidityProviderClaim(ctx, addr)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrClaimNotFound, "address: %s", addr)
+	}
+
+	multiplier, found := k.GetMultiplier(ctx, multiplierName)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrInvalidMultiplier, string(multiplierName))
+	}
+
+	claimEnd := k.GetClaimEnd(ctx)
+
+	if ctx.BlockTime().After(claimEnd) {
+		return sdkerrors.Wrapf(types.ErrClaimExpired, "block time %s > claim end time %s", ctx.BlockTime(), claimEnd)
+	}
+
+	k.SynchronizeHardLiquidityProviderClaim(ctx, addr)
+
+	claim, found := k.GetHardLiquidityProviderClaim(ctx, addr)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrClaimNotFound, "address: %s", addr)
+	}
+
+	rewardAmount := claim.Reward.Amount.ToDec().Mul(multiplier.Factor).RoundInt()
+	if rewardAmount.IsZero() {
+		return types.ErrZeroClaim
+	}
+	rewardCoin := sdk.NewCoin(claim.Reward.Denom, rewardAmount)
+	length := ctx.BlockTime().AddDate(0, int(multiplier.MonthsLockup), 0).Unix() - ctx.BlockTime().Unix()
+
+	err := k.SendTimeLockedCoinsToAccount(ctx, types.IncentiveMacc, addr, sdk.NewCoins(rewardCoin), length)
+	if err != nil {
+		return err
+	}
+
+	k.ZeroHardLiquidityProviderClaim(ctx, claim)
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -129,7 +129,7 @@ func (suite *KeeperTestSuite) TestPayoutClaim() {
 			err = suite.keeper.AccumulateUSDXMintingRewards(suite.ctx, rewardPeriod)
 			suite.Require().NoError(err)
 
-			err = suite.keeper.ClaimReward(suite.ctx, suite.addrs[0], tc.args.multiplier)
+			err = suite.keeper.ClaimUSDXMintingReward(suite.ctx, suite.addrs[0], tc.args.multiplier)
 
 			if tc.errArgs.expectPass {
 				suite.Require().NoError(err)

--- a/x/incentive/types/codec.go
+++ b/x/incentive/types/codec.go
@@ -20,4 +20,5 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	// Register msgs
 	cdc.RegisterConcrete(MsgClaimUSDXMintingReward{}, "incentive/MsgClaimUSDXMintingReward", nil)
+	cdc.RegisterConcrete(MsgClaimHardLiquidityProviderReward{}, "incentive/MsgClaimHardLiquidityProviderReward", nil)
 }

--- a/x/incentive/types/events.go
+++ b/x/incentive/types/events.go
@@ -10,6 +10,7 @@ const (
 	AttributeValueCategory   = ModuleName
 	AttributeKeyClaimedBy    = "claimed_by"
 	AttributeKeyClaimAmount  = "claim_amount"
+	AttributeKeyClaimType    = "claim_type"
 	AttributeKeyRewardPeriod = "reward_period"
 	AttributeKeyClaimPeriod  = "claim_period"
 )

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -33,6 +33,8 @@ type CdpKeeper interface {
 
 // HardKeeper defines the expected hard keeper for interacting with Hard protocol
 type HardKeeper interface {
+	GetDeposit(ctx sdk.Context, depositor sdk.AccAddress) (hardtypes.Deposit, bool)
+	GetBorrow(ctx sdk.Context, borrower sdk.AccAddress) (hardtypes.Borrow, bool)
 	GetSupplyInterestFactor(ctx sdk.Context, denom string) (sdk.Dec, bool)
 	GetBorrowInterestFactor(ctx sdk.Context, denom string) (sdk.Dec, bool)
 	GetBorrowedCoins(ctx sdk.Context) (coins sdk.Coins, found bool)

--- a/x/incentive/types/msg.go
+++ b/x/incentive/types/msg.go
@@ -9,8 +9,9 @@ import (
 
 // ensure Msg interface compliance at compile time
 var _ sdk.Msg = &MsgClaimUSDXMintingReward{}
+var _ sdk.Msg = &MsgClaimHardLiquidityProviderReward{}
 
-// MsgClaimUSDXMintingReward message type used to claim rewards
+// MsgClaimUSDXMintingReward message type used to claim USDX minting rewards
 type MsgClaimUSDXMintingReward struct {
 	Sender         sdk.AccAddress `json:"sender" yaml:"sender"`
 	MultiplierName string         `json:"multiplier_name" yaml:"multiplier_name"`
@@ -28,7 +29,7 @@ func NewMsgClaimUSDXMintingReward(sender sdk.AccAddress, multiplierName string) 
 func (msg MsgClaimUSDXMintingReward) Route() string { return RouterKey }
 
 // Type returns a human-readable string for the message, intended for utilization within tags.
-func (msg MsgClaimUSDXMintingReward) Type() string { return "claim_reward" }
+func (msg MsgClaimUSDXMintingReward) Type() string { return "claim_usdx_minting_reward" }
 
 // ValidateBasic does a simple validation check that doesn't require access to state.
 func (msg MsgClaimUSDXMintingReward) ValidateBasic() error {
@@ -46,5 +47,46 @@ func (msg MsgClaimUSDXMintingReward) GetSignBytes() []byte {
 
 // GetSigners returns the addresses of signers that must sign.
 func (msg MsgClaimUSDXMintingReward) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Sender}
+}
+
+// MsgClaimHardLiquidityProviderReward message type used to claim Hard liquidity provider rewards
+type MsgClaimHardLiquidityProviderReward struct {
+	Sender         sdk.AccAddress `json:"sender" yaml:"sender"`
+	MultiplierName string         `json:"multiplier_name" yaml:"multiplier_name"`
+}
+
+// NewMsgClaimHardLiquidityProviderReward returns a new MsgClaimHardLiquidityProviderReward.
+func NewMsgClaimHardLiquidityProviderReward(sender sdk.AccAddress, multiplierName string) MsgClaimHardLiquidityProviderReward {
+	return MsgClaimHardLiquidityProviderReward{
+		Sender:         sender,
+		MultiplierName: multiplierName,
+	}
+}
+
+// Route return the message type used for routing the message.
+func (msg MsgClaimHardLiquidityProviderReward) Route() string { return RouterKey }
+
+// Type returns a human-readable string for the message, intended for utilization within tags.
+func (msg MsgClaimHardLiquidityProviderReward) Type() string {
+	return "claim_hard_liquidity_provider_reward"
+}
+
+// ValidateBasic does a simple validation check that doesn't require access to state.
+func (msg MsgClaimHardLiquidityProviderReward) ValidateBasic() error {
+	if msg.Sender.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "sender address cannot be empty")
+	}
+	return MultiplierName(strings.ToLower(msg.MultiplierName)).IsValid()
+}
+
+// GetSignBytes gets the canonical byte representation of the Msg.
+func (msg MsgClaimHardLiquidityProviderReward) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// GetSigners returns the addresses of signers that must sign.
+func (msg MsgClaimHardLiquidityProviderReward) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Sender}
 }

--- a/x/incentive/types/querier.go
+++ b/x/incentive/types/querier.go
@@ -7,7 +7,8 @@ import (
 
 // Querier routes for the incentive module
 const (
-	QueryGetClaims          = "claims"
+	QueryGetCdpClaims       = "cdp-claims"
+	QueryGetHardClaims      = "hard-claims"
 	RestClaimOwner          = "owner"
 	RestClaimCollateralType = "collateral_type"
 	QueryGetParams          = "parameters"
@@ -15,16 +16,32 @@ const (
 	QueryGetClaimPeriods    = "claim-periods"
 )
 
-// QueryClaimsParams params for query /incentive/claims
-type QueryClaimsParams struct {
+// QueryCdpClaimsParams params for query /incentive/claims
+type QueryCdpClaimsParams struct {
 	Page  int `json:"page" yaml:"page"`
 	Limit int `json:"limit" yaml:"limit"`
 	Owner sdk.AccAddress
 }
 
-// NewQueryClaimsParams returns QueryClaimsParams
-func NewQueryClaimsParams(page, limit int, owner sdk.AccAddress) QueryClaimsParams {
-	return QueryClaimsParams{
+// NewQueryCdpClaimsParams returns QueryCdpClaimsParams
+func NewQueryCdpClaimsParams(page, limit int, owner sdk.AccAddress) QueryCdpClaimsParams {
+	return QueryCdpClaimsParams{
+		Page:  page,
+		Limit: limit,
+		Owner: owner,
+	}
+}
+
+// QueryHardClaimsParams params for query /incentive/claims
+type QueryHardClaimsParams struct {
+	Page  int `json:"page" yaml:"page"`
+	Limit int `json:"limit" yaml:"limit"`
+	Owner sdk.AccAddress
+}
+
+// NewQueryHardClaimsParams returns QueryHardClaimsParams
+func NewQueryHardClaimsParams(page, limit int, owner sdk.AccAddress) QueryHardClaimsParams {
+	return QueryHardClaimsParams{
 		Page:  page,
 		Limit: limit,
 		Owner: owner,


### PR DESCRIPTION
- [x] Add message for hard rewards claims that allow users to claim rewards
- [x] Message claims all (supply, borrow, delegation) HARD rewards and deletes the claim object from the store
- [x] CLI/Rest API should also be updated for new transaction types
- [x] Added basic Hard claims queries

Questions:
- What should the Incentive module's API look like (Hard module vs. CDP module claims)?