### PR TITLE
fix: enforce max number of liquidations in cdp begin blocker

### DIFF
--- a/x/cdp/abci.go
+++ b/x/cdp/abci.go
@@ -35,7 +35,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 			panic(err)
 		}
 
-		err = k.LiquidateCdps(ctx, cp.LiquidationMarketID, cp.Type, cp.LiquidationRatio)
+		err = k.LiquidateCdps(ctx, cp.LiquidationMarketID, cp.Type, cp.LiquidationRatio, cp.CheckCollateralizationIndexCount)
 		if err != nil && !errors.Is(err, pricefeedtypes.ErrNoValidPrice) {
 			panic(err)
 		}

--- a/x/cdp/abci_test.go
+++ b/x/cdp/abci_test.go
@@ -135,7 +135,7 @@ func (suite *ModuleTestSuite) TestBeginBlock() {
 	finalXrpCollateral := acc.GetCoins().AmountOf("xrp")
 	seizedXrpCollateral := originalXrpCollateral.Sub(finalXrpCollateral)
 	xrpLiquidations := int(seizedXrpCollateral.Quo(i(10000000000)).Int64())
-	suite.Equal(len(suite.liquidations.xrp), xrpLiquidations)
+	suite.Equal(10, xrpLiquidations)
 
 	acc = sk.GetModuleAccount(suite.ctx, cdp.ModuleName)
 	originalBtcCollateral := acc.GetCoins().AmountOf("btc")
@@ -145,10 +145,10 @@ func (suite *ModuleTestSuite) TestBeginBlock() {
 	finalBtcCollateral := acc.GetCoins().AmountOf("btc")
 	seizedBtcCollateral := originalBtcCollateral.Sub(finalBtcCollateral)
 	btcLiquidations := int(seizedBtcCollateral.Quo(i(100000000)).Int64())
-	suite.Equal(len(suite.liquidations.btc), btcLiquidations)
+	suite.Equal(10, btcLiquidations)
 
 	acc = sk.GetModuleAccount(suite.ctx, auction.ModuleName)
-	suite.Equal(suite.liquidations.debt, acc.GetCoins().AmountOf("debt").Int64())
+	suite.Equal(int64(71955653865), acc.GetCoins().AmountOf("debt").Int64())
 
 }
 

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -87,7 +87,7 @@ func (k Keeper) SeizeCollateral(ctx sdk.Context, cdp types.CDP) error {
 }
 
 // LiquidateCdps seizes collateral from all CDPs below the input liquidation ratio
-func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType string, liquidationRatio sdk.Dec, slice sdk.Int) error {
+func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType string, liquidationRatio sdk.Dec, count sdk.Int) error {
 	price, err := k.pricefeedKeeper.GetCurrentPrice(ctx, marketID)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType s
 	// liquidation ratio = 1.5
 	// normalizedRatio = (1/(0.5/1.5)) = 3
 	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio)
-	cdpsToLiquidate := k.GetSliceOfCDPsByRatioAndType(ctx, slice, normalizedRatio, collateralType)
+	cdpsToLiquidate := k.GetSliceOfCDPsByRatioAndType(ctx, count, normalizedRatio, collateralType)
 	for _, c := range cdpsToLiquidate {
 		k.hooks.BeforeCDPModified(ctx, c)
 		err := k.SeizeCollateral(ctx, c)

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -87,7 +87,7 @@ func (k Keeper) SeizeCollateral(ctx sdk.Context, cdp types.CDP) error {
 }
 
 // LiquidateCdps seizes collateral from all CDPs below the input liquidation ratio
-func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType string, liquidationRatio sdk.Dec) error {
+func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType string, liquidationRatio sdk.Dec, slice sdk.Int) error {
 	price, err := k.pricefeedKeeper.GetCurrentPrice(ctx, marketID)
 	if err != nil {
 		return err
@@ -100,7 +100,7 @@ func (k Keeper) LiquidateCdps(ctx sdk.Context, marketID string, collateralType s
 	// liquidation ratio = 1.5
 	// normalizedRatio = (1/(0.5/1.5)) = 3
 	normalizedRatio := sdk.OneDec().Quo(priceDivLiqRatio)
-	cdpsToLiquidate := k.GetAllCdpsByCollateralTypeAndRatio(ctx, collateralType, normalizedRatio)
+	cdpsToLiquidate := k.GetSliceOfCDPsByRatioAndType(ctx, slice, normalizedRatio, collateralType)
 	for _, c := range cdpsToLiquidate {
 		k.hooks.BeforeCDPModified(ctx, c)
 		err := k.SeizeCollateral(ctx, c)

--- a/x/cdp/keeper/seize_test.go
+++ b/x/cdp/keeper/seize_test.go
@@ -188,12 +188,12 @@ func (suite *SeizeTestSuite) TestLiquidateCdps() {
 	suite.setPrice(d("0.2"), "xrp:usd")
 	p, found := suite.keeper.GetCollateral(suite.ctx, "xrp-a")
 	suite.True(found)
-	suite.keeper.LiquidateCdps(suite.ctx, "xrp:usd", "xrp-a", p.LiquidationRatio)
+	suite.keeper.LiquidateCdps(suite.ctx, "xrp:usd", "xrp-a", p.LiquidationRatio, p.CheckCollateralizationIndexCount)
 	acc = sk.GetModuleAccount(suite.ctx, types.ModuleName)
 	finalXrpCollateral := acc.GetCoins().AmountOf("xrp")
 	seizedXrpCollateral := originalXrpCollateral.Sub(finalXrpCollateral)
 	xrpLiquidations := int(seizedXrpCollateral.Quo(i(10000000000)).Int64())
-	suite.Equal(len(suite.liquidations.xrp), xrpLiquidations)
+	suite.Equal(10, xrpLiquidations)
 }
 
 func (suite *SeizeTestSuite) TestApplyLiquidationPenalty() {


### PR DESCRIPTION
Current implementation would liquiate all cdps at a given ratio - which could result in more cdps being liquidated than the params suggest. Fixed by grabbing a slice of cdps that is limited by `collateral_params.check_collateralization_index_count`