### PR TITLE
fix: don't accumulate if borrow interest rounds to zero

### DIFF
--- a/x/hard/keeper/interest.go
+++ b/x/hard/keeper/interest.go
@@ -120,6 +120,12 @@ func (k Keeper) AccrueInterest(ctx sdk.Context, denom string) error {
 	// Calculate borrow interest factor and update
 	borrowInterestFactor := CalculateBorrowInterestFactor(borrowRateSpy, sdk.NewInt(timeElapsed))
 	interestBorrowAccumulated := (borrowInterestFactor.Mul(sdk.NewDecFromInt(borrowedPrior.Amount)).TruncateInt()).Sub(borrowedPrior.Amount)
+
+	if interestBorrowAccumulated.IsZero() && borrowRateApy.IsPositive() {
+		// don't accumulate if borrow interest is rounding to zero
+		return nil
+	}
+
 	totalBorrowInterestAccumulated := sdk.NewCoins(sdk.NewCoin(denom, interestBorrowAccumulated))
 	reservesNew := interestBorrowAccumulated.ToDec().Mul(mm.ReserveFactor).TruncateInt()
 	borrowInterestFactorNew := borrowInterestFactorPrior.Mul(borrowInterestFactor)


### PR DESCRIPTION
Description of bug

If borrow interest is positive (ie. APY > 0), but the amount of interest rounds to zero, the current implementation will update the borrow factor incorrectly, while the supply factor will remain at zero.

To repdoduce:

```
// start with btcb interest rate model hard.NewInterestRateModel(sdk.ZeroDec(), sdk.MustNewDecFromStr("0.1"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("1.0"))
dkvcli tx hard deposit 100000000btcb --from user1
dkvcli tx hard deposit 100000000000bnb --from user2
dkvcli tx hard borrow 10000000btcb --from user2

// observe that the borrow index is increasing, while the supply index remains 1.0
dkvcli q hard deposits --owner (user1)
dkvcli q hard borrows --owner (user2)
```

Fix:

Check if `interestBorrowAccumulated` is 0 and `borrowRateApy` > 0. If so, don't accumulate interest. When enough time has accumulated such that `interestBorrowAccumulated` no longer rounds to zero, the correct updates will occur. 


