### PR TITLE
Hard Audit: refresh borrow/deposit after syncing

### DIFF
--- a/x/hard/keeper/repay.go
+++ b/x/hard/keeper/repay.go
@@ -20,6 +20,9 @@ func (k Keeper) Repay(ctx sdk.Context, sender, owner sdk.AccAddress, coins sdk.C
 	// Sync borrow interest so loan is up-to-date
 	k.SyncBorrowInterest(ctx, owner)
 
+	// Refresh borrow after syncing interest
+	borrow, _ = k.GetBorrow(ctx, owner)
+
 	// Validate that sender holds coins for repayment
 	err := k.ValidateRepay(ctx, sender, coins)
 	if err != nil {

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -26,7 +26,7 @@ func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Co
 	k.SyncSupplyInterest(ctx, depositor)
 
 	// Refresh Deposit after syncing interest
-	deposit, found := k.GetDeposit(ctx, depositor)
+	deposit, _ := k.GetDeposit(ctx, depositor)
 
 	amount, err := k.CalculateWithdrawAmount(deposit.Amount, coins)
 	if err != nil {

--- a/x/hard/keeper/withdraw.go
+++ b/x/hard/keeper/withdraw.go
@@ -9,19 +9,24 @@ import (
 
 // Withdraw returns some or all of a deposit back to original depositor
 func (k Keeper) Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coins) error {
-	deposit, found := k.GetDeposit(ctx, depositor)
+	// Call incentive hooks
+	existingDeposit, found := k.GetDeposit(ctx, depositor)
 	if !found {
 		return sdkerrors.Wrapf(types.ErrDepositNotFound, "no deposit found for %s", depositor)
 	}
-	// Call incentive hooks
-	k.BeforeDepositModified(ctx, deposit)
+	k.BeforeDepositModified(ctx, existingDeposit)
+
 	existingBorrow, hasExistingBorrow := k.GetBorrow(ctx, depositor)
 	if hasExistingBorrow {
 		k.BeforeBorrowModified(ctx, existingBorrow)
 	}
 
+	// Sync interest
 	k.SyncBorrowInterest(ctx, depositor)
 	k.SyncSupplyInterest(ctx, depositor)
+
+	// Refresh Deposit after syncing interest
+	deposit, found := k.GetDeposit(ctx, depositor)
 
 	amount, err := k.CalculateWithdrawAmount(deposit.Amount, coins)
 	if err != nil {


### PR DESCRIPTION
General structure:
1. Get deposit/borrow from store
2. Pass fetched deposit/borrow to incentive hook `BeforeDepositModified`/`BeforeBorrowModified`
3. Sync deposit/borrow interest
4. If deposit/borrow is operated upon in the function, re-fetch deposit/borrow from the store