### PR TITLE
fix: account for start time in calculating time elapsed

### DIFF
--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -642,10 +642,16 @@ func (k Keeper) ZeroHardLiquidityProviderClaim(ctx sdk.Context, claim types.Hard
 // CalculateTimeElapsed calculates the number of reward-eligible seconds that have passed since the previous
 // time rewards were accrued, taking into account the end time of the reward period
 func CalculateTimeElapsed(start, end, blockTime time.Time, previousAccrualTime time.Time) sdk.Int {
-	if end.Before(blockTime) &&
-		(end.Before(previousAccrualTime) || end.Equal(previousAccrualTime)) {
+	if (end.Before(blockTime) &&
+		(end.Before(previousAccrualTime) || end.Equal(previousAccrualTime))) ||
+		(start.After(previousAccrualTime)) ||
+		(start.Equal(blockTime)) {
 		return sdk.ZeroInt()
 	}
+	if start.After(previousAccrualTime) && start.Before(blockTime) {
+		previousAccrualTime = start
+	}
+
 	if end.Before(blockTime) {
 		return sdk.NewInt(int64(math.RoundToEven(
 			end.Sub(previousAccrualTime).Seconds(),


### PR DESCRIPTION
Incentive rewards wasn't looking at reward period start time, so it would accumulate rewards even if they were not supposed to have started. 