### PR TITLE
Hard Audit: return error in ValidateBorrow

### DIFF
--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -193,7 +193,7 @@ func (k Keeper) ValidateBorrow(ctx sdk.Context, borrower sdk.AccAddress, amount 
 		// Calculate the borrowable amount and add it to the user's total borrowable amount
 		assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
 		if err != nil {
-			sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+			return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
 		}
 		depositUSDValue := sdk.NewDecFromInt(depCoin.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPriceInfo.Price)
 		borrowableAmountForDeposit := depositUSDValue.Mul(moneyMarket.BorrowLimit.LoanToValue)


### PR DESCRIPTION
An error message wasn't being returned, so the function could have hit the error and continued execution.