### PR TITLE
Hard Audit: skipped error check after borrow validation

### DIFF
--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -57,6 +57,9 @@ func (k Keeper) Borrow(ctx sdk.Context, borrower sdk.AccAddress, coins sdk.Coins
 			}
 		}
 	}
+	if err != nil {
+		return err
+	}
 
 	interestFactors := types.BorrowInterestFactors{}
 	currBorrow, foundBorrow := k.GetBorrow(ctx, borrower)


### PR DESCRIPTION
Check error returned from `ValidateBorrow` for general errors as well after checking for module balance errors. The correct approach was already being done in `ValidateDeposit`, in this PR borrow is updated to match it.