### PR TITLE
fix: collateral param permission

### DIFF
--- a/x/committee/types/permissions.go
+++ b/x/committee/types/permissions.go
@@ -354,7 +354,7 @@ func (acps AllowedCollateralParams) Allows(current, incoming cdptypes.Collateral
 		var foundCurrentCP bool
 		var currentCP cdptypes.CollateralParam
 		for _, p := range current {
-			if p.Denom != incomingCP.Denom {
+			if p.Type != incomingCP.Type {
 				continue
 			}
 			foundCurrentCP = true


### PR DESCRIPTION
FIxes issue in `Allows` method for `cdp.CollateralParams` which was comparing `Denom` instead of `Type`. Denom is no longer guaranteed to be unique (`busd-a` and `busd-b`) and this caused the `Allows` method to fail for collateral param changes. 