### PR TITLE
[R4R] fix: set interest accumulation time and exit when borrows are zero

### DIFF
--- a/x/hard/keeper/interest.go
+++ b/x/hard/keeper/interest.go
@@ -81,6 +81,10 @@ func (k Keeper) AccrueInterest(ctx sdk.Context, denom string) error {
 	if foundBorrowedCoinsPrior {
 		borrowedPrior = sdk.NewCoin(denom, borrowedCoinsPrior.AmountOf(denom))
 	}
+	if borrowedPrior.IsZero() {
+		k.SetPreviousAccrualTime(ctx, denom, ctx.BlockTime())
+		return nil
+	}
 
 	reservesPrior, foundReservesPrior := k.GetTotalReserves(ctx)
 	if !foundReservesPrior {


### PR DESCRIPTION
Fixes issue when BaseAPY is positive and borrows are zero, where interest accumulation is exiting without updating the time accumulated because of this line:

```
if interestBorrowAccumulated.IsZero() && borrowRateApy.IsPositive() {
		// don't accumulate if borrow interest is rounding to zero
		return nil
	}
```

In general, base rates are zero so this wasn't getting hit on testnet, but kvtool caught it. 

Fix: Check if borrows are zero, if they are - update accumulation tme and exit. 