### PR TITLE
Hard incentive reward querier updates for acceptance

### DIFF
--- a/x/incentive/abci.go
+++ b/x/incentive/abci.go
@@ -27,4 +27,10 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 			panic(err)
 		}
 	}
+	for _, rp := range params.HardDelegatorRewardPeriods {
+		err := k.AccumulateHardDelegatorRewards(ctx, rp)
+		if err != nil {
+			panic(err)
+		}
+	}
 }

--- a/x/incentive/keeper/querier.go
+++ b/x/incentive/keeper/querier.go
@@ -67,8 +67,14 @@ func queryGetHardRewards(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]by
 		paginatedHardClaims = hardClaims[startH:endH]
 	}
 
+	var augmentedHardClaims types.HardLiquidityProviderClaims
+	for _, claim := range paginatedHardClaims {
+		augmentedClaim := k.SimulateHardSynchronization(ctx, claim)
+		augmentedHardClaims = append(augmentedHardClaims, augmentedClaim)
+	}
+
 	// Marshal Hard claims
-	bz, err := codec.MarshalJSONIndent(k.cdc, paginatedHardClaims)
+	bz, err := codec.MarshalJSONIndent(k.cdc, augmentedHardClaims)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/incentive/keeper/querier.go
+++ b/x/incentive/keeper/querier.go
@@ -108,8 +108,14 @@ func queryGetUSDXMintingRewards(ctx sdk.Context, req abci.RequestQuery, k Keeper
 		paginatedUsdxMintingClaims = usdxMintingClaims[startU:endU]
 	}
 
+	var augmentedUsdxMintingClaims types.USDXMintingClaims
+	for _, claim := range paginatedUsdxMintingClaims {
+		augmentedClaim := k.SimulateUSDXMintingSynchronization(ctx, claim)
+		augmentedUsdxMintingClaims = append(augmentedUsdxMintingClaims, augmentedClaim)
+	}
+
 	// Marshal USDX minting claims
-	bz, err := codec.MarshalJSONIndent(k.cdc, paginatedUsdxMintingClaims)
+	bz, err := codec.MarshalJSONIndent(k.cdc, augmentedUsdxMintingClaims)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}


### PR DESCRIPTION
This PR simulates reward synchronization so that reward queries return the correct outstanding reward amount/reward indexes. Individual methods are implemented for HardLiquidityProvider and USDXMinting claims. Instead of taking a deposit/borrow/cdp object, the simulation methods all take an existing claim as input and return the updated claim object.