### PR TITLE
Incentive module: accounts should only be able to claim their own rewards

### DIFF
--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
@@ -36,35 +35,26 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 
 func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "claim-cdp [owner] [multiplier]",
-		Short: "claim CDP rewards for cdp owner and collateral-type",
+		Use:   "claim-cdp [multiplier]",
+		Short: "claim CDP rewards using a given multiplier",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Claim any outstanding CDP rewards owned by owner for the input collateral-type and multiplier
+			fmt.Sprintf(`Claim sender's outstanding CDP rewards using a given multiplier
 
 			Example:
-			$ %s tx %s claim-cdp kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
+			$ %s tx %s claim-cdp large
 		`, version.ClientName, types.ModuleName),
 		),
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			owner, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				return err
-			}
-
 			sender := cliCtx.GetFromAddress()
-			if !sender.Equals(owner) {
-				return sdkerrors.Wrapf(types.ErrInvalidClaimOwner, "tx sender %s does not match claim owner %s", sender, owner)
-			}
+			multiplier := args[0]
 
-			multiplier := args[1]
-
-			msg := types.NewMsgClaimUSDXMintingReward(owner, multiplier)
-			err = msg.ValidateBasic()
+			msg := types.NewMsgClaimUSDXMintingReward(sender, multiplier)
+			err := msg.ValidateBasic()
 			if err != nil {
 				return err
 			}
@@ -75,35 +65,26 @@ func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 
 func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "claim-hard [owner] [multiplier]",
-		Short: "claim Hard rewards for deposit/borrow and delegating",
+		Use:   "claim-hard [multiplier]",
+		Short: "claim sender's Hard module rewards using a given multiplier",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Claim owner's outstanding Hard rewards using given multiplier
+			fmt.Sprintf(`Claim sender's outstanding Hard rewards for deposit/borrow/delegate using given multiplier
 
 			Example:
-			$ %s tx %s claim-hard kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
+			$ %s tx %s claim-hard large
 		`, version.ClientName, types.ModuleName),
 		),
-		Args: cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			owner, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				return err
-			}
-
 			sender := cliCtx.GetFromAddress()
-			if !sender.Equals(owner) {
-				return sdkerrors.Wrapf(types.ErrInvalidClaimOwner, "tx sender %s does not match claim owner %s", sender, owner)
-			}
+			multiplier := args[0]
 
-			multiplier := args[1]
-
-			msg := types.NewMsgClaimHardLiquidityProviderReward(owner, multiplier)
-			err = msg.ValidateBasic()
+			msg := types.NewMsgClaimHardLiquidityProviderReward(sender, multiplier)
+			err := msg.ValidateBasic()
 			if err != nil {
 				return err
 			}

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -32,7 +32,6 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	)...)
 
 	return incentiveTxCmd
-
 }
 
 func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
@@ -40,7 +39,7 @@ func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 		Use:   "claim-cdp [owner] [multiplier]",
 		Short: "claim CDP rewards for cdp owner and collateral-type",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Claim any outstanding CDP rewards owned by owner for the input collateral-type and multiplier,
+			fmt.Sprintf(`Claim any outstanding CDP rewards owned by owner for the input collateral-type and multiplier
 
 			Example:
 			$ %s tx %s claim-cdp kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
@@ -49,7 +48,7 @@ func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
 			owner, err := sdk.AccAddressFromBech32(args[0])
@@ -62,7 +61,9 @@ func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
 				return sdkerrors.Wrapf(types.ErrInvalidClaimOwner, "tx sender %s does not match claim owner %s", sender, owner)
 			}
 
-			msg := types.NewMsgClaimUSDXMintingReward(owner, args[1])
+			multiplier := args[1]
+
+			msg := types.NewMsgClaimUSDXMintingReward(owner, multiplier)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -77,7 +78,7 @@ func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
 		Use:   "claim-hard [owner] [multiplier]",
 		Short: "claim Hard rewards for deposit/borrow and delegating",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Claim owner's outstanding Hard rewards using given multiplier multiplier,
+			fmt.Sprintf(`Claim owner's outstanding Hard rewards using given multiplier
 
 			Example:
 			$ %s tx %s claim-hard kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw large
@@ -86,7 +87,7 @@ func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
 
 			owner, err := sdk.AccAddressFromBech32(args[0])
@@ -99,7 +100,9 @@ func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
 				return sdkerrors.Wrapf(types.ErrInvalidClaimOwner, "tx sender %s does not match claim owner %s", sender, owner)
 			}
 
-			msg := types.NewMsgClaimHardLiquidityProviderReward(owner, args[1])
+			multiplier := args[1]
+
+			msg := types.NewMsgClaimHardLiquidityProviderReward(owner, multiplier)
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/incentive/types/errors.go
+++ b/x/incentive/types/errors.go
@@ -8,10 +8,10 @@ import (
 
 // Incentive module errors
 var (
-	ErrClaimNotFound                 = sdkerrors.Register(ModuleName, 2, "no claim with input id found for owner and collateral type")
+	ErrClaimNotFound                 = sdkerrors.Register(ModuleName, 2, "no claimable rewards found for user")
 	ErrRewardPeriodNotFound          = sdkerrors.Register(ModuleName, 3, "no reward period found for collateral type")
 	ErrInvalidAccountType            = sdkerrors.Register(ModuleName, 4, "account type not supported")
-	ErrNoClaimsFound                 = sdkerrors.Register(ModuleName, 5, "no claims with collateral type found for address")
+	ErrNoClaimsFound                 = sdkerrors.Register(ModuleName, 5, "no claimable rewards found")
 	ErrInsufficientModAccountBalance = sdkerrors.Register(ModuleName, 6, "module account has insufficient balance to pay claim")
 	ErrAccountNotFound               = sdkerrors.Register(ModuleName, 7, "account not found")
 	ErrInvalidMultiplier             = sdkerrors.Register(ModuleName, 8, "invalid rewards multiplier")


### PR DESCRIPTION
There was a bug in the previous fix: the sender's address was being pulled from the 'owner' argument by `cliCtx := context.NewCLIContextWithInputAndFrom(inBuf, args[0]).WithCodec(cdc)`, so you could send the claim tx on behalf of another address.

- 1st commit: fix the bug
- 2nd commit: remove `owner` argument, the REST endpoint already didn't use `owner`