### PR TITLE
Hard Audit: remove liquidation account from Hard module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -103,7 +103,6 @@ var (
 		kavadist.ModuleName:         {supply.Minter},
 		issuance.ModuleAccountName:  {supply.Minter, supply.Burner},
 		hard.ModuleAccountName:      {supply.Minter, supply.Burner},
-		hard.LiquidatorAccount:      {supply.Minter, supply.Burner},
 	}
 
 	// module accounts that are allowed to receive tokens

--- a/x/hard/alias.go
+++ b/x/hard/alias.go
@@ -29,7 +29,6 @@ const (
 	EventTypeHardLPDistribution        = types.EventTypeHardLPDistribution
 	EventTypeHardRepay                 = types.EventTypeHardRepay
 	EventTypeHardWithdrawal            = types.EventTypeHardWithdrawal
-	LiquidatorAccount                  = types.LiquidatorAccount
 	ModuleAccountName                  = types.ModuleAccountName
 	ModuleName                         = types.ModuleName
 	QuerierRoute                       = types.QuerierRoute

--- a/x/hard/genesis.go
+++ b/x/hard/genesis.go
@@ -43,13 +43,6 @@ func InitGenesis(ctx sdk.Context, k Keeper, supplyKeeper types.SupplyKeeper, gs 
 	if DepositModuleAccount == nil {
 		panic(fmt.Sprintf("%s module account has not been set", DepositModuleAccount))
 	}
-
-	// check if the module account exists
-	LiquidatorModuleAcc := supplyKeeper.GetModuleAccount(ctx, LiquidatorAccount)
-	if LiquidatorModuleAcc == nil {
-		panic(fmt.Sprintf("%s module account has not been set", LiquidatorAccount))
-	}
-
 }
 
 // ExportGenesis export genesis state for hard module

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -77,7 +77,7 @@ func (k Keeper) SeizeDeposits(ctx sdk.Context, keeper sdk.AccAddress, deposit ty
 	for _, depCoin := range deposit.Amount {
 		mm, _ := k.GetMoneyMarket(ctx, depCoin.Denom)
 		// No keeper rewards if liquidated by LTV index
-		if !keeper.Equals(sdk.AccAddress(types.LiquidatorAccount)) {
+		if !keeper.Equals(sdk.AccAddress(types.ModuleAccountName)) {
 			keeperReward := mm.KeeperRewardPercentage.MulInt(depCoin.Amount).TruncateInt()
 			if keeperReward.GT(sdk.ZeroInt()) {
 				// Send keeper their reward
@@ -179,11 +179,7 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				}
 
 				// Start auction: bid = full borrow amount, lot = maxLotSize
-				err := k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleAccountName, types.LiquidatorAccount, sdk.NewCoins(lot))
-				if err != nil {
-					return liquidatedCoins, err
-				}
-				_, err = k.auctionKeeper.StartCollateralAuction(ctx, types.LiquidatorAccount, lot, bid, returnAddrs, weights, debt)
+				_, err := k.auctionKeeper.StartCollateralAuction(ctx, types.ModuleAccountName, lot, bid, returnAddrs, weights, debt)
 				if err != nil {
 					return liquidatedCoins, err
 				}
@@ -224,11 +220,7 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				}
 
 				// Start auction: bid = maxBid, lot = whole deposit amount
-				err := k.supplyKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleAccountName, types.LiquidatorAccount, sdk.NewCoins(lot))
-				if err != nil {
-					return liquidatedCoins, err
-				}
-				_, err = k.auctionKeeper.StartCollateralAuction(ctx, types.LiquidatorAccount, lot, bid, returnAddrs, weights, debt)
+				_, err := k.auctionKeeper.StartCollateralAuction(ctx, types.ModuleAccountName, lot, bid, returnAddrs, weights, debt)
 				if err != nil {
 					return liquidatedCoins, err
 				}

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -76,14 +76,11 @@ func (k Keeper) SeizeDeposits(ctx sdk.Context, keeper sdk.AccAddress, deposit ty
 	keeperRewardCoins := sdk.Coins{}
 	for _, depCoin := range deposit.Amount {
 		mm, _ := k.GetMoneyMarket(ctx, depCoin.Denom)
-		// No keeper rewards if liquidated by LTV index
-		if !keeper.Equals(sdk.AccAddress(types.ModuleAccountName)) {
-			keeperReward := mm.KeeperRewardPercentage.MulInt(depCoin.Amount).TruncateInt()
-			if keeperReward.GT(sdk.ZeroInt()) {
-				// Send keeper their reward
-				keeperCoin := sdk.NewCoin(depCoin.Denom, keeperReward)
-				keeperRewardCoins = append(keeperRewardCoins, keeperCoin)
-			}
+		keeperReward := mm.KeeperRewardPercentage.MulInt(depCoin.Amount).TruncateInt()
+		if keeperReward.GT(sdk.ZeroInt()) {
+			// Send keeper their reward
+			keeperCoin := sdk.NewCoin(depCoin.Denom, keeperReward)
+			keeperRewardCoins = append(keeperRewardCoins, keeperCoin)
 		}
 	}
 	if !keeperRewardCoins.Empty() {

--- a/x/hard/keeper/liquidation_test.go
+++ b/x/hard/keeper/liquidation_test.go
@@ -78,7 +78,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              1,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 9500390),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -116,7 +116,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              1,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 11874430),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("bnb", 0),
@@ -131,7 +131,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              2,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 11874254),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("btc", 0),
@@ -146,7 +146,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              3,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 11875163),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -161,7 +161,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              4,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 11876185),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("usdc", 0),
@@ -199,7 +199,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              1,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("bnb", 950000000),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -214,7 +214,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              2,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("btc", 95000000),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -229,7 +229,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              3,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("ukava", 47504818),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -268,7 +268,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              1,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdc", 95000000), // $95.00
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("bnb", 0),
@@ -283,7 +283,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              2,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdt", 10552835), // $10.55
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("bnb", 0),
@@ -298,7 +298,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              3,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdt", 84447165), // $84.45
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("btc", 0),
@@ -313,7 +313,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              4,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdx", 21097866), // $21.10
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("btc", 0),
@@ -328,7 +328,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              5,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdx", 73902133), //$73.90
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("ukava", 0),
@@ -366,7 +366,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              1,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("dai", 263894126),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("usdt", 0),
@@ -381,7 +381,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              2,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("dai", 68605874),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("usdx", 0),
@@ -396,7 +396,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 					auctypes.CollateralAuction{
 						BaseAuction: auctypes.BaseAuction{
 							ID:              3,
-							Initiator:       "hard_liquidator",
+							Initiator:       "hard",
 							Lot:             sdk.NewInt64Coin("usdc", 189999999),
 							Bidder:          nil,
 							Bid:             sdk.NewInt64Coin("usdx", 0),

--- a/x/hard/keeper/timelock_test.go
+++ b/x/hard/keeper/timelock_test.go
@@ -299,19 +299,19 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 				ak.SetAccount(ctx, pva)
 			}
 			supplyKeeper := tApp.GetSupplyKeeper()
-			supplyKeeper.MintCoins(ctx, types.LiquidatorAccount, sdk.NewCoins(sdk.NewCoin("hard", sdk.NewInt(1000))))
+			supplyKeeper.MintCoins(ctx, types.ModuleAccountName, sdk.NewCoins(sdk.NewCoin("hard", sdk.NewInt(1000))))
 			keeper := tApp.GetHardKeeper()
 			suite.app = tApp
 			suite.ctx = ctx
 			suite.keeper = keeper
 
-			err := suite.keeper.SendTimeLockedCoinsToAccount(suite.ctx, types.LiquidatorAccount, tc.args.accArgs.addr, tc.args.period.Amount, tc.args.period.Length)
+			err := suite.keeper.SendTimeLockedCoinsToAccount(suite.ctx, types.ModuleAccountName, tc.args.accArgs.addr, tc.args.period.Amount, tc.args.period.Length)
 
 			if tc.errArgs.expectPass {
 				suite.Require().NoError(err)
 				acc := suite.getAccount(tc.args.accArgs.addr)
 				suite.Require().Equal(tc.args.expectedAccountBalance, acc.GetCoins())
-				mAcc := suite.getModuleAccount(types.LiquidatorAccount)
+				mAcc := suite.getModuleAccount(types.ModuleAccountName)
 				suite.Require().Equal(tc.args.expectedModAccountBalance, mAcc.GetCoins())
 				vacc, ok := acc.(*vesting.PeriodicVestingAccount)
 				if tc.args.accArgs.vestingAccountAfter {

--- a/x/hard/types/keys.go
+++ b/x/hard/types/keys.go
@@ -4,9 +4,6 @@ const (
 	// ModuleName name that will be used throughout the module
 	ModuleName = "hard"
 
-	// LiquidatorAccount module account for liquidator
-	LiquidatorAccount = "hard_liquidator"
-
 	// ModuleAccountName name of module account used to hold deposits
 	ModuleAccountName = "hard"
 


### PR DESCRIPTION
- Remove liquidation module account from Hard module
- Remove legacy code originally removed in https://github.com/Kava-Labs/kava/pull/795, but that PR was closed so it didn't get included in master