### PR TITLE
Hard minor fix: call incentive hooks before sync

### DIFF
--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -23,15 +23,19 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 		}
 	}
 
-	// Call incentive hook
+	// Call incentive hooks
 	existingDeposit, hasExistingDeposit := k.GetDeposit(ctx, depositor)
 	if hasExistingDeposit {
 		k.BeforeDepositModified(ctx, existingDeposit)
 	}
+	existingBorrow, hasExistingBorrow := k.GetBorrow(ctx, depositor)
+	if hasExistingBorrow {
+		k.BeforeBorrowModified(ctx, existingBorrow)
+	}
 
 	// Sync any outstanding interest
-	k.SyncBorrowInterest(ctx, depositor)
 	k.SyncSupplyInterest(ctx, depositor)
+	k.SyncBorrowInterest(ctx, depositor)
 
 	err := k.ValidateDeposit(ctx, coins)
 	if err != nil {


### PR DESCRIPTION
As noted [here](https://github.com/Kava-Labs/kava/pull/800#discussion_r571646085) we should call both Deposit/Borrow incentive hooks before syncing interest. While `repay` and `withdraw` were updated in the previous PR, the fix should also be applied for `deposit`.