### PR TITLE
Hard Audit: fix duplicate supply/borrow index factors

### DIFF
--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -43,6 +43,13 @@ func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) e
 		return err
 	}
 
+	// If any coin denoms have been completely repaid reset the denom's borrow index factor
+	for _, coin := range payment {
+		if coin.Amount.Equal(borrow.Amount.AmountOf(coin.Denom)) {
+			borrow.Index = borrow.Index.SetInterestFactor(coin.Denom, sdk.ZeroDec())
+		}
+	}
+
 	// Update user's borrow in store
 	borrow.Amount = borrow.Amount.Sub(payment)
 

--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -46,7 +46,11 @@ func (k Keeper) Repay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) e
 	// If any coin denoms have been completely repaid reset the denom's borrow index factor
 	for _, coin := range payment {
 		if coin.Amount.Equal(borrow.Amount.AmountOf(coin.Denom)) {
-			borrow.Index = borrow.Index.SetInterestFactor(coin.Denom, sdk.ZeroDec())
+			borrowIndex, removed := borrow.Index.RemoveInterestFactor(coin.Denom)
+			if !removed {
+				return sdkerrors.Wrapf(types.ErrInvalidIndexFactorDenom, "%s", coin.Denom)
+			}
+			borrow.Index = borrowIndex
 		}
 	}
 

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -52,7 +52,11 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 	// If any coin denoms have been completely withdrawn reset the denom's supply index factor
 	for _, coin := range deposit.Amount {
 		if !sdk.NewCoins(coin).DenomsSubsetOf(proposedDeposit.Amount) {
-			deposit.Index = deposit.Index.SetInterestFactor(coin.Denom, sdk.ZeroDec())
+			depositIndex, removed := deposit.Index.RemoveInterestFactor(coin.Denom)
+			if !removed {
+				return sdkerrors.Wrapf(types.ErrInvalidIndexFactorDenom, "%s", coin.Denom)
+			}
+			deposit.Index = depositIndex
 		}
 	}
 

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -49,6 +49,13 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 		return err
 	}
 
+	// If any coin denoms have been completely withdrawn reset the denom's supply index factor
+	for _, coin := range deposit.Amount {
+		if !sdk.NewCoins(coin).DenomsSubsetOf(proposedDeposit.Amount) {
+			deposit.Index = deposit.Index.SetInterestFactor(coin.Denom, sdk.ZeroDec())
+		}
+	}
+
 	deposit.Amount = deposit.Amount.Sub(amount)
 	newLtv, err := k.CalculateLtv(ctx, deposit, borrow)
 	if err != nil {

--- a/x/hard/types/borrow.go
+++ b/x/hard/types/borrow.go
@@ -100,6 +100,28 @@ func (bif BorrowInterestFactor) String() string {
 // BorrowInterestFactors is a slice of BorrowInterestFactor, because Amino won't marshal maps
 type BorrowInterestFactors []BorrowInterestFactor
 
+// GetInterestFactor returns a denom's interest factor value
+func (bifs BorrowInterestFactors) GetInterestFactor(denom string) (sdk.Dec, bool) {
+	for _, bif := range bifs {
+		if bif.Denom == denom {
+			return bif.Value, true
+		}
+	}
+	return sdk.ZeroDec(), false
+}
+
+// SetInterestFactor sets a denom's interest factor value
+func (bifs BorrowInterestFactors) SetInterestFactor(denom string, factor sdk.Dec) BorrowInterestFactors {
+	for i, bif := range bifs {
+		if bif.Denom == denom {
+			bif.Value = factor
+			bifs[i] = bif
+			return bifs
+		}
+	}
+	return append(bifs, NewBorrowInterestFactor(denom, factor))
+}
+
 // Validate validates BorrowInterestFactors
 func (bifs BorrowInterestFactors) Validate() error {
 	for _, bif := range bifs {

--- a/x/hard/types/borrow.go
+++ b/x/hard/types/borrow.go
@@ -122,6 +122,16 @@ func (bifs BorrowInterestFactors) SetInterestFactor(denom string, factor sdk.Dec
 	return append(bifs, NewBorrowInterestFactor(denom, factor))
 }
 
+// RemoveInterestFactor removes a denom's interest factor value
+func (bifs BorrowInterestFactors) RemoveInterestFactor(denom string) (BorrowInterestFactors, bool) {
+	for i, bif := range bifs {
+		if bif.Denom == denom {
+			return append(bifs[:i], bifs[i+1:]...), true
+		}
+	}
+	return bifs, false
+}
+
 // Validate validates BorrowInterestFactors
 func (bifs BorrowInterestFactors) Validate() error {
 	for _, bif := range bifs {

--- a/x/hard/types/deposit.go
+++ b/x/hard/types/deposit.go
@@ -122,6 +122,16 @@ func (sifs SupplyInterestFactors) SetInterestFactor(denom string, factor sdk.Dec
 	return append(sifs, NewSupplyInterestFactor(denom, factor))
 }
 
+// RemoveInterestFactor removes a denom's interest factor value
+func (sifs SupplyInterestFactors) RemoveInterestFactor(denom string) (SupplyInterestFactors, bool) {
+	for i, sif := range sifs {
+		if sif.Denom == denom {
+			return append(sifs[:i], sifs[i+1:]...), true
+		}
+	}
+	return sifs, false
+}
+
 // Validate validates SupplyInterestFactors
 func (sifs SupplyInterestFactors) Validate() error {
 	for _, sif := range sifs {

--- a/x/hard/types/deposit.go
+++ b/x/hard/types/deposit.go
@@ -100,6 +100,28 @@ func (sif SupplyInterestFactor) String() string {
 // SupplyInterestFactors is a slice of SupplyInterestFactor, because Amino won't marshal maps
 type SupplyInterestFactors []SupplyInterestFactor
 
+// GetInterestFactor returns a denom's interest factor value
+func (sifs SupplyInterestFactors) GetInterestFactor(denom string) (sdk.Dec, bool) {
+	for _, sif := range sifs {
+		if sif.Denom == denom {
+			return sif.Value, true
+		}
+	}
+	return sdk.ZeroDec(), false
+}
+
+// SetInterestFactor sets a denom's interest factor value
+func (sifs SupplyInterestFactors) SetInterestFactor(denom string, factor sdk.Dec) SupplyInterestFactors {
+	for i, sif := range sifs {
+		if sif.Denom == denom {
+			sif.Value = factor
+			sifs[i] = sif
+			return sifs
+		}
+	}
+	return append(sifs, NewSupplyInterestFactor(denom, factor))
+}
+
 // Validate validates SupplyInterestFactors
 func (sifs SupplyInterestFactors) Validate() error {
 	for _, sif := range sifs {

--- a/x/hard/types/errors.go
+++ b/x/hard/types/errors.go
@@ -61,4 +61,6 @@ var (
 	ErrInvalidWithdrawDenom = sdkerrors.Register(ModuleName, 26, "no coins of this type deposited")
 	// ErrInvalidRepaymentDenom error for when user attempts to repay a non-borrowed coin type
 	ErrInvalidRepaymentDenom = sdkerrors.Register(ModuleName, 27, "no coins of this type borrowed")
+	// ErrInvalidIndexFactorDenom error for when index factor denom cannot be found
+	ErrInvalidIndexFactorDenom = sdkerrors.Register(ModuleName, 28, "no index factor found for denom")
 )


### PR DESCRIPTION
- [x] Reset SupplyIndexFactor/BorrowIndexFactor if the underlying denom amount is 0 due to a withdraw/repay
- [x] Instead of appending new IndexFactors, update the values of existing IndexFactors 