### PR TITLE
Query Hard module's supply/borrow APYs

### DIFF
--- a/x/hard/alias.go
+++ b/x/hard/alias.go
@@ -45,6 +45,7 @@ const (
 var (
 	// function aliases
 	APYToSPY                      = keeper.APYToSPY
+	SPYToEstimatedAPY             = keeper.SPYToEstimatedAPY
 	CalculateBorrowInterestFactor = keeper.CalculateBorrowInterestFactor
 	CalculateBorrowRate           = keeper.CalculateBorrowRate
 	CalculateSupplyInterestFactor = keeper.CalculateSupplyInterestFactor

--- a/x/hard/client/cli/query.go
+++ b/x/hard/client/cli/query.go
@@ -41,6 +41,7 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		queryTotalDepositedCmd(queryRoute, cdc),
 		queryBorrowsCmd(queryRoute, cdc),
 		queryTotalBorrowedCmd(queryRoute, cdc),
+		queryInterestRateCmd(queryRoute, cdc),
 	)...)
 
 	return hardQueryCmd
@@ -314,5 +315,48 @@ func queryTotalDepositedCmd(queryRoute string, cdc *codec.Codec) *cobra.Command 
 		},
 	}
 	cmd.Flags().String(flagDenom, "", "(optional) filter total deposited coins by denom")
+	return cmd
+}
+
+func queryInterestRateCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "interest-rate",
+		Short: "get current money market interest rates",
+		Long: strings.TrimSpace(`get current money market interest rates:
+
+		Example:
+		$ kvcli q hard interest-rate
+		$ kvcli q hard interest-rate --denom bnb`,
+		),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			denom := viper.GetString(flagDenom)
+
+			// Construct query with params
+			params := types.NewQueryInterestRateParams(denom)
+			bz, err := cdc.MarshalJSON(params)
+			if err != nil {
+				return err
+			}
+
+			// Execute query
+			route := fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryGetInterestRate)
+			res, height, err := cliCtx.QueryWithData(route, bz)
+			if err != nil {
+				return err
+			}
+			cliCtx = cliCtx.WithHeight(height)
+
+			// Decode and print results
+			var moneyMarketInterestRates types.MoneyMarketInterestRates
+			if err := cdc.UnmarshalJSON(res, &moneyMarketInterestRates); err != nil {
+				return fmt.Errorf("failed to unmarshal money market interest rates: %w", err)
+			}
+			return cliCtx.PrintOutput(moneyMarketInterestRates)
+		},
+	}
+	cmd.Flags().String(flagDenom, "", "(optional) filter interest rates by denom")
 	return cmd
 }

--- a/x/hard/keeper/interest.go
+++ b/x/hard/keeper/interest.go
@@ -300,6 +300,12 @@ func APYToSPY(apy sdk.Dec) (sdk.Dec, error) {
 	return root, nil
 }
 
+// SPYToEstimatedAPY converts the internal per second compounded interest rate into an estimated annual
+// interest rate. The returned value is an estimate  and should not be used for financial calculations.
+func SPYToEstimatedAPY(apy sdk.Dec) sdk.Dec {
+	return apy.Power(uint64(secondsPerYear))
+}
+
 // minInt64 returns the smaller of x or y
 func minDec(x, y sdk.Dec) sdk.Dec {
 	if x.GT(y) {

--- a/x/hard/keeper/keeper.go
+++ b/x/hard/keeper/keeper.go
@@ -235,6 +235,15 @@ func (k Keeper) IterateMoneyMarkets(ctx sdk.Context, cb func(denom string, money
 	}
 }
 
+// GetAllMoneyMarkets returns all money markets from the store
+func (k Keeper) GetAllMoneyMarkets(ctx sdk.Context) (moneyMarkets types.MoneyMarkets) {
+	k.IterateMoneyMarkets(ctx, func(denom string, moneyMarket types.MoneyMarket) bool {
+		moneyMarkets = append(moneyMarkets, moneyMarket)
+		return false
+	})
+	return
+}
+
 // GetPreviousAccrualTime returns the last time an individual market accrued interest
 func (k Keeper) GetPreviousAccrualTime(ctx sdk.Context, denom string) (time.Time, bool) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.PreviousAccrualTimePrefix)

--- a/x/hard/types/querier.go
+++ b/x/hard/types/querier.go
@@ -12,6 +12,7 @@ const (
 	QueryGetTotalDeposited = "total-deposited"
 	QueryGetBorrows        = "borrows"
 	QueryGetTotalBorrowed  = "total-borrowed"
+	QueryGetInterestRate   = "interest-rate"
 )
 
 // QueryDepositsParams is the params for a filtered deposit query
@@ -89,3 +90,34 @@ func NewQueryTotalDepositedParams(denom string) QueryTotalDepositedParams {
 		Denom: denom,
 	}
 }
+
+// QueryInterestRateParams is the params for a filtered interest rate query
+type QueryInterestRateParams struct {
+	Denom string `json:"denom" yaml:"denom"`
+}
+
+// NewQueryInterestRateParams creates a new QueryInterestRateParams
+func NewQueryInterestRateParams(denom string) QueryInterestRateParams {
+	return QueryInterestRateParams{
+		Denom: denom,
+	}
+}
+
+// MoneyMarketInterestRate is a unique type returned by interest rate queries
+type MoneyMarketInterestRate struct {
+	Denom              string  `json:"denom" yaml:"denom"`
+	SupplyInterestRate sdk.Dec `json:"supply_interest_rate" yaml:"supply_interest_rate"`
+	BorrowInterestRate sdk.Dec `json:"borrow_interest_rate" yaml:"borrow_interest_rate"`
+}
+
+// NewMoneyMarketInterestRate returns a new instance of MoneyMarketInterestRate
+func NewMoneyMarketInterestRate(denom string, supplyInterestRate, borrowInterestRate sdk.Dec) MoneyMarketInterestRate {
+	return MoneyMarketInterestRate{
+		Denom:              denom,
+		SupplyInterestRate: supplyInterestRate,
+		BorrowInterestRate: borrowInterestRate,
+	}
+}
+
+// MoneyMarketInterestRates is a slice of MoneyMarketInterestRate
+type MoneyMarketInterestRates []MoneyMarketInterestRate


### PR DESCRIPTION
Implements new query `kvcli q hard interest-rate` which accepts an optional denom argument i.e. `kvcli q hard interest-rate ukava` and returns an array of MoneyMarketInterestRates:

```go
// MoneyMarketInterestRate is a unique type returned by interest rate queries
type MoneyMarketInterestRate struct {
	Denom              string  `json:"denom" yaml:"denom"`
	SupplyInterestRate sdk.Dec `json:"supply_interest_rate" yaml:"supply_interest_rate"`
	BorrowInterestRate sdk.Dec `json:"borrow_interest_rate" yaml:"borrow_interest_rate"`
}
```