### PR TITLE
fix: export synced deposits/borrows

### DIFF
--- a/x/cdp/genesis.go
+++ b/x/cdp/genesis.go
@@ -94,7 +94,8 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 	cdps := CDPs{}
 	deposits := Deposits{}
 	k.IterateAllCdps(ctx, func(cdp CDP) (stop bool) {
-		cdps = append(cdps, cdp)
+		syncedCdp := k.SynchronizeInterest(ctx, cdp)
+		cdps = append(cdps, syncedCdp)
 		k.IterateDeposits(ctx, cdp.ID, func(deposit Deposit) (stop bool) {
 			deposits = append(deposits, deposit)
 			return false

--- a/x/hard/genesis.go
+++ b/x/hard/genesis.go
@@ -61,12 +61,20 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 	borrows := types.Borrows{}
 
 	k.IterateDeposits(ctx, func(d types.Deposit) bool {
-		deposits = append(deposits, d)
+		syncedDeposit, found := k.GetSyncedDeposit(ctx, d.Depositor)
+		if !found {
+			panic(fmt.Sprintf("syncable deposit not found for %s", d.Depositor))
+		}
+		deposits = append(deposits, syncedDeposit)
 		return false
 	})
 
 	k.IterateBorrows(ctx, func(b types.Borrow) bool {
-		borrows = append(borrows, b)
+		syncedBorrow, found := k.GetSyncedBorrow(ctx, b.Borrower)
+		if !found {
+			panic(fmt.Sprintf("syncable borrow not found for %s", b.Borrower))
+		}
+		borrows = append(borrows, syncedBorrow)
 		return false
 	})
 


### PR DESCRIPTION
Synchronizes each deposit/borrow at `ExportGenesis` so that the balance is correct and the object's indexes match the global indexes. 

Synchronizes CDP interest at export as well. 