### PR TITLE
Query Hard module reserves

### DIFF
--- a/x/hard/client/rest/query.go
+++ b/x/hard/client/rest/query.go
@@ -22,6 +22,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc(fmt.Sprintf("/%s/borrows", types.ModuleName), queryBorrowsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/total-borrowed", types.ModuleName), queryTotalBorrowedHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/interest-rate", types.ModuleName), queryInterestRateHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/reserves", types.ModuleName), queryReservesHandlerFn(cliCtx)).Methods("GET")
 }
 
 func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
@@ -282,6 +283,44 @@ func queryModAccountsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		route := fmt.Sprintf("custom/%s/%s", types.ModuleName, types.QueryGetModuleAccounts)
+		res, height, err := cliCtx.QueryWithData(route, bz)
+		cliCtx = cliCtx.WithHeight(height)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
+func queryReservesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, _, _, err := rest.ParseHTTPArgsWithLimit(r, 0)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		// Parse the query height
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		var denom string
+
+		if x := r.URL.Query().Get(RestDenom); len(x) != 0 {
+			denom = strings.TrimSpace(x)
+		}
+
+		params := types.NewQueryReservesParams(denom)
+
+		bz, err := cliCtx.Codec.MarshalJSON(params)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		route := fmt.Sprintf("custom/%s/%s", types.ModuleName, types.QueryGetReserves)
 		res, height, err := cliCtx.QueryWithData(route, bz)
 		cliCtx = cliCtx.WithHeight(height)
 		if err != nil {

--- a/x/hard/types/querier.go
+++ b/x/hard/types/querier.go
@@ -13,6 +13,7 @@ const (
 	QueryGetBorrows        = "borrows"
 	QueryGetTotalBorrowed  = "total-borrowed"
 	QueryGetInterestRate   = "interest-rate"
+	QueryGetReserves       = "reserves"
 )
 
 // QueryDepositsParams is the params for a filtered deposit query
@@ -121,3 +122,15 @@ func NewMoneyMarketInterestRate(denom string, supplyInterestRate, borrowInterest
 
 // MoneyMarketInterestRates is a slice of MoneyMarketInterestRate
 type MoneyMarketInterestRates []MoneyMarketInterestRate
+
+// QueryReservesParams is the params for a filtered reserves query
+type QueryReservesParams struct {
+	Denom string `json:"denom" yaml:"denom"`
+}
+
+// NewQueryReservesParams creates a new QueryReservesParams
+func NewQueryReservesParams(denom string) QueryReservesParams {
+	return QueryReservesParams{
+		Denom: denom,
+	}
+}


### PR DESCRIPTION
Implements CLI and REST querier for Hard module's current reserves. The query is filterable by `denom` and always returns the `sdk.Coins` data type.