### PR TITLE
Hard Audit: remove unused PreviousBlockTime

### DIFF
--- a/x/hard/abci.go
+++ b/x/hard/abci.go
@@ -8,5 +8,4 @@ import (
 func BeginBlocker(ctx sdk.Context, k Keeper) {
 	k.ApplyInterestRateUpdates(ctx)
 	k.AttemptIndexLiquidations(ctx)
-	k.SetPreviousBlockTime(ctx, ctx.BlockTime())
 }

--- a/x/hard/alias.go
+++ b/x/hard/alias.go
@@ -132,7 +132,6 @@ var (
 	ModuleCdc                        = types.ModuleCdc
 	MoneyMarketsPrefix               = types.MoneyMarketsPrefix
 	PreviousAccrualTimePrefix        = types.PreviousAccrualTimePrefix
-	PreviousBlockTimeKey             = types.PreviousBlockTimeKey
 	SuppliedCoinsPrefix              = types.SuppliedCoinsPrefix
 	SupplyInterestFactorPrefix       = types.SupplyInterestFactorPrefix
 	TotalReservesPrefix              = types.TotalReservesPrefix

--- a/x/hard/keeper/keeper.go
+++ b/x/hard/keeper/keeper.go
@@ -54,23 +54,6 @@ func (k *Keeper) SetHooks(hooks types.HARDHooks) *Keeper {
 	return k
 }
 
-// GetPreviousBlockTime get the blocktime for the previous block
-func (k Keeper) GetPreviousBlockTime(ctx sdk.Context) (blockTime time.Time, found bool) {
-	store := prefix.NewStore(ctx.KVStore(k.key), types.PreviousBlockTimeKey)
-	b := store.Get([]byte{})
-	if b == nil {
-		return time.Time{}, false
-	}
-	k.cdc.MustUnmarshalBinaryBare(b, &blockTime)
-	return blockTime, true
-}
-
-// SetPreviousBlockTime set the time of the previous block
-func (k Keeper) SetPreviousBlockTime(ctx sdk.Context, blockTime time.Time) {
-	store := prefix.NewStore(ctx.KVStore(k.key), types.PreviousBlockTimeKey)
-	store.Set([]byte{}, k.cdc.MustMarshalBinaryBare(blockTime))
-}
-
 // GetDeposit returns a deposit from the store for a particular depositor address, deposit denom
 func (k Keeper) GetDeposit(ctx sdk.Context, depositor sdk.AccAddress) (types.Deposit, bool) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.DepositsKeyPrefix)

--- a/x/hard/keeper/keeper_test.go
+++ b/x/hard/keeper/keeper_test.go
@@ -49,19 +49,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.addrs = addrs
 }
 
-func (suite *KeeperTestSuite) TestGetSetPreviousBlockTime() {
-	now := tmtime.Now()
-
-	_, f := suite.keeper.GetPreviousBlockTime(suite.ctx)
-	suite.Require().False(f)
-
-	suite.NotPanics(func() { suite.keeper.SetPreviousBlockTime(suite.ctx, now) })
-
-	pbt, f := suite.keeper.GetPreviousBlockTime(suite.ctx)
-	suite.True(f)
-	suite.Equal(now, pbt)
-}
-
 func (suite *KeeperTestSuite) TestGetSetDeleteDeposit() {
 	dep := types.NewDeposit(sdk.AccAddress("test"), sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(100))),
 		types.SupplyInterestFactors{types.NewSupplyInterestFactor("", sdk.MustNewDecFromStr("0"))})

--- a/x/hard/simulation/decoder.go
+++ b/x/hard/simulation/decoder.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"bytes"
 	"fmt"
-	"time"
 
 	"github.com/tendermint/tendermint/libs/kv"
 
@@ -20,11 +19,6 @@ func DecodeStore(cdc *codec.Codec, kvA, kvB kv.Pair) string {
 		cdc.MustUnmarshalBinaryBare(kvA.Value, &depA)
 		cdc.MustUnmarshalBinaryBare(kvB.Value, &depB)
 		return fmt.Sprintf("%s\n%s", depA, depB)
-	case bytes.Equal(kvA.Key[:1], types.PreviousBlockTimeKey):
-		var timeA, timeB time.Time
-		cdc.MustUnmarshalBinaryBare(kvA.Value, &timeA)
-		cdc.MustUnmarshalBinaryBare(kvB.Value, &timeB)
-		return fmt.Sprintf("%s\n%s", timeA, timeB)
 	default:
 		panic(fmt.Sprintf("invalid %s key prefix %X", types.ModuleName, kvA.Key[:1]))
 	}

--- a/x/hard/simulation/decoder_test.go
+++ b/x/hard/simulation/decoder_test.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -26,11 +25,9 @@ func makeTestCodec() (cdc *codec.Codec) {
 func TestDecodeDistributionStore(t *testing.T) {
 	cdc := makeTestCodec()
 
-	prevBlockTime := time.Now().UTC()
 	deposit := types.NewDeposit(sdk.AccAddress("test"), sdk.NewCoins(sdk.NewCoin("bnb", sdk.NewInt(1))), types.SupplyInterestFactors{})
 
 	kvPairs := kv.Pairs{
-		kv.Pair{Key: []byte(types.PreviousBlockTimeKey), Value: cdc.MustMarshalBinaryBare(prevBlockTime)},
 		kv.Pair{Key: []byte(types.DepositsKeyPrefix), Value: cdc.MustMarshalBinaryBare(deposit)},
 		kv.Pair{Key: []byte{0x99}, Value: []byte{0x99}},
 	}
@@ -39,7 +36,6 @@ func TestDecodeDistributionStore(t *testing.T) {
 		name        string
 		expectedLog string
 	}{
-		{"PreviousBlockTime", fmt.Sprintf("%s\n%s", prevBlockTime, prevBlockTime)},
 		{"Deposit", fmt.Sprintf("%s\n%s", deposit, deposit)},
 		{"other", ""},
 	}

--- a/x/hard/types/keys.go
+++ b/x/hard/types/keys.go
@@ -34,18 +34,17 @@ const (
 )
 
 var (
-	PreviousBlockTimeKey          = []byte{0x01}
-	DepositsKeyPrefix             = []byte{0x03}
-	BorrowsKeyPrefix              = []byte{0x05}
-	BorrowedCoinsPrefix           = []byte{0x06}
-	SuppliedCoinsPrefix           = []byte{0x07}
-	MoneyMarketsPrefix            = []byte{0x08}
-	PreviousAccrualTimePrefix     = []byte{0x09} // denom -> time
-	TotalReservesPrefix           = []byte{0x10} // denom -> sdk.Coin
-	BorrowInterestFactorPrefix    = []byte{0x11} // denom -> sdk.Dec
-	SupplyInterestFactorPrefix    = []byte{0x12} // denom -> sdk.Dec
-	DelegatorInterestFactorPrefix = []byte{0x12} // denom -> sdk.Dec
-	LtvIndexPrefix                = []byte{0x13}
+	DepositsKeyPrefix             = []byte{0x01}
+	BorrowsKeyPrefix              = []byte{0x02}
+	BorrowedCoinsPrefix           = []byte{0x03}
+	SuppliedCoinsPrefix           = []byte{0x04}
+	MoneyMarketsPrefix            = []byte{0x05}
+	PreviousAccrualTimePrefix     = []byte{0x06} // denom -> time
+	TotalReservesPrefix           = []byte{0x07} // denom -> sdk.Coin
+	BorrowInterestFactorPrefix    = []byte{0x08} // denom -> sdk.Dec
+	SupplyInterestFactorPrefix    = []byte{0x09} // denom -> sdk.Dec
+	DelegatorInterestFactorPrefix = []byte{0x10} // denom -> sdk.Dec
+	LtvIndexPrefix                = []byte{0x11}
 	sep                           = []byte(":")
 )
 


### PR DESCRIPTION
Removes the unused GetPreviousBlockTime/SetPreviousBlockTime methods from the Hard module.