### PR TITLE
Allocate Hard supply/borrow rewards to legacy suppliers/borrowers

### DIFF
--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -220,14 +220,8 @@ func (suite *KeeperTestSuite) SetupWithGenState() {
 		NewHardGenStateMulti(),
 	)
 
-	suite.app = tApp
-	suite.ctx = ctx
-	suite.keeper = tApp.GetIncentiveKeeper()
-	suite.hardKeeper = tApp.GetHardKeeper()
-	suite.stakingKeeper = tApp.GetStakingKeeper()
-	suite.committeeKeeper = tApp.GetCommitteeKeeper()
-
 	// Set up a god committee
+	committeeModKeeper := tApp.GetCommitteeKeeper()
 	godCommittee := committeetypes.Committee{
 		ID:               12,
 		Description:      "This committee is for testing.",
@@ -236,5 +230,12 @@ func (suite *KeeperTestSuite) SetupWithGenState() {
 		VoteThreshold:    d("0.667"),
 		ProposalDuration: time.Hour * 24 * 7,
 	}
-	suite.committeeKeeper.SetCommittee(ctx, godCommittee)
+	committeeModKeeper.SetCommittee(ctx, godCommittee)
+
+	suite.app = tApp
+	suite.ctx = ctx
+	suite.keeper = tApp.GetIncentiveKeeper()
+	suite.hardKeeper = tApp.GetHardKeeper()
+	suite.stakingKeeper = tApp.GetStakingKeeper()
+	suite.committeeKeeper = committeeModKeeper
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -4,9 +4,14 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
 
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/cdp"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
 	"github.com/kava-labs/kava/x/hard"
 	"github.com/kava-labs/kava/x/pricefeed"
 )
@@ -165,4 +170,71 @@ func NewHardGenStateMulti() app.GenesisState {
 	)
 
 	return app.GenesisState{hard.ModuleName: hard.ModuleCdc.MustMarshalJSON(hardGS)}
+}
+
+func NewAuthGenState(addresses []sdk.AccAddress, coins sdk.Coins) app.GenesisState {
+	coinsList := []sdk.Coins{}
+	for range addresses {
+		coinsList = append(coinsList, coins)
+	}
+
+	// Load up our primary user address
+	if len(addresses) >= 4 {
+		coinsList[3] = sdk.NewCoins(
+			sdk.NewCoin("bnb", sdk.NewInt(1000000000000000)),
+			sdk.NewCoin("ukava", sdk.NewInt(1000000000000000)),
+			sdk.NewCoin("btcb", sdk.NewInt(1000000000000000)),
+			sdk.NewCoin("xrp", sdk.NewInt(1000000000000000)),
+		)
+	}
+
+	return app.NewAuthGenState(addresses, coinsList)
+}
+
+func NewStakingGenesisState() app.GenesisState {
+	genState := staking.DefaultGenesisState()
+	genState.Params.BondDenom = "ukava"
+	return app.GenesisState{
+		staking.ModuleName: staking.ModuleCdc.MustMarshalJSON(genState),
+	}
+}
+
+func (suite *KeeperTestSuite) SetupWithGenState() {
+	config := sdk.GetConfig()
+	app.SetBech32AddressPrefixes(config)
+
+	_, allAddrs := app.GeneratePrivKeyAddressPairs(10)
+	suite.addrs = allAddrs[:5]
+	for _, a := range allAddrs[5:] {
+		suite.validatorAddrs = append(suite.validatorAddrs, sdk.ValAddress(a))
+	}
+
+	tApp := app.NewTestApp()
+	ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+
+	tApp.InitializeFromGenesisStates(
+		NewAuthGenState(allAddrs, cs(c("ukava", 5_000_000))),
+		NewStakingGenesisState(),
+		NewPricefeedGenStateMulti(),
+		NewCDPGenStateMulti(),
+		NewHardGenStateMulti(),
+	)
+
+	suite.app = tApp
+	suite.ctx = ctx
+	suite.keeper = tApp.GetIncentiveKeeper()
+	suite.hardKeeper = tApp.GetHardKeeper()
+	suite.stakingKeeper = tApp.GetStakingKeeper()
+	suite.committeeKeeper = tApp.GetCommitteeKeeper()
+
+	// Set up a god committee
+	godCommittee := committeetypes.Committee{
+		ID:               12,
+		Description:      "This committee is for testing.",
+		Members:          suite.addrs[:2],
+		Permissions:      []committeetypes.Permission{committeetypes.GodPermission{}},
+		VoteThreshold:    d("0.667"),
+		ProposalDuration: time.Hour * 24 * 7,
+	}
+	suite.committeeKeeper.SetCommittee(ctx, godCommittee)
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -114,6 +114,7 @@ func NewPricefeedGenStateMulti() app.GenesisState {
 				{MarketID: "xrp:usd", BaseAsset: "xrp", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 				{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 				{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+				{MarketID: "zzz:usd", BaseAsset: "zzz", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 			},
 		},
 		PostedPrices: []pricefeed.PostedPrice{
@@ -147,6 +148,12 @@ func NewPricefeedGenStateMulti() app.GenesisState {
 				Price:         sdk.OneDec(),
 				Expiry:        time.Now().Add(1 * time.Hour),
 			},
+			{
+				MarketID:      "zzz:usd",
+				OracleAddress: sdk.AccAddress{},
+				Price:         sdk.MustNewDecFromStr("2.00"),
+				Expiry:        time.Now().Add(1 * time.Hour),
+			},
 		},
 	}
 	return app.GenesisState{pricefeed.ModuleName: pricefeed.ModuleCdc.MustMarshalJSON(pfGenesis)}
@@ -163,6 +170,7 @@ func NewHardGenStateMulti() app.GenesisState {
 			hard.NewMoneyMarket("bnb", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "bnb:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 			hard.NewMoneyMarket("btcb", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "btc:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 			hard.NewMoneyMarket("xrp", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "xrp:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+			hard.NewMoneyMarket("zzz", hard.NewBorrowLimit(false, borrowLimit, loanToValue), "zzz:usd", sdk.NewInt(1000000), hard.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
 		},
 		sdk.NewDec(10),
 	), hard.DefaultAccumulationTimes, hard.DefaultDeposits, hard.DefaultBorrows,
@@ -185,6 +193,7 @@ func NewAuthGenState(addresses []sdk.AccAddress, coins sdk.Coins) app.GenesisSta
 			sdk.NewCoin("ukava", sdk.NewInt(1000000000000000)),
 			sdk.NewCoin("btcb", sdk.NewInt(1000000000000000)),
 			sdk.NewCoin("xrp", sdk.NewInt(1000000000000000)),
+			sdk.NewCoin("zzz", sdk.NewInt(1000000000000000)),
 		)
 	}
 
@@ -223,7 +232,7 @@ func (suite *KeeperTestSuite) SetupWithGenState() {
 	// Set up a god committee
 	committeeModKeeper := tApp.GetCommitteeKeeper()
 	godCommittee := committeetypes.Committee{
-		ID:               12,
+		ID:               1,
 		Description:      "This committee is for testing.",
 		Members:          suite.addrs[:2],
 		Permissions:      []committeetypes.Permission{committeetypes.GodPermission{}},

--- a/x/incentive/keeper/keeper_test.go
+++ b/x/incentive/keeper/keeper_test.go
@@ -16,6 +16,7 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 
 	"github.com/kava-labs/kava/app"
+	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
 	hardkeeper "github.com/kava-labs/kava/x/hard/keeper"
 	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
@@ -25,13 +26,14 @@ import (
 type KeeperTestSuite struct {
 	suite.Suite
 
-	keeper         keeper.Keeper
-	hardKeeper     hardkeeper.Keeper
-	stakingKeeper  stakingkeeper.Keeper
-	app            app.TestApp
-	ctx            sdk.Context
-	addrs          []sdk.AccAddress
-	validatorAddrs []sdk.ValAddress
+	keeper          keeper.Keeper
+	hardKeeper      hardkeeper.Keeper
+	stakingKeeper   stakingkeeper.Keeper
+	committeeKeeper committeekeeper.Keeper
+	app             app.TestApp
+	ctx             sdk.Context
+	addrs           []sdk.AccAddress
+	validatorAddrs  []sdk.ValAddress
 }
 
 // The default state used by each test

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -439,11 +439,13 @@ func (k Keeper) UpdateHardSupplyIndexDenoms(ctx sdk.Context, deposit hardtypes.D
 	for _, coin := range deposit.Amount {
 		_, foundUserRewardIndexes := claim.SupplyRewardIndexes.GetRewardIndex(coin.Denom)
 		if !foundUserRewardIndexes {
-			globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-			if !foundGlobalRewardIndexes {
-				continue // No rewards for this coin type
+			globalSupplyRewardIndexes, foundGlobalSupplyRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
+			var multiRewardIndex types.MultiRewardIndex
+			if foundGlobalSupplyRewardIndexes {
+				multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, globalSupplyRewardIndexes)
+			} else {
+				multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, types.RewardIndexes{})
 			}
-			multiRewardIndex := types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
 			supplyRewardIndexes = append(supplyRewardIndexes, multiRewardIndex)
 		}
 	}
@@ -465,11 +467,13 @@ func (k Keeper) UpdateHardBorrowIndexDenoms(ctx sdk.Context, borrow hardtypes.Bo
 	for _, coin := range borrow.Amount {
 		_, foundUserRewardIndexes := claim.BorrowRewardIndexes.GetRewardIndex(coin.Denom)
 		if !foundUserRewardIndexes {
-			globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
-			if !foundGlobalRewardIndexes {
-				continue // No rewards for this coin type
+			globalBorrowRewardIndexes, foundGlobalBorrowRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
+			var multiRewardIndex types.MultiRewardIndex
+			if foundGlobalBorrowRewardIndexes {
+				multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, globalBorrowRewardIndexes)
+			} else {
+				multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, types.RewardIndexes{})
 			}
-			multiRewardIndex := types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
 			borrowRewardIndexes = append(borrowRewardIndexes, multiRewardIndex)
 		}
 	}

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -382,7 +382,7 @@ func (k Keeper) SynchronizeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bo
 			continue
 		}
 
-		userMultiRewardIndex, foundUserMultiRewardIndex := claim.SupplyRewardIndexes.GetRewardIndex(coin.Denom)
+		userMultiRewardIndex, foundUserMultiRewardIndex := claim.BorrowRewardIndexes.GetRewardIndex(coin.Denom)
 		if !foundUserMultiRewardIndex {
 			continue
 		}

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -696,14 +696,16 @@ func (k Keeper) SimulateHardSynchronization(ctx sdk.Context, claim types.HardLiq
 
 		userRewardIndexIndex, foundUserRewardIndexIndex := claim.SupplyRewardIndexes.GetRewardIndexIndex(ri.CollateralType)
 		if !foundUserRewardIndexIndex {
-			fmt.Printf("\n[LOG]: factor index for %s should always be found", ri.CollateralType) // TODO: remove before production
+			fmt.Printf("\n[LOG]: claim.SupplyRewardIndexes.GetRewardIndexIndex for %s should always be found", ri.CollateralType) // TODO: remove before production
 			continue
 		}
 
 		for _, globalRewardIndex := range globalRewardIndexes {
 			userRewardIndex, foundUserRewardIndex := userRewardIndexes.RewardIndexes.GetRewardIndex(globalRewardIndex.CollateralType)
 			if !foundUserRewardIndex {
-				continue
+				userRewardIndex = types.NewRewardIndex(globalRewardIndex.CollateralType, sdk.ZeroDec())
+				userRewardIndexes.RewardIndexes = append(userRewardIndexes.RewardIndexes, userRewardIndex)
+				claim.SupplyRewardIndexes[userRewardIndexIndex].RewardIndexes = append(claim.SupplyRewardIndexes[userRewardIndexIndex].RewardIndexes, userRewardIndex)
 			}
 
 			globalRewardFactor := globalRewardIndex.RewardFactor
@@ -723,7 +725,7 @@ func (k Keeper) SimulateHardSynchronization(ctx sdk.Context, claim types.HardLiq
 
 			factorIndex, foundFactorIndex := userRewardIndexes.RewardIndexes.GetFactorIndex(globalRewardIndex.CollateralType)
 			if !foundFactorIndex {
-				fmt.Printf("[LOG]: factor index for %s should always be found", ri.CollateralType) // TODO: remove before production
+				fmt.Printf("[LOG]: userRewardIndexes.RewardIndexes.GetFactorIndex for %s should always be found", globalRewardIndex.CollateralType) // TODO: remove before production
 				continue
 			}
 			claim.SupplyRewardIndexes[userRewardIndexIndex].RewardIndexes[factorIndex].RewardFactor = globalRewardIndex.RewardFactor
@@ -746,14 +748,16 @@ func (k Keeper) SimulateHardSynchronization(ctx sdk.Context, claim types.HardLiq
 
 		userRewardIndexIndex, foundUserRewardIndexIndex := claim.BorrowRewardIndexes.GetRewardIndexIndex(ri.CollateralType)
 		if !foundUserRewardIndexIndex {
-			fmt.Printf("\n[LOG]: factor index for %s should always be found", ri.CollateralType) // TODO: remove before production
+			fmt.Printf("\n[LOG]: claim.BorrowRewardIndexes.GetRewardIndexIndex for %s should always be found", ri.CollateralType) // TODO: remove before production
 			continue
 		}
 
 		for _, globalRewardIndex := range globalRewardIndexes {
 			userRewardIndex, foundUserRewardIndex := userRewardIndexes.RewardIndexes.GetRewardIndex(globalRewardIndex.CollateralType)
 			if !foundUserRewardIndex {
-				continue
+				userRewardIndex = types.NewRewardIndex(globalRewardIndex.CollateralType, sdk.ZeroDec())
+				userRewardIndexes.RewardIndexes = append(userRewardIndexes.RewardIndexes, userRewardIndex)
+				claim.BorrowRewardIndexes[userRewardIndexIndex].RewardIndexes = append(claim.BorrowRewardIndexes[userRewardIndexIndex].RewardIndexes, userRewardIndex)
 			}
 
 			globalRewardFactor := globalRewardIndex.RewardFactor
@@ -773,7 +777,7 @@ func (k Keeper) SimulateHardSynchronization(ctx sdk.Context, claim types.HardLiq
 
 			factorIndex, foundFactorIndex := userRewardIndexes.RewardIndexes.GetFactorIndex(globalRewardIndex.CollateralType)
 			if !foundFactorIndex {
-				fmt.Printf("[LOG]: factor index for %s should always be found", ri.CollateralType) // TODO: remove before production
+				fmt.Printf("[LOG]: userRewardIndexes.RewardIndexes.GetFactorIndex for %s should always be found", globalRewardIndex.CollateralType) // TODO: remove before production
 				continue
 			}
 			claim.BorrowRewardIndexes[userRewardIndexIndex].RewardIndexes[factorIndex].RewardFactor = globalRewardIndex.RewardFactor

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -262,10 +262,12 @@ func (k Keeper) InitializeHardSupplyReward(ctx sdk.Context, deposit hardtypes.De
 	var supplyRewardIndexes types.MultiRewardIndexes
 	for _, coin := range deposit.Amount {
 		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
-			continue
+		var multiRewardIndex types.MultiRewardIndex
+		if foundGlobalRewardIndexes {
+			multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
+		} else {
+			multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, types.RewardIndexes{})
 		}
-		multiRewardIndex := types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
 		supplyRewardIndexes = append(supplyRewardIndexes, multiRewardIndex)
 	}
 

--- a/x/incentive/keeper/rewards.go
+++ b/x/incentive/keeper/rewards.go
@@ -355,10 +355,12 @@ func (k Keeper) InitializeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bor
 	var borrowRewardIndexes types.MultiRewardIndexes
 	for _, coin := range borrow.Amount {
 		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
-			continue
+		var multiRewardIndex types.MultiRewardIndex
+		if foundGlobalRewardIndexes {
+			multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
+		} else {
+			multiRewardIndex = types.NewMultiRewardIndex(coin.Denom, types.RewardIndexes{})
 		}
-		multiRewardIndex := types.NewMultiRewardIndex(coin.Denom, globalRewardIndexes)
 		borrowRewardIndexes = append(borrowRewardIndexes, multiRewardIndex)
 	}
 

--- a/x/incentive/keeper/rewards_test.go
+++ b/x/incentive/keeper/rewards_test.go
@@ -495,7 +495,7 @@ func (suite *KeeperTestSuite) TestSynchronizeHardBorrowReward() {
 				updateRewardsViaCommmittee: true,
 				updatedBaseDenom:           "bnb",
 				updatedRewardsPerSecond:    cs(c("hard", 122354), c("ukava", 100000)),
-				updatedExpectedRewards:     cs(c("hard", 31714156802), c("ukava", 8640000000)),
+				updatedExpectedRewards:     cs(c("hard", 21142771202), c("ukava", 8640000000)),
 				updatedExpectedRewardIndexes: types.RewardIndexes{
 					types.NewRewardIndex("hard", d("2.114277120120202320")),
 					types.NewRewardIndex("ukava", d("0.864000000049120715")),

--- a/x/incentive/keeper/rewards_test.go
+++ b/x/incentive/keeper/rewards_test.go
@@ -650,6 +650,189 @@ func (suite *KeeperTestSuite) TestAccumulateHardDelegatorRewards() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestInitializeHardSupplyRewards() {
+
+	type args struct {
+		moneyMarketRewardDenoms          map[string][]string
+		deposit                          sdk.Coins
+		initialTime                      time.Time
+		expectedClaimSupplyRewardIndexes types.MultiRewardIndexes
+	}
+	type test struct {
+		name string
+		args args
+	}
+
+	standardMoneyMarketRewardDenoms := map[string][]string{
+		"bnb":  {"hard"},
+		"btcb": {"hard", "ukava"},
+		"xrp":  {},
+	}
+
+	testCases := []test{
+		{
+			"single deposit denom, single reward denom",
+			args{
+				moneyMarketRewardDenoms: standardMoneyMarketRewardDenoms,
+				deposit:                 cs(c("bnb", 1000000000000)),
+				initialTime:             time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC),
+				expectedClaimSupplyRewardIndexes: types.MultiRewardIndexes{
+					types.NewMultiRewardIndex(
+						"bnb",
+						types.RewardIndexes{
+							types.NewRewardIndex("hard", d("0.0")),
+						},
+					),
+				},
+			},
+		},
+		{
+			"single deposit denom, multiple reward denoms",
+			args{
+				moneyMarketRewardDenoms: standardMoneyMarketRewardDenoms,
+				deposit:                 cs(c("btcb", 1000000000000)),
+				initialTime:             time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC),
+				expectedClaimSupplyRewardIndexes: types.MultiRewardIndexes{
+					types.NewMultiRewardIndex(
+						"btcb",
+						types.RewardIndexes{
+							types.NewRewardIndex("hard", d("0.0")),
+							types.NewRewardIndex("ukava", d("0.0")),
+						},
+					),
+				},
+			},
+		},
+		{
+			"single deposit denom, no reward denoms",
+			args{
+				moneyMarketRewardDenoms: standardMoneyMarketRewardDenoms,
+				deposit:                 cs(c("xrp", 1000000000000)),
+				initialTime:             time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC),
+				expectedClaimSupplyRewardIndexes: types.MultiRewardIndexes{
+					types.NewMultiRewardIndex(
+						"xrp",
+						nil,
+					),
+				},
+			},
+		},
+		{
+			"multiple deposit denoms, multiple overlapping reward denoms",
+			args{
+				moneyMarketRewardDenoms: standardMoneyMarketRewardDenoms,
+				deposit:                 cs(c("bnb", 1000000000000), c("btcb", 1000000000000)),
+				initialTime:             time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC),
+				expectedClaimSupplyRewardIndexes: types.MultiRewardIndexes{
+					types.NewMultiRewardIndex(
+						"bnb",
+						types.RewardIndexes{
+							types.NewRewardIndex("hard", d("0.0")),
+						},
+					),
+					types.NewMultiRewardIndex(
+						"btcb",
+						types.RewardIndexes{
+							types.NewRewardIndex("hard", d("0.0")),
+							types.NewRewardIndex("ukava", d("0.0")),
+						},
+					),
+				},
+			},
+		},
+		{
+			"multiple deposit denoms, correct discrete reward denoms",
+			args{
+				moneyMarketRewardDenoms: standardMoneyMarketRewardDenoms,
+				deposit:                 cs(c("bnb", 1000000000000), c("xrp", 1000000000000)),
+				initialTime:             time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC),
+				expectedClaimSupplyRewardIndexes: types.MultiRewardIndexes{
+					types.NewMultiRewardIndex(
+						"bnb",
+						types.RewardIndexes{
+							types.NewRewardIndex("hard", d("0.0")),
+						},
+					),
+					types.NewMultiRewardIndex(
+						"xrp",
+						nil,
+					),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupWithGenState()
+			suite.ctx = suite.ctx.WithBlockTime(tc.args.initialTime)
+
+			// Mint coins to hard module account
+			supplyKeeper := suite.app.GetSupplyKeeper()
+			hardMaccCoins := sdk.NewCoins(sdk.NewCoin("usdx", sdk.NewInt(200000000)))
+			supplyKeeper.MintCoins(suite.ctx, hardtypes.ModuleAccountName, hardMaccCoins)
+
+			userAddr := suite.addrs[3]
+
+			// ----------------------------------------------------------
+			// Prepare money market + reward params
+			i := 0
+			var multiRewardPeriods types.MultiRewardPeriods
+			var rewardPeriods types.RewardPeriods
+			for moneyMarketDenom, rewardDenoms := range tc.args.moneyMarketRewardDenoms {
+				// Set up multi reward periods for supply/borrow indexes with dynamic money market denoms/reward denoms
+				var rewardsPerSecond sdk.Coins
+				for _, rewardDenom := range rewardDenoms {
+					rewardsPerSecond = append(rewardsPerSecond, sdk.NewCoin(rewardDenom, sdk.OneInt()))
+				}
+				multiRewardPeriod := types.NewMultiRewardPeriod(true, moneyMarketDenom, tc.args.initialTime, tc.args.initialTime.Add(time.Hour*24*365*4), rewardsPerSecond)
+				multiRewardPeriods = append(multiRewardPeriods, multiRewardPeriod)
+
+				// Set up generic reward periods for usdx minting/delegator indexes
+				if i == 0 && len(rewardDenoms) > 0 {
+					rewardPeriod := types.NewRewardPeriod(true, moneyMarketDenom, tc.args.initialTime, tc.args.initialTime.Add(time.Hour*24*365*4), rewardsPerSecond[i])
+					rewardPeriods = append(rewardPeriods, rewardPeriod)
+					i++
+				}
+			}
+
+			// Initialize and set incentive params
+			params := types.NewParams(
+				rewardPeriods, multiRewardPeriods, multiRewardPeriods, rewardPeriods,
+				types.Multipliers{types.NewMultiplier(types.MultiplierName("small"), 1, d("0.25")), types.NewMultiplier(types.MultiplierName("large"), 12, d("1.0"))},
+				tc.args.initialTime.Add(time.Hour*24*365*5),
+			)
+			suite.keeper.SetParams(suite.ctx, params)
+
+			// Set each money market's previous accrual time and supply reward indexes
+			for moneyMarketDenom, rewardDenoms := range tc.args.moneyMarketRewardDenoms {
+				var rewardIndexes types.RewardIndexes
+				for _, rewardDenom := range rewardDenoms {
+					rewardIndex := types.NewRewardIndex(rewardDenom, sdk.ZeroDec())
+					rewardIndexes = append(rewardIndexes, rewardIndex)
+				}
+				suite.keeper.SetPreviousHardSupplyRewardAccrualTime(suite.ctx, moneyMarketDenom, tc.args.initialTime)
+				if len(rewardIndexes) > 0 {
+					suite.keeper.SetHardSupplyRewardIndexes(suite.ctx, moneyMarketDenom, rewardIndexes)
+				}
+			}
+
+			// TODO: for sync test
+			// Set up hard state (interest factor for the relevant denom)
+			// suite.hardKeeper.SetSupplyInterestFactor(suite.ctx, tc.args.deposit[0].Denom, sdk.MustNewDecFromStr("1.0"))
+			// suite.hardKeeper.SetPreviousAccrualTime(suite.ctx, tc.args.deposit[0].Denom, tc.args.initialTime)
+
+			// User deposits
+			hardKeeper := suite.app.GetHardKeeper()
+			err := hardKeeper.Deposit(suite.ctx, userAddr, tc.args.deposit)
+			suite.Require().NoError(err)
+
+			claim, foundClaim := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, userAddr)
+			suite.Require().True(foundClaim)
+			suite.Require().Equal(tc.args.expectedClaimSupplyRewardIndexes, claim.SupplyRewardIndexes)
+		})
+	}
+}
+
 func (suite *KeeperTestSuite) TestAccumulateHardSupplyRewards() {
 	type args struct {
 		deposit               sdk.Coin

--- a/x/incentive/keeper/rewards_test.go
+++ b/x/incentive/keeper/rewards_test.go
@@ -773,7 +773,6 @@ func (suite *KeeperTestSuite) TestInitializeHardSupplyRewards() {
 
 			userAddr := suite.addrs[3]
 
-			// ----------------------------------------------------------
 			// Prepare money market + reward params
 			i := 0
 			var multiRewardPeriods types.MultiRewardPeriods
@@ -1703,7 +1702,6 @@ func (suite *KeeperTestSuite) TestInitializeHardBorrowRewards() {
 
 			userAddr := suite.addrs[3]
 
-			// ----------------------------------------------------------
 			// Prepare money market + reward params
 			i := 0
 			var multiRewardPeriods types.MultiRewardPeriods

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -264,9 +264,101 @@ func (cs HardLiquidityProviderClaims) Validate() error {
 	return nil
 }
 
-// -------------- Subcomponents of Custom Claim Types --------------
+// ---------------------- Reward periods are used by the params ----------------------
 
-// TODO: refactor RewardPeriod name from 'collateralType' to 'denom'
+// MultiRewardPeriod supports multiple reward types
+type MultiRewardPeriod struct {
+	Active           bool      `json:"active" yaml:"active"`
+	CollateralType   string    `json:"collateral_type" yaml:"collateral_type"`
+	Start            time.Time `json:"start" yaml:"start"`
+	End              time.Time `json:"end" yaml:"end"`
+	RewardsPerSecond sdk.Coins `json:"rewards_per_second" yaml:"rewards_per_second"` // per second reward payouts
+}
+
+// String implements fmt.Stringer
+func (mrp MultiRewardPeriod) String() string {
+	return fmt.Sprintf(`Reward Period:
+	Collateral Type: %s,
+	Start: %s,
+	End: %s,
+	Rewards Per Second: %s,
+	Active %t,
+	`, mrp.CollateralType, mrp.Start, mrp.End, mrp.RewardsPerSecond, mrp.Active)
+}
+
+// NewMultiRewardPeriod returns a new MultiRewardPeriod
+func NewMultiRewardPeriod(active bool, collateralType string, start time.Time, end time.Time, reward sdk.Coins) MultiRewardPeriod {
+	return MultiRewardPeriod{
+		Active:           active,
+		CollateralType:   collateralType,
+		Start:            start,
+		End:              end,
+		RewardsPerSecond: reward,
+	}
+}
+
+// Validate performs a basic check of a MultiRewardPeriod.
+func (mrp MultiRewardPeriod) Validate() error {
+	if mrp.Start.IsZero() {
+		return errors.New("reward period start time cannot be 0")
+	}
+	if mrp.End.IsZero() {
+		return errors.New("reward period end time cannot be 0")
+	}
+	if mrp.Start.After(mrp.End) {
+		return fmt.Errorf("end period time %s cannot be before start time %s", mrp.End, mrp.Start)
+	}
+	if !mrp.RewardsPerSecond.IsValid() {
+		return fmt.Errorf("invalid reward amount: %s", mrp.RewardsPerSecond)
+	}
+	if strings.TrimSpace(mrp.CollateralType) == "" {
+		return fmt.Errorf("reward period collateral type cannot be blank: %s", mrp)
+	}
+	return nil
+}
+
+// MultiRewardPeriods array of MultiRewardPeriod
+type MultiRewardPeriods []MultiRewardPeriod
+
+// GetMultiRewardPeriod fetches a MultiRewardPeriod from an array of MultiRewardPeriods by its denom
+func (mrps MultiRewardPeriods) GetMultiRewardPeriod(denom string) (MultiRewardPeriod, bool) {
+	for _, rp := range mrps {
+		if rp.CollateralType == denom {
+			return rp, true
+		}
+	}
+	return MultiRewardPeriod{}, false
+}
+
+// GetMultiRewardPeriodIndex returns the index of a MultiRewardPeriod inside array MultiRewardPeriods
+func (mrps MultiRewardPeriods) GetMultiRewardPeriodIndex(denom string) (int, bool) {
+	for i, rp := range mrps {
+		if rp.CollateralType == denom {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// Validate checks if all the RewardPeriods are valid and there are no duplicated
+// entries.
+func (mrps MultiRewardPeriods) Validate() error {
+	seenPeriods := make(map[string]bool)
+	for _, rp := range mrps {
+		if seenPeriods[rp.CollateralType] {
+			return fmt.Errorf("duplicated reward period with collateral type %s", rp.CollateralType)
+		}
+
+		if err := rp.Validate(); err != nil {
+			return err
+		}
+		seenPeriods[rp.CollateralType] = true
+	}
+
+	return nil
+}
+
+// ---------------------- Reward indexes are used internally in the store ----------------------
 
 // RewardIndex stores reward accumulation information
 type RewardIndex struct {
@@ -327,80 +419,6 @@ func (ris RewardIndexes) Validate() error {
 			return err
 		}
 	}
-	return nil
-}
-
-// -------------------------------------------------------------------------
-
-// MultiRewardPeriod supports multiple reward types
-type MultiRewardPeriod struct {
-	Active           bool      `json:"active" yaml:"active"`
-	CollateralType   string    `json:"collateral_type" yaml:"collateral_type"`
-	Start            time.Time `json:"start" yaml:"start"`
-	End              time.Time `json:"end" yaml:"end"`
-	RewardsPerSecond sdk.Coins `json:"rewards_per_second" yaml:"rewards_per_second"` // per second reward payouts
-}
-
-// String implements fmt.Stringer
-func (mrp MultiRewardPeriod) String() string {
-	return fmt.Sprintf(`Reward Period:
-	Collateral Type: %s,
-	Start: %s,
-	End: %s,
-	Rewards Per Second: %s,
-	Active %t,
-	`, mrp.CollateralType, mrp.Start, mrp.End, mrp.RewardsPerSecond, mrp.Active)
-}
-
-// NewMultiRewardPeriod returns a new MultiRewardPeriod
-func NewMultiRewardPeriod(active bool, collateralType string, start time.Time, end time.Time, reward sdk.Coins) MultiRewardPeriod {
-	return MultiRewardPeriod{
-		Active:           active,
-		CollateralType:   collateralType,
-		Start:            start,
-		End:              end,
-		RewardsPerSecond: reward,
-	}
-}
-
-// Validate performs a basic check of a MultiRewardPeriod.
-func (mrp MultiRewardPeriod) Validate() error {
-	if mrp.Start.IsZero() {
-		return errors.New("reward period start time cannot be 0")
-	}
-	if mrp.End.IsZero() {
-		return errors.New("reward period end time cannot be 0")
-	}
-	if mrp.Start.After(mrp.End) {
-		return fmt.Errorf("end period time %s cannot be before start time %s", mrp.End, mrp.Start)
-	}
-	if !mrp.RewardsPerSecond.IsValid() {
-		return fmt.Errorf("invalid reward amount: %s", mrp.RewardsPerSecond)
-	}
-	if strings.TrimSpace(mrp.CollateralType) == "" {
-		return fmt.Errorf("reward period collateral type cannot be blank: %s", mrp)
-	}
-	return nil
-}
-
-// MultiRewardPeriods array of MultiRewardPeriod
-type MultiRewardPeriods []MultiRewardPeriod
-
-// Validate checks if all the RewardPeriods are valid and there are no duplicated
-// entries.
-func (mrps MultiRewardPeriods) Validate() error {
-	seenPeriods := make(map[string]bool)
-	for _, rp := range mrps {
-		if seenPeriods[rp.CollateralType] {
-			return fmt.Errorf("duplicated reward period with collateral type %s", rp.CollateralType)
-		}
-
-		if err := rp.Validate(); err != nil {
-			return err
-		}
-		seenPeriods[rp.CollateralType] = true
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
When a user deposits or borrows an asset that doesn't have rewards, they should start earning rewards if they're added for the asset.

**General logic**
1. On first deposit/borrow, if the deposited/borrowed denom doesn't have rewards, still add the denom to the user's claim object but initialize it with empty reward indexes
2. Do the same on successive borrows/deposits
3. On sync, if the denom now has global rewards, sync the user's reward index from 0.0 to the current global reward index 