### PR TITLE
Hard Audit: add minimum borrow USD value

### DIFF
--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -245,6 +245,50 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				contains:   "fails global asset borrow limit validation",
 			},
 		},
+		{
+			"invalid: borrowing an individual coin type results in a borrow that's under the minimum USD borrow limit",
+			args{
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))),
+				previousBorrowCoins:       sdk.NewCoins(),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(5*USDX_CF))),
+				expectedAccountBalance:    sdk.NewCoins(),
+				expectedModAccountBalance: sdk.NewCoins(),
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "below the minimum borrow limit",
+			},
+		},
+		{
+			"invalid: borrowing multiple coins results in a borrow that's under the minimum USD borrow limit",
+			args{
+				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(50*KAVA_CF))),
+				previousBorrowCoins:       sdk.NewCoins(),
+				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(5*USDX_CF)), sdk.NewCoin("ukava", sdk.NewInt(2*USDX_CF))),
+				expectedAccountBalance:    sdk.NewCoins(),
+				expectedModAccountBalance: sdk.NewCoins(),
+			},
+			errArgs{
+				expectPass: false,
+				contains:   "below the minimum borrow limit",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
@@ -269,6 +313,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 					types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BNB_CF), tc.args.loanToValueBNB), "bnb:usd", sdk.NewInt(BNB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 					types.NewMoneyMarket("xyz", types.NewBorrowLimit(false, sdk.NewDec(1), tc.args.loanToValueBNB), "xyz:usd", sdk.NewInt(1), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/deposit_test.go
+++ b/x/hard/keeper/deposit_test.go
@@ -111,6 +111,7 @@ func (suite *KeeperTestSuite) TestDeposit() {
 					types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "bnb:usd", sdk.NewInt(1000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 					types.NewMoneyMarket("btcb", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "btcb:usd", sdk.NewInt(1000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/interest_test.go
+++ b/x/hard/keeper/interest_test.go
@@ -796,6 +796,7 @@ func (suite *KeeperTestSuite) TestBorrowInterest() {
 						tc.args.reserveFactor,     // Reserve Factor
 						sdk.ZeroDec()),            // Keeper Reward Percentage
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)
@@ -1209,6 +1210,7 @@ func (suite *KeeperTestSuite) TestSupplyInterest() {
 						tc.args.reserveFactor,     // Reserve Factor
 						sdk.ZeroDec()),            // Keeper Reward Percentage
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/liquidation_test.go
+++ b/x/hard/keeper/liquidation_test.go
@@ -511,6 +511,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 						reserveFactor,                // Reserve Factor
 						tc.args.keeperRewardPercent), // Keeper Reward Percent
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/params.go
+++ b/x/hard/keeper/params.go
@@ -28,3 +28,9 @@ func (k Keeper) GetMoneyMarketParam(ctx sdk.Context, denom string) (types.MoneyM
 	}
 	return types.MoneyMarket{}, false
 }
+
+// GetMinimumBorrowUSDValue returns the minimum borrow USD value
+func (k Keeper) GetMinimumBorrowUSDValue(ctx sdk.Context) sdk.Dec {
+	params := k.GetParams(ctx)
+	return params.MinimumBorrowUSDValue
+}

--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -148,7 +148,7 @@ func (k Keeper) ValidateRepay(ctx sdk.Context, sender, owner sdk.AccAddress, coi
 
 	// If the proposed repayment would results in a borrowed USD value below the minimum borrow USD value, reject it.
 	// User can overpay their loan to close it out, but underpaying by such a margin that the USD value is in an
-	// invalid range is not allowed.
+	// invalid range is not allowed
 	proposedBorrowNewUSDValue := existingBorrowUSDValue.Sub(repayTotalUSDValue)
 	if proposedBorrowNewUSDValue.IsPositive() && proposedBorrowNewUSDValue.LT(k.GetMinimumBorrowUSDValue(ctx)) {
 		return sdkerrors.Wrapf(types.ErrBelowMinimumBorrowValue, "the proposed borrow's USD value $%s is below the minimum borrow limit $%s", proposedBorrowNewUSDValue, k.GetMinimumBorrowUSDValue(ctx))

--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -21,7 +21,7 @@ func (k Keeper) Repay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.C
 	k.SyncBorrowInterest(ctx, owner)
 
 	// Validate that sender holds coins for repayment
-	err := k.ValidateRepay(ctx, sender, coins)
+	err := k.ValidateRepay(ctx, sender, owner, coins)
 	if err != nil {
 		return err
 	}
@@ -78,14 +78,80 @@ func (k Keeper) Repay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.C
 }
 
 // ValidateRepay validates a requested loan repay
-func (k Keeper) ValidateRepay(ctx sdk.Context, sender sdk.AccAddress, coins sdk.Coins) error {
+func (k Keeper) ValidateRepay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.Coins) error {
+	moneyMarketCache := map[string]types.MoneyMarket{}
+	assetPriceCache := map[string]sdk.Dec{}
+
+	// Get the total USD value of user's existing borrows
+	existingBorrowUSDValue := sdk.ZeroDec()
+	existingBorrow, found := k.GetBorrow(ctx, owner)
+	if found {
+		for _, borrowedCoin := range existingBorrow.Amount {
+			moneyMarket, ok := moneyMarketCache[borrowedCoin.Denom]
+			if !ok { // Fetch money market and store in local cache
+				newMoneyMarket, found := k.GetMoneyMarketParam(ctx, borrowedCoin.Denom)
+				if !found {
+					return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", borrowedCoin.Denom)
+				}
+				moneyMarketCache[borrowedCoin.Denom] = newMoneyMarket
+				moneyMarket = newMoneyMarket
+			}
+
+			assetPrice, ok := assetPriceCache[borrowedCoin.Denom]
+			if !ok { // Fetch current asset price and store in local cache
+				assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+				if err != nil {
+					return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+				}
+				assetPriceCache[borrowedCoin.Denom] = assetPriceInfo.Price
+				assetPrice = assetPriceInfo.Price
+			}
+
+			// Calculate this borrow coin's USD value and add it to the total previous borrowed USD value
+			coinUSDValue := sdk.NewDecFromInt(borrowedCoin.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPrice)
+			existingBorrowUSDValue = existingBorrowUSDValue.Add(coinUSDValue)
+		}
+	}
+
 	senderAcc := k.accountKeeper.GetAccount(ctx, sender)
 	senderCoins := senderAcc.SpendableCoins(ctx.BlockTime())
-
-	for _, coin := range coins {
-		if senderCoins.AmountOf(coin.Denom).LT(coin.Amount) {
-			return sdkerrors.Wrapf(types.ErrInsufficientBalanceForRepay, "account can only repay up to %s%s", senderCoins.AmountOf(coin.Denom), coin.Denom)
+	repayTotalUSDValue := sdk.ZeroDec()
+	for _, repayCoin := range coins {
+		// Check that sender holds enough tokens to make the proposed payment
+		if senderCoins.AmountOf(repayCoin.Denom).LT(repayCoin.Amount) {
+			return sdkerrors.Wrapf(types.ErrInsufficientBalanceForRepay, "account can only repay up to %s%s", senderCoins.AmountOf(repayCoin.Denom), repayCoin.Denom)
 		}
+
+		moneyMarket, ok := moneyMarketCache[repayCoin.Denom]
+		if !ok { // Fetch money market and store in local cache
+			newMoneyMarket, found := k.GetMoneyMarketParam(ctx, repayCoin.Denom)
+			if !found {
+				return sdkerrors.Wrapf(types.ErrMarketNotFound, "no market found for denom %s", repayCoin.Denom)
+			}
+			moneyMarketCache[repayCoin.Denom] = newMoneyMarket
+			moneyMarket = newMoneyMarket
+		}
+
+		// Calculate this coin's USD value and add it to the repay's total USD value
+		assetPrice, ok := assetPriceCache[repayCoin.Denom]
+		if !ok { // Fetch current asset price and store in local cache
+			assetPriceInfo, err := k.pricefeedKeeper.GetCurrentPrice(ctx, moneyMarket.SpotMarketID)
+			if err != nil {
+				return sdkerrors.Wrapf(types.ErrPriceNotFound, "no price found for market %s", moneyMarket.SpotMarketID)
+			}
+			assetPriceCache[repayCoin.Denom] = assetPriceInfo.Price
+			assetPrice = assetPriceInfo.Price
+		}
+		coinUSDValue := sdk.NewDecFromInt(repayCoin.Amount).Quo(sdk.NewDecFromInt(moneyMarket.ConversionFactor)).Mul(assetPrice)
+		repayTotalUSDValue = repayTotalUSDValue.Add(coinUSDValue)
+	}
+
+	// If the proposed repayment would results in a borrowed USD value below the minimum borrow USD value, reject it.
+	// User can overpay their loan to close it out, but underpaying by such a margin that the USD value is in an
+	// invalid range is not allowed.
+	proposedBorrowNewUSDValue := existingBorrowUSDValue.Sub(repayTotalUSDValue)
+	if proposedBorrowNewUSDValue.IsPositive() && proposedBorrowNewUSDValue.LT(k.GetMinimumBorrowUSDValue(ctx)) {
+		return sdkerrors.Wrapf(types.ErrBelowMinimumBorrowValue, "the proposed borrow's USD value $%s is below the minimum borrow limit $%s", proposedBorrowNewUSDValue, k.GetMinimumBorrowUSDValue(ctx))
 	}
 
 	return nil

--- a/x/hard/keeper/timelock_test.go
+++ b/x/hard/keeper/timelock_test.go
@@ -285,6 +285,7 @@ func (suite *KeeperTestSuite) TestSendTimeLockedCoinsToAccount() {
 					types.NewMoneyMarket("usdx", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "usdx:usd", sdk.NewInt(1000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 					types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "kava:usd", sdk.NewInt(1000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/withdraw_test.go
+++ b/x/hard/keeper/withdraw_test.go
@@ -129,6 +129,7 @@ func (suite *KeeperTestSuite) TestWithdraw() {
 					types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "kava:usd", sdk.NewInt(1000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 					types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(1000000000000000), loanToValue), "bnb:usd", sdk.NewInt(100000000), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)
@@ -280,6 +281,7 @@ func (suite *KeeperTestSuite) TestLtvWithdraw() {
 						reserveFactor,                  // Reserve Factor
 						sdk.MustNewDecFromStr("0.05")), // Keeper Reward Percent
 				},
+				sdk.NewDec(10),
 			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
 				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
 			)

--- a/x/hard/keeper/withdraw_test.go
+++ b/x/hard/keeper/withdraw_test.go
@@ -213,6 +213,7 @@ func (suite *KeeperTestSuite) TestLtvWithdraw() {
 		initialBorrowerCoins sdk.Coins
 		depositCoins         sdk.Coins
 		borrowCoins          sdk.Coins
+		repayCoins           sdk.Coins
 		futureTime           int64
 	}
 
@@ -240,8 +241,9 @@ func (suite *KeeperTestSuite) TestLtvWithdraw() {
 				borrower:             borrower,
 				initialModuleCoins:   sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))),
 				initialBorrowerCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF)), sdk.NewCoin("usdx", sdk.NewInt(100*KAVA_CF))),
-				depositCoins:         sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(10*KAVA_CF))), // 10 * 2 = $20
-				borrowCoins:          sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(8*KAVA_CF))),  // 8 * 2 = $16
+				depositCoins:         sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(100*KAVA_CF))), // 100 * 2 = $200
+				borrowCoins:          sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(80*KAVA_CF))),  // 80 * 2 = $160
+				repayCoins:           sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(60*KAVA_CF))),  // 60 * 2 = $120
 				futureTime:           oneMonthInSeconds,
 			},
 			errArgs{
@@ -355,8 +357,8 @@ func (suite *KeeperTestSuite) TestLtvWithdraw() {
 			suite.Require().Error(err)
 			suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
 
-			// Repay the initial principal
-			err = suite.keeper.Repay(suite.ctx, tc.args.borrower, tc.args.borrower, tc.args.borrowCoins)
+			// Repay the initial principal. Over pay the position so the borrow is closed.
+			err = suite.keeper.Repay(suite.ctx, tc.args.borrower, tc.args.borrower, tc.args.repayCoins)
 			suite.Require().NoError(err)
 
 			// Attempted withdraw of all deposited coins fails as user hasn't repaid interest debt
@@ -364,8 +366,8 @@ func (suite *KeeperTestSuite) TestLtvWithdraw() {
 			suite.Require().Error(err)
 			suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
 
-			// Withdrawing half the coins should succeed
-			withdrawCoins := sdk.NewCoins(sdk.NewCoin("ukava", tc.args.depositCoins[0].Amount.Quo(sdk.NewInt(2))))
+			// Withdrawing 10% of the coins should succeed
+			withdrawCoins := sdk.NewCoins(sdk.NewCoin("ukava", tc.args.depositCoins[0].Amount.Quo(sdk.NewInt(10))))
 			err = suite.keeper.Withdraw(suite.ctx, tc.args.borrower, withdrawCoins)
 			suite.Require().NoError(err)
 		})

--- a/x/hard/types/errors.go
+++ b/x/hard/types/errors.go
@@ -63,4 +63,6 @@ var (
 	ErrInvalidRepaymentDenom = sdkerrors.Register(ModuleName, 28, "no coins of this type borrowed")
 	// ErrInvalidIndexFactorDenom error for when index factor denom cannot be found
 	ErrInvalidIndexFactorDenom = sdkerrors.Register(ModuleName, 29, "no index factor found for denom")
+	// ErrBelowMinimumBorrowValue error for when a proposed borrow position is less than the minimum USD value
+	ErrBelowMinimumBorrowValue = sdkerrors.Register(ModuleName, 30, "invalid proposed borrow value")
 )

--- a/x/hard/types/genesis_test.go
+++ b/x/hard/types/genesis_test.go
@@ -61,6 +61,7 @@ func (suite *GenesisTestSuite) TestGenesisValidation() {
 					types.MoneyMarkets{
 						types.NewMoneyMarket("usdx", types.NewBorrowLimit(true, sdk.MustNewDecFromStr("100000000000"), sdk.MustNewDecFromStr("1")), "usdx:usd", sdk.NewInt(USDX_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 					},
+					sdk.MustNewDecFromStr("10"),
 				),
 				gats: types.GenesisAccumulationTimes{
 					types.NewGenesisAccumulationTime("usdx", time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC), sdk.OneDec(), sdk.OneDec()),

--- a/x/hard/types/params_test.go
+++ b/x/hard/types/params_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/kava-labs/kava/x/hard/types"
@@ -15,7 +16,8 @@ type ParamTestSuite struct {
 
 func (suite *ParamTestSuite) TestParamValidation() {
 	type args struct {
-		mms types.MoneyMarkets
+		minBorrowVal sdk.Dec
+		mms          types.MoneyMarkets
 	}
 	testCases := []struct {
 		name        string
@@ -26,7 +28,8 @@ func (suite *ParamTestSuite) TestParamValidation() {
 		{
 			name: "default",
 			args: args{
-				mms: types.DefaultMoneyMarkets,
+				minBorrowVal: types.DefaultMinimumBorrowUSDValue,
+				mms:          types.DefaultMoneyMarkets,
 			},
 			expectPass:  true,
 			expectedErr: "",
@@ -34,7 +37,7 @@ func (suite *ParamTestSuite) TestParamValidation() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			params := types.NewParams(tc.args.mms)
+			params := types.NewParams(tc.args.mms, tc.args.minBorrowVal)
 			err := params.Validate()
 			if tc.expectPass {
 				suite.NoError(err)

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -159,6 +159,7 @@ func NewHardGenStateMulti() app.GenesisState {
 			hard.NewMoneyMarket("btcb", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "btc:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 			hard.NewMoneyMarket("xrp", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "xrp:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 		},
+		sdk.NewDec(10),
 	), hard.DefaultAccumulationTimes, hard.DefaultDeposits, hard.DefaultBorrows,
 		hard.DefaultTotalSupplied, hard.DefaultTotalBorrowed, hard.DefaultTotalReserves,
 	)


### PR DESCRIPTION
Adds a minimum borrow USD value, default is $10.

Design decisions:
- `MinimumBorrowUSDValue` is a module-level param, it's not inside `MoneyMarkets`. Users can borrow/repay multiple coins per tx so instead of checking individual asset values we need to calculate the proposed resulting borrow's total USD value and compare it to an aggregate minimum USD limit. It also simplifies param management, as there's just one USD denominated value instead of maintaining several limits denominated in different currencies.

Optimizations:
- `ValidateBorrow` and `ValidateRepay` use a caching strategy to reduce param reads as they add computational overhead. Since `MoneyMarkets` are available in the store, we should just read them directly from there and not fetch `MoneyMarkets` from params at all. If we're in agreement about this change let's add an issue/card for it.