### PR TITLE
Hard Audit: decrement total borrowed on liquidation

### DIFF
--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -234,9 +234,15 @@ func (k Keeper) DecrementBorrowedCoins(ctx sdk.Context, coins sdk.Coins) error {
 		return sdkerrors.Wrapf(types.ErrBorrowedCoinsNotFound, "cannot repay coins if no coins are currently borrowed")
 	}
 
-	updatedBorrowedCoins, isAnyNegative := borrowedCoins.SafeSub(coins)
-	if isAnyNegative {
-		return types.ErrNegativeBorrowedCoins
+	updatedBorrowedCoins := sdk.NewCoins()
+	for _, coin := range coins {
+		// If amount is greater than total borrowed amount due to rounding, set total borrowed amount to 0
+		// by skipping the coin such that it's not included in the updatedBorrowedCoins object
+		if coin.Amount.GTE(borrowedCoins.AmountOf(coin.Denom)) {
+			continue
+		}
+		updatedBorrowCoin := sdk.NewCoin(coin.Denom, borrowedCoins.AmountOf(coin.Denom).Sub(coin.Amount))
+		updatedBorrowedCoins = updatedBorrowedCoins.Add(updatedBorrowCoin)
 	}
 
 	k.SetBorrowedCoins(ctx, updatedBorrowedCoins)

--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -156,7 +156,7 @@ func (k Keeper) DecrementSuppliedCoins(ctx sdk.Context, coins sdk.Coins) error {
 		updatedSuppliedCoins = updatedSuppliedCoins.Add(updatedSupplyCoin)
 	}
 
-	k.SetSuppliedCoins(ctx, suppliedCoins)
+	k.SetSuppliedCoins(ctx, updatedSuppliedCoins)
 	return nil
 }
 

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -180,7 +180,7 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				if err != nil {
 					return liquidatedCoins, err
 				}
-				// Decrement supplied coins and increment borrowed coins optimistically
+				// Decrement supplied coins and decrement borrowed coins optimistically
 				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
 				err = k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
 				if err != nil {
@@ -228,9 +228,12 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				if err != nil {
 					return liquidatedCoins, err
 				}
-				// Decrement supplied coins and increment borrowed coins optimistically
+				// Decrement supplied coins and decrement borrowed coins optimistically
 				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
-				k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
+				err = k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
+				if err != nil {
+					return liquidatedCoins, err
+				}
 
 				// Add lot to liquidated coins
 				liquidatedCoins = liquidatedCoins.Add(lot)

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -181,7 +181,10 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 					return liquidatedCoins, err
 				}
 				// Decrement supplied coins and decrement borrowed coins optimistically
-				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
+				err = k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
+				if err != nil {
+					return liquidatedCoins, err
+				}
 				err = k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
 				if err != nil {
 					return liquidatedCoins, err
@@ -229,7 +232,10 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 					return liquidatedCoins, err
 				}
 				// Decrement supplied coins and decrement borrowed coins optimistically
-				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
+				err = k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
+				if err != nil {
+					return liquidatedCoins, err
+				}
 				err = k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
 				if err != nil {
 					return liquidatedCoins, err

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -182,7 +182,7 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				}
 				// Decrement supplied coins and increment borrowed coins optimistically
 				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
-				k.IncrementBorrowedCoins(ctx, sdk.Coins{bid})
+				k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
 
 				// Add lot to liquidated coins
 				liquidatedCoins = liquidatedCoins.Add(lot)
@@ -227,7 +227,7 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				}
 				// Decrement supplied coins and increment borrowed coins optimistically
 				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
-				k.IncrementBorrowedCoins(ctx, sdk.Coins{bid})
+				k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
 
 				// Add lot to liquidated coins
 				liquidatedCoins = liquidatedCoins.Add(lot)

--- a/x/hard/keeper/liquidation.go
+++ b/x/hard/keeper/liquidation.go
@@ -182,7 +182,10 @@ func (k Keeper) StartAuctions(ctx sdk.Context, borrower sdk.AccAddress, borrows,
 				}
 				// Decrement supplied coins and increment borrowed coins optimistically
 				k.DecrementSuppliedCoins(ctx, sdk.Coins{lot})
-				k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
+				err = k.DecrementBorrowedCoins(ctx, sdk.Coins{bid})
+				if err != nil {
+					return liquidatedCoins, err
+				}
 
 				// Add lot to liquidated coins
 				liquidatedCoins = liquidatedCoins.Add(lot)

--- a/x/hard/keeper/liquidation_test.go
+++ b/x/hard/keeper/liquidation_test.go
@@ -652,7 +652,7 @@ func (suite *KeeperTestSuite) TestKeeperLiquidation() {
 				suite.Require().Equal(suppliedCoinsPre.Sub(tc.args.expectedLiquidatedCoins), suppliedCoinsPost)
 				borrowedCoinsPost, _ := suite.keeper.GetBorrowedCoins(liqCtx)
 
-				suite.Require().Equal(borrowedCoinsPre.Add(tc.args.expectedBidCoins...), borrowedCoinsPost)
+				suite.Require().Equal(borrowedCoinsPre.Sub(tc.args.expectedBidCoins), borrowedCoinsPost)
 			} else {
 				suite.Require().Error(err)
 				suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))

--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -58,7 +58,10 @@ func (k Keeper) Repay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.C
 	}
 
 	// Update total borrowed amount
-	k.DecrementBorrowedCoins(ctx, payment)
+	err = k.DecrementBorrowedCoins(ctx, payment)
+	if err != nil {
+		return err
+	}
 
 	// Call incentive hook
 	if !borrow.Amount.Empty() {

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -64,8 +64,12 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 	} else {
 		k.SetDeposit(ctx, deposit)
 	}
+
 	// Update total supplied amount
-	k.DecrementSuppliedCoins(ctx, amount)
+	err = k.DecrementSuppliedCoins(ctx, amount)
+	if err != nil {
+		return err
+	}
 
 	// Call incentive hook
 	k.AfterDepositModified(ctx, deposit)


### PR DESCRIPTION
Decrement total borrowed instead of increment it when an auction starts