### PR TITLE
[R4R] Hard Audit: Refresh borrow before repay

### DIFF
--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -9,16 +9,19 @@ import (
 
 // Repay borrowed funds
 func (k Keeper) Repay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.Coins) error {
-	// Sync borrow interest so loan is up-to-date
-	k.SyncBorrowInterest(ctx, owner)
 
-	// Check borrow exists here to avoid duplicating store read in ValidateRepay
 	borrow, found := k.GetBorrow(ctx, owner)
 	if !found {
 		return types.ErrBorrowNotFound
 	}
 	// Call incentive hook
 	k.BeforeBorrowModified(ctx, borrow)
+
+	// Sync borrow interest so loan is up-to-date
+	k.SyncBorrowInterest(ctx, owner)
+
+	// refresh borrow after syncing interest
+	borrow, _ = k.GetBorrow(ctx, owner)
 
 	// Validate that sender holds coins for repayment
 	err := k.ValidateRepay(ctx, sender, coins)

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -23,6 +23,9 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 	k.SyncBorrowInterest(ctx, depositor)
 	k.SyncSupplyInterest(ctx, depositor)
 
+	// refresh deposit after syncing interest
+	deposit, _ = k.GetDeposit(ctx, depositor)
+
 	amount, err := k.CalculateWithdrawAmount(deposit.Amount, coins)
 	if err != nil {
 		return err


### PR DESCRIPTION
Current implementation was fetching `borrow` from the store before syncing interest when a repayment was made. Additionally, the error value for the method `DecrementBorrowedCoins` wasn't being checked. It turns out, it was sometimes throwing an error because it didn't account for the fact that `payment` can be greater than `borrowedCoins`. Because interest accumulates every 7 seconds, while positions are only synced infrequently (when users interact with them), a position can accumulate a few micro-units more borrow interest. When that position is the only position,`DecrementBorrowedCoins` will error. 

