### PR TITLE
fix: allow ltv of zero

### DIFF
--- a/x/hard/types/params.go
+++ b/x/hard/types/params.go
@@ -51,8 +51,8 @@ func (bl BorrowLimit) Validate() error {
 	if bl.MaximumLimit.IsNegative() {
 		return fmt.Errorf("maximum limit USD cannot be negative: %s", bl.MaximumLimit)
 	}
-	if !bl.LoanToValue.IsPositive() {
-		return fmt.Errorf("loan-to-value must be a positive integer: %s", bl.LoanToValue)
+	if bl.LoanToValue.IsNegative() {
+		return fmt.Errorf("loan-to-value must be a non-negative decimal: %s", bl.LoanToValue)
 	}
 	if bl.LoanToValue.GT(sdk.OneDec()) {
 		return fmt.Errorf("loan-to-value cannot be greater than 1.0: %s", bl.LoanToValue)


### PR DESCRIPTION
Money markets can be "supply only" - ie supplying the asset is allowed but it doesn't increase your borrow power. This PR fixes current param validation to allow zero LTV. 