### PR TITLE
Hard Audit: call incentive hooks in export genesis

### DIFF
--- a/x/hard/genesis.go
+++ b/x/hard/genesis.go
@@ -54,6 +54,7 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 	borrows := types.Borrows{}
 
 	k.IterateDeposits(ctx, func(d types.Deposit) bool {
+		k.BeforeDepositModified(ctx, d)
 		syncedDeposit, found := k.GetSyncedDeposit(ctx, d.Depositor)
 		if !found {
 			panic(fmt.Sprintf("syncable deposit not found for %s", d.Depositor))
@@ -63,6 +64,7 @@ func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 	})
 
 	k.IterateBorrows(ctx, func(b types.Borrow) bool {
+		k.BeforeBorrowModified(ctx, b)
 		syncedBorrow, found := k.GetSyncedBorrow(ctx, b.Borrower)
 		if !found {
 			panic(fmt.Sprintf("syncable borrow not found for %s", b.Borrower))


### PR DESCRIPTION
Call `BeforeDepositModified` hook before syncing deposits and `BeforeBorrowModified` hook before syncing borrows in export genesis