### PR TITLE
migrate harvest mod account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -102,7 +102,7 @@ var (
 		bep3.ModuleName:             {supply.Minter, supply.Burner},
 		kavadist.ModuleName:         {supply.Minter},
 		issuance.ModuleAccountName:  {supply.Minter, supply.Burner},
-		hard.ModuleAccountName:      {supply.Minter, supply.Burner},
+		hard.ModuleAccountName:      nil,
 	}
 
 	// module accounts that are allowed to receive tokens

--- a/app/app.go
+++ b/app/app.go
@@ -102,7 +102,7 @@ var (
 		bep3.ModuleName:             {supply.Minter, supply.Burner},
 		kavadist.ModuleName:         {supply.Minter},
 		issuance.ModuleAccountName:  {supply.Minter, supply.Burner},
-		hard.ModuleAccountName:      nil,
+		hard.ModuleAccountName:      {supply.Minter},
 	}
 
 	// module accounts that are allowed to receive tokens

--- a/migrate/v0_13/migrate.go
+++ b/migrate/v0_13/migrate.go
@@ -322,6 +322,9 @@ func Auth(genesisState auth.GenesisState) auth.GenesisState {
 	hardLPIdx := 0
 	hardLPCoins := sdk.NewCoins()
 
+	harvestAddr := supply.NewModuleAddress(v0_11hard.ModuleAccountName)
+	harvestIdx := 0
+
 	kavaDistAddr := supply.NewModuleAddress(kavadist.KavaDistMacc)
 	kavaDistIdx := 0
 
@@ -348,13 +351,24 @@ func Auth(genesisState auth.GenesisState) auth.GenesisState {
 		if acc.GetAddress().Equals(kavaDistAddr) {
 			kavaDistIdx = idx
 		}
+		if acc.GetAddress().Equals(harvestAddr) {
+			harvestIdx = idx
+
+		}
 	}
+	// move remaining cdp savings to liquidator account
 	liquidatorAcc := genesisState.Accounts[liquidatorMaccIndex]
 	err := liquidatorAcc.SetCoins(liquidatorAcc.GetCoins().Add(savingsRateMaccCoins...))
 	if err != nil {
 		panic(err)
 	}
 	genesisState.Accounts[liquidatorMaccIndex] = liquidatorAcc
+
+	// migrate harvest account to new hard name
+	harvestAcc := genesisState.Accounts[harvestIdx].(*supply.ModuleAccount)
+	harvestAcc.Address = supply.NewModuleAddress(v0_13hard.ModuleAccountName)
+	harvestAcc.Name = v0_13hard.ModuleAccountName
+	genesisState.Accounts[harvestIdx] = harvestAcc
 
 	// add hard module accounts to kavadist
 	kavaDistAcc := genesisState.Accounts[kavaDistIdx]

--- a/migrate/v0_13/migrate.go
+++ b/migrate/v0_13/migrate.go
@@ -368,6 +368,7 @@ func Auth(genesisState auth.GenesisState) auth.GenesisState {
 	harvestAcc := genesisState.Accounts[harvestIdx].(*supply.ModuleAccount)
 	harvestAcc.Address = supply.NewModuleAddress(v0_13hard.ModuleAccountName)
 	harvestAcc.Name = v0_13hard.ModuleAccountName
+	harvestAcc.Permissions = nil
 	genesisState.Accounts[harvestIdx] = harvestAcc
 
 	// add hard module accounts to kavadist

--- a/migrate/v0_13/migrate.go
+++ b/migrate/v0_13/migrate.go
@@ -368,7 +368,7 @@ func Auth(genesisState auth.GenesisState) auth.GenesisState {
 	harvestAcc := genesisState.Accounts[harvestIdx].(*supply.ModuleAccount)
 	harvestAcc.Address = supply.NewModuleAddress(v0_13hard.ModuleAccountName)
 	harvestAcc.Name = v0_13hard.ModuleAccountName
-	harvestAcc.Permissions = nil
+	harvestAcc.Permissions = []string{supply.Minter}
 	genesisState.Accounts[harvestIdx] = harvestAcc
 
 	// add hard module accounts to kavadist

--- a/x/hard/types/expected_keepers.go
+++ b/x/hard/types/expected_keepers.go
@@ -18,7 +18,6 @@ type SupplyKeeper interface {
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
-	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 }
 
 // AccountKeeper defines the expected keeper interface for interacting with account


### PR DESCRIPTION
The harvest module account was not migrated to the new "hard" name. This migrates the account's name and address (derived from the name).

Note, `account.SetAddress()` doesn't work for account where the address is already set