### PR TITLE
Update Swagger for kava-5

### DIFF
--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -615,7 +615,7 @@ paths:
           description: Server internal error
   /cdp/{owner}/{collateral-type}/liquidate:
     post:
-      summary: Attempt to liquidate a CDP that is collateralization ratio is under its liquidaiton ratio
+      summary: Attempt to liquidate a CDP whose collateralization ratio is under its liquidaiton ratio
       tags:
         - CDP
       consumes:
@@ -5053,24 +5053,6 @@ definitions:
       phase:
         type: string
         example: forward
-
-type CollateralParam struct {
-	Denom                            string   `json:"denom" yaml:"denom"` // Coin name of collateral type
-	Type                             string   `json:"type" yaml:"type"`
-	LiquidationRatio                 sdk.Dec  `json:"liquidation_ratio" yaml:"liquidation_ratio"`     // The ratio (Collateral (priced in stable coin) / Debt) under which a CDP will be liquidated
-	DebtLimit                        sdk.Coin `json:"debt_limit" yaml:"debt_limit"`                   // Maximum amount of debt allowed to be drawn from this collateral type
-	StabilityFee                     sdk.Dec  `json:"stability_fee" yaml:"stability_fee"`             // per second stability fee for loans opened using this collateral
-	AuctionSize                      sdk.Int  `json:"auction_size" yaml:"auction_size"`               // Max amount of collateral to sell off in any one auction.
-	LiquidationPenalty               sdk.Dec  `json:"liquidation_penalty" yaml:"liquidation_penalty"` // percentage penalty (between [0, 1]) applied to a cdp if it is liquidated
-	Prefix                           byte     `json:"prefix" yaml:"prefix"`
-	SpotMarketID                     string   `json:"spot_market_id" yaml:"spot_market_id"`                                           // marketID of the spot price of the asset from the pricefeed - used for opening CDPs, depositing, withdrawing
-	LiquidationMarketID              string   `json:"liquidation_market_id" yaml:"liquidation_market_id"`                             // marketID of the pricefeed used for liquidation
-	KeeperRewardPercentage           sdk.Dec  `json:"keeper_reward_percentage" yaml:"keeper_reward_percentage"`                       // the percentage of a CDPs collateral that gets rewarded to a keeper that liquidates the position
-	CheckCollateralizationIndexCount sdk.Int  `json:"check_collateralization_index_count" yaml:"check_collateralization_index_count"` // the number of cdps that will be checked for liquidation in the begin blocker
-	ConversionFactor                 sdk.Int  `json:"conversion_factor" yaml:"conversion_factor"`                                     // factor for converting internal units to one base unit of collateral
-}
-
-
   CollateralParam:
     type: object
     properties:

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -4567,73 +4567,73 @@ definitions:
     properties:
       hard_claims:
         type: array
-          items:
-            $ref: "#/definitions/HardLiquidityProviderClaim"
+        items:
+          $ref: "#/definitions/HardLiquidityProviderClaim"
       usdx_minting_claims:
         type: array
-          items:
-            $ref: "#/definitions/USDXMintingClaims"
+        items:
+          $ref: "#/definitions/USDXMintingClaims"
   HardLiquidityProviderClaim:
-   type: object
+    type: object
     properties:
       base_claim:
         $ref: "#/definitions/BaseMultiClaim"
       supply_reward_indexes:
         type: array
-          items:
-            $ref: "#/definitions/MultiRewardIndex"
+        items:
+          $ref: "#/definitions/MultiRewardIndex"
       borrow_reward_indexes:
         type: array
-          items:
-            $ref: "#/definitions/MultiRewardIndex"
+        items:
+          $ref: "#/definitions/MultiRewardIndex"
       delegator_reward_indexes:
         type: array
-          items:
-            $ref: "#/definitions/RewardIndex"
+        items:
+          $ref: "#/definitions/RewardIndex"
   USDXMintingClaims:
-   type: object
+    type: object
     properties:
       base_claim:
         $ref: "#/definitions/BaseClaim"
       reward_indexes:
         type: array
-          items:
-            $ref: "#/definitions/RewardIndex"
- BaseClaim:
-   type: object
+        items:
+          $ref: "#/definitions/RewardIndex"
+  BaseClaim:
+    type: object
     properties:
       owner:
         $ref: "#/definitions/AccAddress"
       reward:
         $ref: "#/definitions/Coin"
   BaseMultiClaim:
-   type: object
+    type: object
     properties:
       owner:
         $ref: "#/definitions/AccAddress"
       reward:
         type: array
-          items:
-            $ref: "#/definitions/Coin"
+        items:
+          $ref: "#/definitions/Coin"
   MultiRewardIndex:
-   type: object
+    type: object
     properties:
       collateral_type:
         type: string
-        example: 'bnb'
+        example: "bnb"
       reward_indexes:
         type: array
-          items:
-            $ref: "#/definitions/RewardIndex"
+        items:
+          $ref: "#/definitions/RewardIndex"
   RewardIndex:
-   type: object
+    type: object
     properties:
       collateral_type:
         type: string
-        example: 'bnb'
+        example: "bnb"
       reward_factor:
         type: string
-        example: '1.2581'
+        example: "1.2581"
   IncentiveParams:
     type: object
     properties:

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -4561,33 +4561,65 @@ definitions:
   IncentiveParams:
     type: object
     properties:
-      active:
-        type: boolean
-        example: true
-      rewards:
+      usdx_minting_reward_periods:
         type: array
         items:
-          $ref: "#/definitions/Reward"
-  Reward:
+          $ref: "#/definitions/RewardPeriod"
+      hard_supply_reward_periods:
+        type: array
+        items:
+          $ref: "#/definitions/MultiRewardPeriod"
+      hard_borrow_reward_periods:
+        type: array
+        items:
+          $ref: "#/definitions/MultiRewardPeriod"
+      hard_delegator_reward_periods:
+        type: array
+        items:
+          $ref: "#/definitions/RewardPeriod"
+      claim_multipliers:
+        type: array
+        items:
+          $ref: "#/definitions/Multiplier"
+      claim_end:
+        type: string
+        example: "2022-02-05T23:45:55.761435272Z"
+  RewardPeriod:
     type: object
     properties:
       active:
         type: boolean
         example: true
-      denom:
+      collateral_type:
         type: string
         example: bnb
-      available_rewards:
+      start:
+        type: string
+        example: "2020-02-05T23:45:55.761435272Z"
+      end:
+        type: string
+        example: "2024-02-05T23:45:55.761435272Z"
+      rewards_per_second:
         $ref: "#/definitions/Coin"
-      duration:
+  MultiRewardPeriod:
+    type: object
+    properties:
+      active:
+        type: boolean
+        example: true
+      collateral_type:
         type: string
-        example: 36800000000000
-      time_lock:
+        example: bnb
+      start:
         type: string
-        example: 36800000000000
-      claim_duration:
+        example: "2020-02-05T23:45:55.761435272Z"
+      end:
         type: string
-        example: 36800000000000
+        example: "2024-02-05T23:45:55.761435272Z"
+      rewards_per_second:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
   PubProposal:
     type: object
     properties:
@@ -4803,6 +4835,17 @@ definitions:
   MultiplierName:
     type: string
     example: "small"
+  Multiplier:
+    type: object
+    properties:
+      name:
+        $ref: "#/definitions/MultiplierName"
+      months_lockup:
+        type: string
+        example: "12"
+      factor:
+        type: string
+        example: "0.33"
   IssuanceParams:
     type: object
     properties:

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -1,904 +1,628 @@
 ---
-  swagger: '2.0'
-  info:
-    version: '3.0'
-    title: Kava Light Client RPC
-    description: A REST interface for state queries, transaction generation and broadcasting.
-  tags:
-    - name: Transactions
-      description: Search, encode, or broadcast transactions.
-    - name: Tendermint RPC
-      description: Tendermint APIs, such as query blocks, transactions and validatorset
-    - name: CDP
-      description: CDP module APIs
-    - name: Auction
-      description: Auction module APIs
-    - name: BEP3
-      description: BEP3 module APIs
-    - name: Incentive
-      description: Incentive module APIs
-    - name: Pricefeed
-      description: Auction module APIs
-    - name: Hard
-      description: Hard module APIs
-    - name: Committee
-      description: Committee module APIs
-    - name: Auth
-      description: Authenticate accounts
-    - name: Bank
-      description: Create and broadcast transactions
-    - name: Staking
-      description: Stake module APIs
-    - name: Governance
-      description: Governance module APIs
-    - name: Slashing
-      description: Slashing module APIs
-    - name: Distribution
-      description: Fee distribution module APIs
-    - name: Supply
-      description: Supply module APIs
-    - name: Mint
-      description: Minting module APIs
-    - name: Kavadist
-      description: Kavadist module APIs
-    - name: Issuance
-      description: Issuance module APIs
-    - name: Misc
-      description: Query app version
-  schemes:
-    - https
-  host: kava4.data.kava.io
-  securityDefinitions:
-    kms:
-      type: basic
-  paths:
-    /node_info:
-      get:
-        description: Information about the connected node
-        summary: The properties of the connected node
-        tags:
-          - Tendermint RPC
-        produces:
-          - application/json
-        responses:
-          200:
-            description: Node status
-            schema:
-              type: object
-              properties:
-                application_version:
-                  properties:
-                    build_tags:
-                      type: string
-                    client_name:
-                      type: string
-                    commit:
-                      type: string
-                    go:
-                      type: string
-                    name:
-                      type: string
-                    server_name:
-                      type: string
-                    version:
-                      type: string
-                node_info:
-                  properties:
-                    id:
-                      type: string
-                    moniker:
-                      type: string
-                      example: validator-name
-                    protocol_version:
-                      properties:
-                        p2p:
-                          type: string
-                          example: 7
-                        block:
-                          type: string
-                          example: 10
-                        app:
-                          type: string
-                          example: 0
-                    network:
-                      type: string
-                      example: kava-2
-                    channels:
-                      type: string
-                    listen_addr:
-                      type: string
-                      example: 192.168.56.1:26656
-                    version:
-                      description: Tendermint version
-                      type: string
-                      example: 0.15.0
-                    other:
-                      description: more information on versions
-                      type: object
-                      properties:
-                        tx_index:
-                          type: string
-                          example: on
-                        rpc_address:
-                          type: string
-                          example: tcp://0.0.0.0:26657
-          500:
-            description: Failed to query node status
-    /syncing:
-      get:
-        summary: Syncing state of node
-        tags:
-          - Tendermint RPC
-        description: Get the syncing status of the node
-        produces:
-          - application/json
-        responses:
-          200:
-            description: Node syncing status
-            schema:
-              type: object
-              properties:
-                syncing:
-                  type: boolean
-          500:
-            description: Server internal error
-    /blocks/latest:
-      get:
-        summary: Get the latest block
-        tags:
-          - Tendermint RPC
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The latest block
-            schema:
-              $ref: '#/definitions/BlockQuery'
-          500:
-            description: Server internal error
-    /blocks/{height}:
-      get:
-        summary: Get a block at a certain height
-        tags:
-          - Tendermint RPC
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: height
-            description: Block height
-            required: true
-            type: number
-            x-example: 1
-        responses:
-          200:
-            description: The block at a specific height
-            schema:
-              $ref: '#/definitions/BlockQuery'
-          404:
-            description: Request block height doesn't
-          400:
-            description: Invalid height
-          500:
-            description: Server internal error
-    /validatorsets/latest:
-      get:
-        summary: Get the latest validator set
-        tags:
-          - Tendermint RPC
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The validator set at the latest block height
-            schema:
-              type: object
-              properties:
-                block_height:
-                  type: string
-                validators:
-                  type: array
-                  items:
-                    $ref: '#/definitions/TendermintValidator'
-          500:
-            description: Server internal error
-    /validatorsets/{height}:
-      get:
-        summary: Get a validator set a certain height
-        tags:
-          - Tendermint RPC
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: height
-            description: Block height
-            required: true
-            type: number
-            x-example: 1
-        responses:
-          200:
-            description: The validator set at a specific block height
-            schema:
-              type: object
-              properties:
-                block_height:
-                  type: string
-                validators:
-                  type: array
-                  items:
-                    $ref: '#/definitions/TendermintValidator'
-          404:
-            description: Block at height not available
-          400:
-            description: Invalid height
-          500:
-            description: Server internal error
-    /txs/{hash}:
-      get:
-        summary: Get a Tx by hash
-        tags:
-          - Transactions
-        description: Retrieve a transaction using its hash.
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: hash
-            description: Tx hash
-            required: true
-            type: string
-            x-example: FFC8D0E5D52D330AD315E950E5C18A9D65FC640156B9A95B5AEF07DDAE32E61D
-        responses:
-          200:
-            description: Tx with the provided hash
-            schema:
-              $ref: "#/definitions/TxQuery"
-          500:
-            description: Internal Server Error
-    /txs:
-      get:
-        tags:
-          - Transactions
-        summary: Search transactions
-        description: Search transactions by events.
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: message.action
-            type: string
-            description: "transaction events such as 'message.action=send' which results in the following endpoint: 'GET /txs?message.action=send'. note that each module documents its own events. look for xx_events.md in the corresponding cosmos-sdk/docs/spec directory"
-            x-example: "send"
-          - in: query
-            name: message.sender
-            type: string
-            description: "transaction tags with sender: 'GET /txs?message.action=send&message.sender=kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9'"
-            x-example: "kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9"
-          - in: query
-            name: page
-            description: Page number
-            type: integer
-            x-example: 1
-          - in: query
-            name: limit
-            description: Maximum number of items per page
-            type: integer
-            x-example: 1
-          - in: query
-            name: txheight # this should actually be tx.height but dredd doesn't handle periods in get parameter names so no period allows the test to pass
-            description: Transaction height
-            type: integer
-            x-example: 1
-        responses:
-          200:
-            description: All txs matching the provided events
-            schema:
-              $ref: "#/definitions/PaginatedQueryTxs"
-          400:
-            description: Invalid search events
-          500:
-            description: Internal Server Error
-      post:
-        tags:
-          - Transactions
-        summary: Broadcast a signed tx
-        description: Broadcast a signed tx to a full node
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: txBroadcast
-            description: The tx must be a signed StdTx. The supported broadcast modes include `"block"`(return after tx commit), `"sync"`(return afer CheckTx) and `"async"`(return right away).
-            required: true
-            schema:
-              type: object
-              properties:
-                tx:
-                  $ref: "#/definitions/PostStdTx"
-                mode:
-                  type: string
-                  example: block
-        responses:
-          200:
-            description: Tx broadcasting result
-            schema:
-              $ref: "#/definitions/BroadcastTxCommitResult"
-          500:
-            description: Internal Server Error
-    /txs/encode:
-      post:
-        tags:
-          - Transactions
-        summary: Encode a transaction to the Amino wire format
-        description: Encode a transaction (signed or not) from JSON to base64-encoded Amino serialized bytes
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - description: ""
-            name: EncodeBody
-            in: body
-            required: true
-            schema:
-              type: object
-              $ref: "#/definitions/EncodeTx"
-        responses:
-          200:
-            description: The tx was successfully decoded and re-encoded
-            schema:
-              type: object
-              properties:
-                tx:
-                  type: string
-                  example: The base64-encoded Amino-serialized bytes for the tx
-          400:
-            description: The tx was malformatted
-          500:
-            description: Server internal error
-    /txs/decode:
-      post:
-        tags:
-          - Transactions
-        summary: Decode a transaction from the Amino wire format
-        description: Decode a transaction (signed or not) from base64-encoded Amino serialized bytes to JSON
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: tx
-            description: The tx to decode
-            required: true
-            schema:
-              type: object
-              properties:
-                tx:
-                  type: string
-                  example: ogEoKBapCjyoo2GaChRKWendsRagTF1ACC1nxzjVxW3xJBIU/A6hCReBn5NYI6K2dl10kCEeTfgaCgoFc3Rha2USATESEAoKCgVzdGFrZRIBMRDAmgwaQhJAdlC1HbNw+ux6lRrK3mNdmaH62NE3ThD8SswlDcnhFex7pKSNhaxE4m6TgDhosoK6EyU0LnOZKutXKECNSvO+WCIIdGVzdG1lbW8=
-        responses:
-          200:
-            description: The tx was successfully decoded
-            schema:
-              $ref: "#/definitions/StdTx"
-          400:
-            description: The tx was malformated
-          500:
-            description: Server internal error
-    /cdp:
-      post:
-        summary: Create a cdp transaction
-        tags:
-          - CDP
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - description: create cdp post parameters
-            name: post_cdp_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                collateral:
-                  $ref: '#/definitions/CoinCollateral'
-                principal:
-                  $ref: '#/definitions/CoinPrincipal'
-                collateral_type:
-                  $ref: '#/definitions/CollateralType'
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /cdp/{owner}/{collateral-type}/deposits:
-      post:
-        summary: Create a deposit to cdp transaction
-        tags:
-          - CDP
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: collateral_type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-          - description: deposit cdp post parameters
-            name: post_deposit_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                depositor:
-                  $ref: '#/definitions/Address'
-                collateral:
-                  $ref: '#/definitions/CoinCollateral'
-                collateral_type:
-                  $ref: '#/definitions/CollateralType'
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /cdp/{owner}/{collateral-type}/withdraw:
-      post:
-        summary: create a withdraw collateral transaction
-        tags:
-          - CDP
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: collateral_type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-          - description: withdraw cdp post parameters
-            name: post_withdraw_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                depositor:
-                  $ref: '#/definitions/Address'
-                collateral:
-                  $ref: '#/definitions/CoinCollateral'
-                collateral_type:
-                  $ref: '#/definitions/CollateralType'
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /cdp/{owner}/{collateral-type}/draw:
-      post:
-        summary: Create a draw debt transaction
-        tags:
-          - CDP
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: collateral_type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-          - description: draw cdp post parameters
-            name: post_draw_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                principal:
-                  $ref: '#/definitions/CoinPrincipal'
-                collateral_type:
-                  $ref: '#/definitions/CollateralType'
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /cdp/{owner}/{collateral-type}/repay:
-      post:
-        summary: Repay debt from a CDP
-        tags:
-          - CDP
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: collateral_type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-          - description: repay cdp post parameters
-            name: post_repay_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                payment:
-                  $ref: '#/definitions/CoinPrincipal'
-                collateral_type:
-                  $ref: '#/definitions/CollateralType'
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /cdp/accounts:
-      get:
-        summary: Get the cdp module accounts
-        tags:
-          - CDP
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The cdp module accounts
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      account_number:
-                        type: number
-                      address:
-                        $ref: '#/definitions/Address'
-                      coins:
-                        type: array
-                        items:
-                          $ref: '#/definitions/Coin'
-                      name:
-                        type: string
-                      permissions:
-                        type: array
-                        items:
-                          type: string
-                      public_key:
-                        $ref: "#/definitions/PublicKey"
-                      sequence:
-                        type: number
-          500:
-            description: Server internal error
-    /cdp/parameters:
-      get:
-        summary: Get the parameters of the cdp module
-        tags:
-          - CDP
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The parameters of the cdp module
-            schema:
-              type: object
-              properties:
-                collateral_params:
-                  type: array
-                  items:
-                    $ref: '#/definitions/CollateralParam'
-                debt_params:
-                  type: array
-                  items:
-                    $ref: '#/definitions/DebtParam'
-                global_debt_limit:
-                  type: array
-                  items:
-                    $ref: '#/definitions/CoinCollateral'
-                surplus_auction_threshold:
-                  type: string
-                  example: '1000000000'
-                surplus_auction_lot:
-                  type: string
-                  example: '10000000'
-                debt_auction_threshold:
-                  type: string
-                  example: '1000000000'
-                savings_distribution_frequency:
-                  type: string
-                  example: '60000000'
-                circuit_breaker:
-                  type: boolean
-                  example: false
-          500:
-            description: Server internal error
-    /cdp/cdps/cdp/{owner}/{collateral-type}:
-      get:
-        summary: Get the cdp associated with the input owner address and collateral type
-        tags:
-          - CDP
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-        responses:
-          200:
-            description: CDP associated with owner
-            schema:
-              $ref: '#/definitions/CdpResponse'
-          500:
-            description: Server internal error
-    /cdp/cdps/collateralType/{collateral-type}:
-      get:
-        summary: Get all cdps with collateral type equal to the input collateral type
-        tags:
-          - CDP
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: type
-            description: Collateral Type
-            required: true
-            type: string
-            x-example: xrpb-a
-        responses:
-          200:
-            description: All CDPs with the input collateral type
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/CdpResponse'
-          500:
-            description: Server internal error
-    /cdp/cdps/ratio/{collateral-type}/{ratio}:
-      get:
-        summary: Get all cdps with collateral type equal to the input collateral type and collateralization ratio strictly less than the input ratio
-        tags:
-          - CDP
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-          - in: path
-            name: ratio
-            description: Collateralization ratio
-            required: true
-            type: string
-            x-example: "2.0"
-        responses:
-          200:
-            description: All CDPs with the input collateral type and collateralization ratio less than the input ratio
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/CdpResponse'
-          500:
-            description: Server internal error
-    /cdp/cdps/cdp/deposits/{owner}/{collateral-type}:
-      get:
-        summary: Get the deposits associated with the cdp owned by an address for a collateral type
-        tags:
-          - CDP
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            description: Owner address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: xrpb-a
-        responses:
-          200:
-            description: Deposits associated with the cdp
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/CdpDepositResponse'
-          500:
-            description: Server internal error
-    /cdp/savingsRateDist:
-      get:
-        summary: Get the total savings rate distributed by the cdp module
-        tags:
-          - CDP
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The distributed savings rate
-            properties:
-              height:
-                type: string
-                example: "100"
-              result:
-                savings_rate_distributed:
-                  type: string
-                  example: "5000000000000"
-          500:
-            description: Server internal error
-    /cdp/savingsRateDistTime:
-      get:
-        summary: Get the most recent savings rate distribution time
-        tags:
-          - CDP
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The most recent savings rate distribution time
-            properties:
-              height:
-                type: string
-                example: "100"
-              result:
-                savings_rate_distributed:
-                  type: string
-                  example: "2020-10-14T14:00:06.955036063Z"
-          500:
-            description: Server internal error
-    /cdp/cdps:
-      get:
-        summary: Query all active cdps
-        tags:
-          - CDP
-        produces:
-          - application/json
-      parameters:
-        - in: query
-          name: owner
-          description: Owner address in bech32 format
-          required: false
-          type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: query
-          name: collateral-type
-          description: Collateral type
-          required: false
-          type: string
-          x-example: xrpb-a
-        - in: query
-          name: id
-          description: CDP ID
-          required: false
-          type: string
-          x-example: "4"
-        - in: query
-          name: ratio
-          description: Collateralization ratio
-          required: false
-          type: string
-          x-example: "2.75"
+swagger: "2.0"
+info:
+  version: "3.0"
+  title: Kava Light Client RPC
+  description: A REST interface for state queries, transaction generation and broadcasting.
+tags:
+  - name: Transactions
+    description: Search, encode, or broadcast transactions.
+  - name: Tendermint RPC
+    description: Tendermint APIs, such as query blocks, transactions and validatorset
+  - name: CDP
+    description: CDP module APIs
+  - name: Auction
+    description: Auction module APIs
+  - name: BEP3
+    description: BEP3 module APIs
+  - name: Incentive
+    description: Incentive module APIs
+  - name: Pricefeed
+    description: Auction module APIs
+  - name: Hard
+    description: Hard module APIs
+  - name: Committee
+    description: Committee module APIs
+  - name: Auth
+    description: Authenticate accounts
+  - name: Bank
+    description: Create and broadcast transactions
+  - name: Staking
+    description: Stake module APIs
+  - name: Governance
+    description: Governance module APIs
+  - name: Slashing
+    description: Slashing module APIs
+  - name: Distribution
+    description: Fee distribution module APIs
+  - name: Supply
+    description: Supply module APIs
+  - name: Mint
+    description: Minting module APIs
+  - name: Kavadist
+    description: Kavadist module APIs
+  - name: Issuance
+    description: Issuance module APIs
+  - name: Misc
+    description: Query app version
+schemes:
+  - https
+host: kava4.data.kava.io
+securityDefinitions:
+  kms:
+    type: basic
+paths:
+  /node_info:
+    get:
+      description: Information about the connected node
+      summary: The properties of the connected node
+      tags:
+        - Tendermint RPC
+      produces:
+        - application/json
       responses:
         200:
-          description: Query cdps
+          description: Node status
+          schema:
+            type: object
+            properties:
+              application_version:
+                properties:
+                  build_tags:
+                    type: string
+                  client_name:
+                    type: string
+                  commit:
+                    type: string
+                  go:
+                    type: string
+                  name:
+                    type: string
+                  server_name:
+                    type: string
+                  version:
+                    type: string
+              node_info:
+                properties:
+                  id:
+                    type: string
+                  moniker:
+                    type: string
+                    example: validator-name
+                  protocol_version:
+                    properties:
+                      p2p:
+                        type: string
+                        example: 7
+                      block:
+                        type: string
+                        example: 10
+                      app:
+                        type: string
+                        example: 0
+                  network:
+                    type: string
+                    example: kava-2
+                  channels:
+                    type: string
+                  listen_addr:
+                    type: string
+                    example: 192.168.56.1:26656
+                  version:
+                    description: Tendermint version
+                    type: string
+                    example: 0.15.0
+                  other:
+                    description: more information on versions
+                    type: object
+                    properties:
+                      tx_index:
+                        type: string
+                        example: on
+                      rpc_address:
+                        type: string
+                        example: tcp://0.0.0.0:26657
+        500:
+          description: Failed to query node status
+  /syncing:
+    get:
+      summary: Syncing state of node
+      tags:
+        - Tendermint RPC
+      description: Get the syncing status of the node
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Node syncing status
+          schema:
+            type: object
+            properties:
+              syncing:
+                type: boolean
+        500:
+          description: Server internal error
+  /blocks/latest:
+    get:
+      summary: Get the latest block
+      tags:
+        - Tendermint RPC
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The latest block
+          schema:
+            $ref: "#/definitions/BlockQuery"
+        500:
+          description: Server internal error
+  /blocks/{height}:
+    get:
+      summary: Get a block at a certain height
+      tags:
+        - Tendermint RPC
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: height
+          description: Block height
+          required: true
+          type: number
+          x-example: 1
+      responses:
+        200:
+          description: The block at a specific height
+          schema:
+            $ref: "#/definitions/BlockQuery"
+        404:
+          description: Request block height doesn't
+        400:
+          description: Invalid height
+        500:
+          description: Server internal error
+  /validatorsets/latest:
+    get:
+      summary: Get the latest validator set
+      tags:
+        - Tendermint RPC
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The validator set at the latest block height
+          schema:
+            type: object
+            properties:
+              block_height:
+                type: string
+              validators:
+                type: array
+                items:
+                  $ref: "#/definitions/TendermintValidator"
+        500:
+          description: Server internal error
+  /validatorsets/{height}:
+    get:
+      summary: Get a validator set a certain height
+      tags:
+        - Tendermint RPC
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: height
+          description: Block height
+          required: true
+          type: number
+          x-example: 1
+      responses:
+        200:
+          description: The validator set at a specific block height
+          schema:
+            type: object
+            properties:
+              block_height:
+                type: string
+              validators:
+                type: array
+                items:
+                  $ref: "#/definitions/TendermintValidator"
+        404:
+          description: Block at height not available
+        400:
+          description: Invalid height
+        500:
+          description: Server internal error
+  /txs/{hash}:
+    get:
+      summary: Get a Tx by hash
+      tags:
+        - Transactions
+      description: Retrieve a transaction using its hash.
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: hash
+          description: Tx hash
+          required: true
+          type: string
+          x-example: FFC8D0E5D52D330AD315E950E5C18A9D65FC640156B9A95B5AEF07DDAE32E61D
+      responses:
+        200:
+          description: Tx with the provided hash
+          schema:
+            $ref: "#/definitions/TxQuery"
+        500:
+          description: Internal Server Error
+  /txs:
+    get:
+      tags:
+        - Transactions
+      summary: Search transactions
+      description: Search transactions by events.
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: message.action
+          type: string
+          description: "transaction events such as 'message.action=send' which results in the following endpoint: 'GET /txs?message.action=send'. note that each module documents its own events. look for xx_events.md in the corresponding cosmos-sdk/docs/spec directory"
+          x-example: "send"
+        - in: query
+          name: message.sender
+          type: string
+          description: "transaction tags with sender: 'GET /txs?message.action=send&message.sender=kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9'"
+          x-example: "kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9"
+        - in: query
+          name: page
+          description: Page number
+          type: integer
+          x-example: 1
+        - in: query
+          name: limit
+          description: Maximum number of items per page
+          type: integer
+          x-example: 1
+        - in: query
+          name: txheight # this should actually be tx.height but dredd doesn't handle periods in get parameter names so no period allows the test to pass
+          description: Transaction height
+          type: integer
+          x-example: 1
+      responses:
+        200:
+          description: All txs matching the provided events
+          schema:
+            $ref: "#/definitions/PaginatedQueryTxs"
+        400:
+          description: Invalid search events
+        500:
+          description: Internal Server Error
+    post:
+      tags:
+        - Transactions
+      summary: Broadcast a signed tx
+      description: Broadcast a signed tx to a full node
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: txBroadcast
+          description: The tx must be a signed StdTx. The supported broadcast modes include `"block"`(return after tx commit), `"sync"`(return afer CheckTx) and `"async"`(return right away).
+          required: true
+          schema:
+            type: object
+            properties:
+              tx:
+                $ref: "#/definitions/PostStdTx"
+              mode:
+                type: string
+                example: block
+      responses:
+        200:
+          description: Tx broadcasting result
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        500:
+          description: Internal Server Error
+  /txs/encode:
+    post:
+      tags:
+        - Transactions
+      summary: Encode a transaction to the Amino wire format
+      description: Encode a transaction (signed or not) from JSON to base64-encoded Amino serialized bytes
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - description: ""
+          name: EncodeBody
+          in: body
+          required: true
+          schema:
+            type: object
+            $ref: "#/definitions/EncodeTx"
+      responses:
+        200:
+          description: The tx was successfully decoded and re-encoded
+          schema:
+            type: object
+            properties:
+              tx:
+                type: string
+                example: The base64-encoded Amino-serialized bytes for the tx
+        400:
+          description: The tx was malformatted
+        500:
+          description: Server internal error
+  /txs/decode:
+    post:
+      tags:
+        - Transactions
+      summary: Decode a transaction from the Amino wire format
+      description: Decode a transaction (signed or not) from base64-encoded Amino serialized bytes to JSON
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: tx
+          description: The tx to decode
+          required: true
+          schema:
+            type: object
+            properties:
+              tx:
+                type: string
+                example: ogEoKBapCjyoo2GaChRKWendsRagTF1ACC1nxzjVxW3xJBIU/A6hCReBn5NYI6K2dl10kCEeTfgaCgoFc3Rha2USATESEAoKCgVzdGFrZRIBMRDAmgwaQhJAdlC1HbNw+ux6lRrK3mNdmaH62NE3ThD8SswlDcnhFex7pKSNhaxE4m6TgDhosoK6EyU0LnOZKutXKECNSvO+WCIIdGVzdG1lbW8=
+      responses:
+        200:
+          description: The tx was successfully decoded
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: The tx was malformated
+        500:
+          description: Server internal error
+  /cdp:
+    post:
+      summary: Create a cdp transaction
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - description: create cdp post parameters
+          name: post_cdp_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              collateral:
+                $ref: "#/definitions/CoinCollateral"
+              principal:
+                $ref: "#/definitions/CoinPrincipal"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /cdp/{owner}/{collateral-type}/deposits:
+    post:
+      summary: Create a deposit to cdp transaction
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: collateral_type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - description: deposit cdp post parameters
+          name: post_deposit_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              depositor:
+                $ref: "#/definitions/Address"
+              collateral:
+                $ref: "#/definitions/CoinCollateral"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /cdp/{owner}/{collateral-type}/withdraw:
+    post:
+      summary: create a withdraw collateral transaction
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: collateral_type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - description: withdraw cdp post parameters
+          name: post_withdraw_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              depositor:
+                $ref: "#/definitions/Address"
+              collateral:
+                $ref: "#/definitions/CoinCollateral"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /cdp/{owner}/{collateral-type}/draw:
+    post:
+      summary: Create a draw debt transaction
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: collateral_type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - description: draw cdp post parameters
+          name: post_draw_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              principal:
+                $ref: "#/definitions/CoinPrincipal"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /cdp/{owner}/{collateral-type}/repay:
+    post:
+      summary: Repay debt from a CDP
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: collateral_type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - description: repay cdp post parameters
+          name: post_repay_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              payment:
+                $ref: "#/definitions/CoinPrincipal"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /cdp/accounts:
+    get:
+      summary: Get the cdp module accounts
+      tags:
+        - CDP
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The cdp module accounts
           schema:
             type: object
             properties:
@@ -908,4449 +632,4722 @@
               result:
                 type: array
                 items:
-                  $ref: '#/definitions/CdpResponse'
-        500:
-          description: Internal Server Error
-    /bep3/swap/create:
-      post:
-        summary: Generate a create atomic swap transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - BEP3
-        parameters:
-          - in: body
-            name: Create atomic swap request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                from:
-                  $ref: '#/definitions/Address'
-                to:
-                  $ref: '#/definitions/Address'
-                recipient_other_chain:
-                  $ref: '#/definitions/BinanceChainAddress'
-                sender_other_chain:
-                  $ref: '#/definitions/BinanceChainAddress2'
-                random_number_hash:
-                  $ref: '#/definitions/RandomNumberHash'
-                timestamp:
-                  $ref: '#/definitions/Timestamp'
-                height_span:
-                  $ref: '#/definitions/HeightSpan'
-                cross_chain:
-                  $ref: '#/definitions/CrossChain'
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /bep3/swap/claim:
-      post:
-        summary: Generate a claim atomic swap transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - BEP3
-        parameters:
-          - in: body
-            name: Create atomic swap request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                from:
-                  $ref: '#/definitions/Address'
-                swap_id:
-                  type: string
-                  example: "3ca20f0152f03b0aabe73e7aa1ddf78b9048ede5a9a73846e1ef53bebbfa4185"
-                random_number:
-                  type: string
-                  example: "e3d0a98b459f72231da69c3bd771c1e721fef4be83c14b80dc805ba71019eebe"
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /bep3/swap/refund:
-      post:
-        summary: Generate a refund atomic swap transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - BEP3
-        parameters:
-          - in: body
-            name: Create atomic swap request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                from:
-                  $ref: '#/definitions/Address'
-                swap_id:
-                  type: string
-                  example: "1b00244021ec239867e5b8c44bcd98e40f3148806a8c0a8fd3418872986becba"
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /bep3/swap/{swap-id}:
-      get:
-        summary: Get the atomic swap object associated with the input swap ID
-        tags:
-          - BEP3
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            required: true
-            name: swap-id
-            description: the swap ID
-            type: string
-            x-example: 1b00244021ec239867e5b8c44bcd98e40f3148806a8c0a8fd3418872986becba
-        responses:
-          200:
-            description: Atomic swap
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: 548883
-                result:
-                  $ref: '#/definitions/AtomicSwapResponse'
-          500:
-            description: Server internal error
-    /bep3/swaps:
-      get:
-        summary: Get all atomic swaps
-        tags:
-          - BEP3
-        produces:
-          - application/json
-        responses:
-          200:
-            description: All atomic swaps
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/AtomicSwapResponse'
-          500:
-            description: Server internal error
-    /bep3/supply/{denom}:
-      get:
-        summary: Get the asset supply for the input denom
-        tags:
-          - BEP3
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            type: string
-            required: true
-            name: denom
-            x-example: bnb
-        responses:
-          200:
-            description: Asset supply
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: object
-                  $ref: '#/definitions/AssetSupplyResponse'
-          500:
-            description: Server internal error
-    /bep3/parameters:
-      get:
-        summary: Get the current parameters of the BEP3 module
-        tags:
-          - BEP3
-        produces:
-          - application/json
-        responses:
-          200:
-            description: BEP3 module parameters
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: 548883
-                result:
-                  type: object
-                  $ref: '#/definitions/Bep3ParamsResponse'
-          500:
-            description: Server internal error
-    /auction/auctions/{id}/bids:
-      post:
-        summary: Generate a place bid transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Auction
-        parameters:
-          - in: path
-            name: id
-            description: Auction id
-            required: true
-            type: string
-            x-example: "1"
-          - in: body
-            name: Auction bid request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                amount:
-                  $ref: '#/definitions/CoinBid'
-
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /auction/parameters:
-      get:
-        summary: Query auction parameters
-        produces:
-          - application/json
-        tags:
-          - Auction
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/AuctionParameters'
-          500:
-            description: Internal Server Error
-    /auction/auctions:
-      get:
-        summary: Query auctions
-        description: Query all ongoing auctions
-        produces:
-          - application/json
-        tags:
-          - Auction
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/AuctionResponse'
-          500:
-            description: Internal Server Error
-    /auction/auctions/{id}:
-      get:
-        summary: Query auction
-        description: Query auction by id
-        produces:
-          - application/json
-        tags:
-          - Auction
-        parameters:
-          - in: path
-            name: id
-            description: Auction id
-            required: true
-            type: string
-            x-example: "1"
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/AuctionResponse'
-          400:
-            description: invalid auction id
-          500:
-            description: Internal Server Error
-    /pricefeed/postprice:
-      post:
-        summary: Generate post price transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        parameters:
-          - description: post price request
-            name: post_price_req
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                market_id:
-                  type: string
-                  example: 'xrp:usd'
-                price:
-                  type: string
-                  example: '0.298464000000000007'
-                expiry:
-                  type: string
-                  example: '158551630291'
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /pricefeed/parameters:
-      get:
-        summary: Query pricefeed parameters
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/PricefeedParameters'
-          500:
-            description: Internal Server Error
-    /pricefeed/markets:
-      get:
-        summary: Query markets in the pricefeed
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Market'
-          500:
-            description: Internal Server Error
-    /pricefeed/oracles/{market_id}:
-      get:
-        summary: Query markets in the pricefeed
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        parameters:
-          - in: path
-            name: market_id
-            description: the market id of the market
-            required: true
-            type: string
-            x-example: 'xrp:usd'
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Address'
-          500:
-            description: Internal Server Error
-    /pricefeed/rawprices/{market_id}:
-      get:
-        summary: Query markets in the pricefeed
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        parameters:
-          - in: path
-            name: market_id
-            description: the market id of the market
-            required: true
-            type: string
-            x-example: 'xrp:usd'
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/PostedPrice'
-
-          500:
-            description: Internal Server Error
-    /pricefeed/price/{market_id}:
-      get:
-        summary: Query markets in the pricefeed
-        produces:
-          - application/json
-        tags:
-          - Pricefeed
-        parameters:
-          - in: path
-            name: market_id
-            description: the market id of the market
-            required: true
-            type: string
-            x-example: 'xrp:usd'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Price'
-          500:
-            description: Internal Server Error
-    /incentive/claim:
-      post:
-        summary: Claim USDX incentive rewards
-        tags:
-          - Incentive
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Incentive claim body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                type:
-                  type: string
-                  example: bnb
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /incentive/claims/{owner}/{collateral-type}:
-      get:
-        summary: Get outstanding claims for the input owner and collateral type
-        tags:
-          - Incentive
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: owner
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: path
-            name: type
-            description: Collateral type
-            required: true
-            type: string
-            x-example: bnb-a
-        responses:
-          200:
-            description: USDX Incentive Claims
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/ClaimResponse'
-          500:
-            description: Server internal error
-    /incentive/parameters:
-      get:
-        summary: Get the current parameters of the incentive module
-        tags:
-          - Incentive
-        produces:
-          - application/json
-        responses:
-          200:
-            description: USDX Incentive Claims
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/IncentiveParams'
-          500:
-            description: Server internal error
-    /committee/committees/{committee-id}/proposals:
-      post:
-        summary: Create a new proposal for a committee
-        tags:
-          - Committee
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: committee-id
-            required: true
-            type: string
-            x-example: 1
-          - in: body
-            name: proposal request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                pub_proposal:
-                  $ref: '#/definitions/PubProposal'
-                proposer:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-      get:
-        summary: Query proposals
-        description: Query all proposals for a committee
-        produces:
-          - application/json
-        tags:
-          - Committee
-        parameters:
-          - in: path
-            name: committee-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Committee governance proposals
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/CommitteeProposal"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/proposals/{proposal-id}/votes:
-      post:
-        summary: Create a new vote for a proposal
-        tags:
-          - Committee
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: proposal-id
-            required: true
-            type: string
-            x-example: 1
-          - in: body
-            name: proposal request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                voter:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-      get:
-        summary: Query proposal votes
-        description: Query proposal votes by proposal ID
-        tags:
-          - Committee
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: proposal-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Votes
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/CommitteeVote"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/committees:
-      get:
-        summary: Query committees
-        description: Query all committees
-        tags:
-          - Committee
-        produces:
-          - application/json
-        responses:
-          200:
-            description: Committees
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Committee"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/committees/{committee-id}:
-      get:
-        summary: Query committee
-        description: Query committee by ID
-        tags:
-          - Committee
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: committee-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Committee
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: object
-                  $ref: "#/definitions/Committee"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/proposals/{proposal-id}:
-      get:
-        summary: Query proposal
-        description: Query proposal by ID
-        tags:
-          - Committee
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: proposal-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Proposal
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: object
-                  $ref: "#/definitions/CommitteeProposal"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/proposals/{proposal-id}/propser:
-      get:
-        summary: Query proposer
-        description: Query proposer by proposal ID
-        tags:
-          - Committee
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: proposal-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Proposer
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: object
-                  $ref: "#/definitions/Proposer"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /committee/proposals/{proposal-id}/tally:
-      get:
-        summary: Query proposal tally
-        description: Query proposal tally by proposal ID
-        tags:
-          - Committee
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: proposal-id
-            required: true
-            type: string
-            x-example: 1
-        responses:
-          200:
-            description: Vote tally
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: string
-                  example: "3"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /hard/deposit:
-      post:
-        summary: Deposit funds to hard liquidity pool
-        tags:
-          - Hard
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: hard deposit body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                depositor:
-                  $ref: '#/definitions/Address'
-                amount:
-                  $ref: '#/definitions/Coins'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /hard/withdraw:
-      post:
-        summary: Withdraw funds from hard liquidity pool
-        tags:
-          - Hard
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: hard withdraw body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                depositor:
-                  $ref: '#/definitions/Address'
-                amount:
-                  $ref: '#/definitions/Coins'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-
-            TODO: add claim to incentive
-    /hard/borrow:
-      post:
-        summary: Borrow funds from hard liquidity pool
-        tags:
-          - Hard
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: hard borrow body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                depositor:
-                  $ref: '#/definitions/Address'
-                amount:
-                  $ref: '#/definitions/Coins'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-  /hard/repay:
-      post:
-        summary: Repay funds borrowed from hard liquidity pool
-        tags:
-          - Hard
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: hard repay body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                owner:
-                  $ref: '#/definitions/Address'
-                amount:
-                  $ref: '#/definitions/Coins'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-  /hard/liquidate:
-      post:
-        summary: Attempt to liquidate a borrower that is over their loan-to-value
-        tags:
-          - Hard
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: hard liquidate body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                borrower:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /hard/parameters:
-      get:
-        summary: Get the current parameters of the hard module
-        tags:
-          - Hard
-        produces:
-          - application/json
-        responses:
-          200:
-            description: Hard module parameters
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/HardParams'
-          500:
-            description: Server internal error
-    /hard/total-deposited:
-      get:
-        summary: Get total coins deposited to hard liquidity pools
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Coin denom
-            required: false
-            type: string
-            x-example: btc
-        responses:
-          200:
-            description: total coins deposited
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/Coin'
-          500:
-            description: Server internal error
-    /hard/total-borrowed:
-      get:
-        summary: Get total coins borrowed from hard liquidity pools
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Coin denom
-            required: false
-            type: string
-            x-example: btc
-        responses:
-          200:
-            description: total coins borrowed
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/Coin'
-          500:
-            description: Server internal error
-    /hard/reserves:
-      get:
-        summary: Get total hard reserve coins
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Coin denom
-            required: false
-            type: string
-            x-example: btc
-        responses:
-          200:
-            description: reserve coins
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/Coin'
-          500:
-            description: Server internal error
-    /hard/interest-rate:
-      get:
-        summary: Get total hard reserve coins
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Money market denom
-            required: false
-            type: string
-            x-example: bnb
-        responses:
-          200:
-            description: money market interest rates
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/MoneyMarketInterestRate'
-          500:
-            description: Server internal error
-    /hard/accounts:
-      get:
-        summary: Get the hard module accounts
-        tags:
-          - Hard
-        produces:
-          - application/json
-        responses:
-          200:
-            description: The hard module accounts
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      account_number:
-                        type: number
-                      address:
-                        $ref: '#/definitions/Address'
-                      coins:
-                        type: array
-                        items:
-                          $ref: '#/definitions/Coin'
-                      name:
-                        type: string
-                      permissions:
-                        type: array
-                        items:
-                          type: string
-                      public_key:
-                        $ref: "#/definitions/PublicKey"
-                      sequence:
-                        type: number
-          500:
-            description: Server internal error
-    /hard/deposits:
-      get:
-        summary: Get hard deposits
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Deposit coin denom
-            required: false
-            type: string
-            x-example: btc
-          - in: query
-            name: owner
-            description: Owner address in bech32 format
-            required: false
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: query
-            name: page
-            description: The page number.
-            type: integer
-            x-example: 1
-          - in: query
-            name: limit
-            description: The maximum number of items per page.
-            type: integer
-            x-example: 100
-        responses:
-          200:
-            description: hard deposits
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/HardDepositResponse'
-          500:
-            description: Server internal error
-    /hard/borrows:
-      get:
-        summary: Get hard borrows
-        tags:
-          - Hard
-        produces:
-          - application/json
-        parameters:
-          - in: query
-            name: denom
-            description: Borrow coin denom
-            required: false
-            type: string
-            x-example: btc
-          - in: query
-            name: owner
-            description: Owner address in bech32 format
-            required: false
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-          - in: query
-            name: page
-            description: The page number.
-            type: integer
-            x-example: 1
-          - in: query
-            name: limit
-            description: The maximum number of items per page.
-            type: integer
-            x-example: 100
-        responses:
-          200:
-            description: hard borrows
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/HardBorrowResponse'
-          500:
-            description: Server internal error
-    /issuance/issue:
-      post:
-        summary: Issue tokens
-        tags:
-          - Issuance
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Issue tokens body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                sender:
-                  $ref: '#/definitions/Address'
-                tokens:
-                  $ref: '#/definitions/Coin'
-                receiver:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /issuance/redeem:
-      post:
-        summary: Redeem tokens
-        tags:
-          - Issuance
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Redeem tokens body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                sender:
-                  $ref: '#/definitions/Address'
-                tokens:
-                  $ref: '#/definitions/Coin'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /issuance/block:
-      post:
-        summary: Block an address from using an issued token
-        tags:
-          - Issuance
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Block address body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                sender:
-                  $ref: '#/definitions/Address'
-                denom:
-                  type: string
-                  example: "usdt"
-                blocked_address:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /issuance/unblock:
-      post:
-        summary: Unblock an address from using an issued token
-        tags:
-          - Issuance
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Unblock address body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                sender:
-                  $ref: '#/definitions/Address'
-                denom:
-                  type: string
-                  example: "usdt"
-                address:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /issuance/pause:
-      post:
-        summary: Set an issued token's pause status
-        tags:
-          - Issuance
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Set pause status body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                sender:
-                  $ref: '#/definitions/Address'
-                denom:
-                  type: string
-                  example: "usdt"
-                status:
-                  type: boolean
-                  example: true
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid request
-          500:
-            description: Internal server error
-    /issuance/parameters:
-      get:
-        summary: Get the current parameters of the Issuance module
-        tags:
-          - Issuance
-        produces:
-          - application/json
-        responses:
-          200:
-            description: Issuance parameters
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  x-nullable: true
-                  items:
-                    $ref: '#/definitions/IssuanceParams'
-          500:
-            description: Server internal error
-    /bank/balances/{address}:
-      get:
-        summary: Get the account balances
-        tags:
-          - Bank
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: address
-            description: Account address in bech32 format
-            required: true
-            type: string
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        responses:
-          200:
-            description: Account balances
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Coin"
-          500:
-            description: Server internal error
-
-    /bank/accounts/{address}/transfers:
-      post:
-        summary: Send coins from one account to another
-        tags:
-          - Bank
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: address
-            description: Account address in bech32 format
-            required: true
-            type: string
-            x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-          - in: body
-            name: account
-            description: The sender and tx information
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: "#/definitions/BaseReq"
-                amount:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Coin"
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: "#/definitions/StdTx"
-          400:
-            description: Invalid request
-          500:
-            description: Server internal error
-    /auth/accounts/{address}:
-      get:
-        summary: Get the account information on blockchain
-        tags:
-          - Auth
-        produces:
-          - application/json
-        parameters:
-          - in: path
-            name: address
-            description: Account address
-            required: true
-            type: string
-            x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-        responses:
-          200:
-            description: Account information on the blockchain
-            schema:
-              type: object
-              properties:
-                type:
-                  type: string
-                value:
                   type: object
                   properties:
                     account_number:
-                      type: string
+                      type: number
                     address:
-                      type: string
+                      $ref: "#/definitions/Address"
                     coins:
                       type: array
                       items:
                         $ref: "#/definitions/Coin"
+                    name:
+                      type: string
+                    permissions:
+                      type: array
+                      items:
+                        type: string
                     public_key:
                       $ref: "#/definitions/PublicKey"
                     sequence:
+                      type: number
+        500:
+          description: Server internal error
+  /cdp/parameters:
+    get:
+      summary: Get the parameters of the cdp module
+      tags:
+        - CDP
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The parameters of the cdp module
+          schema:
+            type: object
+            properties:
+              collateral_params:
+                type: array
+                items:
+                  $ref: "#/definitions/CollateralParam"
+              debt_params:
+                type: array
+                items:
+                  $ref: "#/definitions/DebtParam"
+              global_debt_limit:
+                type: array
+                items:
+                  $ref: "#/definitions/CoinCollateral"
+              surplus_auction_threshold:
+                type: string
+                example: "1000000000"
+              surplus_auction_lot:
+                type: string
+                example: "10000000"
+              debt_auction_threshold:
+                type: string
+                example: "1000000000"
+              savings_distribution_frequency:
+                type: string
+                example: "60000000"
+              circuit_breaker:
+                type: boolean
+                example: false
+        500:
+          description: Server internal error
+  /cdp/cdps/cdp/{owner}/{collateral-type}:
+    get:
+      summary: Get the cdp associated with the input owner address and collateral type
+      tags:
+        - CDP
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+      responses:
+        200:
+          description: CDP associated with owner
+          schema:
+            $ref: "#/definitions/CdpResponse"
+        500:
+          description: Server internal error
+  /cdp/cdps/collateralType/{collateral-type}:
+    get:
+      summary: Get all cdps with collateral type equal to the input collateral type
+      tags:
+        - CDP
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: type
+          description: Collateral Type
+          required: true
+          type: string
+          x-example: xrpb-a
+      responses:
+        200:
+          description: All CDPs with the input collateral type
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/CdpResponse"
+        500:
+          description: Server internal error
+  /cdp/cdps/ratio/{collateral-type}/{ratio}:
+    get:
+      summary: Get all cdps with collateral type equal to the input collateral type and collateralization ratio strictly less than the input ratio
+      tags:
+        - CDP
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - in: path
+          name: ratio
+          description: Collateralization ratio
+          required: true
+          type: string
+          x-example: "2.0"
+      responses:
+        200:
+          description: All CDPs with the input collateral type and collateralization ratio less than the input ratio
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/CdpResponse"
+        500:
+          description: Server internal error
+  /cdp/cdps/cdp/deposits/{owner}/{collateral-type}:
+    get:
+      summary: Get the deposits associated with the cdp owned by an address for a collateral type
+      tags:
+        - CDP
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+      responses:
+        200:
+          description: Deposits associated with the cdp
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/CdpDepositResponse"
+        500:
+          description: Server internal error
+  /cdp/savingsRateDist:
+    get:
+      summary: Get the total savings rate distributed by the cdp module
+      tags:
+        - CDP
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The distributed savings rate
+          properties:
+            height:
+              type: string
+              example: "100"
+            result:
+              savings_rate_distributed:
+                type: string
+                example: "5000000000000"
+        500:
+          description: Server internal error
+  /cdp/savingsRateDistTime:
+    get:
+      summary: Get the most recent savings rate distribution time
+      tags:
+        - CDP
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The most recent savings rate distribution time
+          properties:
+            height:
+              type: string
+              example: "100"
+            result:
+              savings_rate_distributed:
+                type: string
+                example: "2020-10-14T14:00:06.955036063Z"
+        500:
+          description: Server internal error
+  /cdp/cdps:
+    get:
+      summary: Query all active cdps
+      tags:
+        - CDP
+      produces:
+        - application/json
+    parameters:
+      - in: query
+        name: owner
+        description: Owner address in bech32 format
+        required: false
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      - in: query
+        name: collateral-type
+        description: Collateral type
+        required: false
+        type: string
+        x-example: xrpb-a
+      - in: query
+        name: id
+        description: CDP ID
+        required: false
+        type: string
+        x-example: "4"
+      - in: query
+        name: ratio
+        description: Collateralization ratio
+        required: false
+        type: string
+        x-example: "2.75"
+    responses:
+      200:
+        description: Query cdps
+        schema:
+          type: object
+          properties:
+            height:
+              type: string
+              example: "100"
+            result:
+              type: array
+              items:
+                $ref: "#/definitions/CdpResponse"
+      500:
+        description: Internal Server Error
+  /bep3/swap/create:
+    post:
+      summary: Generate a create atomic swap transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - BEP3
+      parameters:
+        - in: body
+          name: Create atomic swap request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              from:
+                $ref: "#/definitions/Address"
+              to:
+                $ref: "#/definitions/Address"
+              recipient_other_chain:
+                $ref: "#/definitions/BinanceChainAddress"
+              sender_other_chain:
+                $ref: "#/definitions/BinanceChainAddress2"
+              random_number_hash:
+                $ref: "#/definitions/RandomNumberHash"
+              timestamp:
+                $ref: "#/definitions/Timestamp"
+              height_span:
+                $ref: "#/definitions/HeightSpan"
+              cross_chain:
+                $ref: "#/definitions/CrossChain"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /bep3/swap/claim:
+    post:
+      summary: Generate a claim atomic swap transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - BEP3
+      parameters:
+        - in: body
+          name: Create atomic swap request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              from:
+                $ref: "#/definitions/Address"
+              swap_id:
+                type: string
+                example: "3ca20f0152f03b0aabe73e7aa1ddf78b9048ede5a9a73846e1ef53bebbfa4185"
+              random_number:
+                type: string
+                example: "e3d0a98b459f72231da69c3bd771c1e721fef4be83c14b80dc805ba71019eebe"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /bep3/swap/refund:
+    post:
+      summary: Generate a refund atomic swap transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - BEP3
+      parameters:
+        - in: body
+          name: Create atomic swap request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              from:
+                $ref: "#/definitions/Address"
+              swap_id:
+                type: string
+                example: "1b00244021ec239867e5b8c44bcd98e40f3148806a8c0a8fd3418872986becba"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /bep3/swap/{swap-id}:
+    get:
+      summary: Get the atomic swap object associated with the input swap ID
+      tags:
+        - BEP3
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          required: true
+          name: swap-id
+          description: the swap ID
+          type: string
+          x-example: 1b00244021ec239867e5b8c44bcd98e40f3148806a8c0a8fd3418872986becba
+      responses:
+        200:
+          description: Atomic swap
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: 548883
+              result:
+                $ref: "#/definitions/AtomicSwapResponse"
+        500:
+          description: Server internal error
+  /bep3/swaps:
+    get:
+      summary: Get all atomic swaps
+      tags:
+        - BEP3
+      produces:
+        - application/json
+      responses:
+        200:
+          description: All atomic swaps
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/AtomicSwapResponse"
+        500:
+          description: Server internal error
+  /bep3/supply/{denom}:
+    get:
+      summary: Get the asset supply for the input denom
+      tags:
+        - BEP3
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          type: string
+          required: true
+          name: denom
+          x-example: bnb
+      responses:
+        200:
+          description: Asset supply
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: object
+                $ref: "#/definitions/AssetSupplyResponse"
+        500:
+          description: Server internal error
+  /bep3/parameters:
+    get:
+      summary: Get the current parameters of the BEP3 module
+      tags:
+        - BEP3
+      produces:
+        - application/json
+      responses:
+        200:
+          description: BEP3 module parameters
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: 548883
+              result:
+                type: object
+                $ref: "#/definitions/Bep3ParamsResponse"
+        500:
+          description: Server internal error
+  /auction/auctions/{id}/bids:
+    post:
+      summary: Generate a place bid transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Auction
+      parameters:
+        - in: path
+          name: id
+          description: Auction id
+          required: true
+          type: string
+          x-example: "1"
+        - in: body
+          name: Auction bid request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              amount:
+                $ref: "#/definitions/CoinBid"
+
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /auction/parameters:
+    get:
+      summary: Query auction parameters
+      produces:
+        - application/json
+      tags:
+        - Auction
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/AuctionParameters"
+        500:
+          description: Internal Server Error
+  /auction/auctions:
+    get:
+      summary: Query auctions
+      description: Query all ongoing auctions
+      produces:
+        - application/json
+      tags:
+        - Auction
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/AuctionResponse"
+        500:
+          description: Internal Server Error
+  /auction/auctions/{id}:
+    get:
+      summary: Query auction
+      description: Query auction by id
+      produces:
+        - application/json
+      tags:
+        - Auction
+      parameters:
+        - in: path
+          name: id
+          description: Auction id
+          required: true
+          type: string
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/AuctionResponse"
+        400:
+          description: invalid auction id
+        500:
+          description: Internal Server Error
+  /pricefeed/postprice:
+    post:
+      summary: Generate post price transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      parameters:
+        - description: post price request
+          name: post_price_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              market_id:
+                type: string
+                example: "xrp:usd"
+              price:
+                type: string
+                example: "0.298464000000000007"
+              expiry:
+                type: string
+                example: "158551630291"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /pricefeed/parameters:
+    get:
+      summary: Query pricefeed parameters
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/PricefeedParameters"
+        500:
+          description: Internal Server Error
+  /pricefeed/markets:
+    get:
+      summary: Query markets in the pricefeed
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Market"
+        500:
+          description: Internal Server Error
+  /pricefeed/oracles/{market_id}:
+    get:
+      summary: Query markets in the pricefeed
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      parameters:
+        - in: path
+          name: market_id
+          description: the market id of the market
+          required: true
+          type: string
+          x-example: "xrp:usd"
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Address"
+        500:
+          description: Internal Server Error
+  /pricefeed/rawprices/{market_id}:
+    get:
+      summary: Query markets in the pricefeed
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      parameters:
+        - in: path
+          name: market_id
+          description: the market id of the market
+          required: true
+          type: string
+          x-example: "xrp:usd"
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/PostedPrice"
+
+        500:
+          description: Internal Server Error
+  /pricefeed/price/{market_id}:
+    get:
+      summary: Query markets in the pricefeed
+      produces:
+        - application/json
+      tags:
+        - Pricefeed
+      parameters:
+        - in: path
+          name: market_id
+          description: the market id of the market
+          required: true
+          type: string
+          x-example: "xrp:usd"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Price"
+        500:
+          description: Internal Server Error
+  /incentive/claim:
+    post:
+      summary: Claim USDX incentive rewards
+      tags:
+        - Incentive
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Incentive claim body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              type:
+                type: string
+                example: bnb
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /incentive/claims/{owner}/{collateral-type}:
+    get:
+      summary: Get outstanding claims for the input owner and collateral type
+      tags:
+        - Incentive
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: bnb-a
+      responses:
+        200:
+          description: USDX Incentive Claims
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/ClaimResponse"
+        500:
+          description: Server internal error
+  /incentive/parameters:
+    get:
+      summary: Get the current parameters of the incentive module
+      tags:
+        - Incentive
+      produces:
+        - application/json
+      responses:
+        200:
+          description: USDX Incentive Claims
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/IncentiveParams"
+        500:
+          description: Server internal error
+  /committee/committees/{committee-id}/proposals:
+    post:
+      summary: Create a new proposal for a committee
+      tags:
+        - Committee
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: committee-id
+          required: true
+          type: string
+          x-example: 1
+        - in: body
+          name: proposal request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              pub_proposal:
+                $ref: "#/definitions/PubProposal"
+              proposer:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+    get:
+      summary: Query proposals
+      description: Query all proposals for a committee
+      produces:
+        - application/json
+      tags:
+        - Committee
+      parameters:
+        - in: path
+          name: committee-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Committee governance proposals
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/CommitteeProposal"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/proposals/{proposal-id}/votes:
+    post:
+      summary: Create a new vote for a proposal
+      tags:
+        - Committee
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: proposal-id
+          required: true
+          type: string
+          x-example: 1
+        - in: body
+          name: proposal request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              voter:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+    get:
+      summary: Query proposal votes
+      description: Query proposal votes by proposal ID
+      tags:
+        - Committee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: proposal-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Votes
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/CommitteeVote"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/committees:
+    get:
+      summary: Query committees
+      description: Query all committees
+      tags:
+        - Committee
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Committees
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Committee"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/committees/{committee-id}:
+    get:
+      summary: Query committee
+      description: Query committee by ID
+      tags:
+        - Committee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: committee-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Committee
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: object
+                $ref: "#/definitions/Committee"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/proposals/{proposal-id}:
+    get:
+      summary: Query proposal
+      description: Query proposal by ID
+      tags:
+        - Committee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: proposal-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Proposal
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: object
+                $ref: "#/definitions/CommitteeProposal"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/proposals/{proposal-id}/propser:
+    get:
+      summary: Query proposer
+      description: Query proposer by proposal ID
+      tags:
+        - Committee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: proposal-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Proposer
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: object
+                $ref: "#/definitions/Proposer"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /committee/proposals/{proposal-id}/tally:
+    get:
+      summary: Query proposal tally
+      description: Query proposal tally by proposal ID
+      tags:
+        - Committee
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: proposal-id
+          required: true
+          type: string
+          x-example: 1
+      responses:
+        200:
+          description: Vote tally
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: string
+                example: "3"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /hard/deposit:
+    post:
+      summary: Deposit funds to hard liquidity pool
+      tags:
+        - Hard
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: hard deposit body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              depositor:
+                $ref: "#/definitions/Address"
+              amount:
+                $ref: "#/definitions/Coins"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /hard/withdraw:
+    post:
+      summary: Withdraw funds from hard liquidity pool
+      tags:
+        - Hard
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: hard withdraw body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              depositor:
+                $ref: "#/definitions/Address"
+              amount:
+                $ref: "#/definitions/Coins"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /hard/borrow:
+    post:
+      summary: Borrow funds from hard liquidity pool
+      tags:
+        - Hard
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: hard borrow body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              depositor:
+                $ref: "#/definitions/Address"
+              amount:
+                $ref: "#/definitions/Coins"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /hard/repay:
+    post:
+      summary: Repay funds borrowed from hard liquidity pool
+      tags:
+        - Hard
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: hard repay body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              amount:
+                $ref: "#/definitions/Coins"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /hard/liquidate:
+    post:
+      summary: Attempt to liquidate a borrower that is over their loan-to-value
+      tags:
+        - Hard
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: hard liquidate body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              borrower:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /hard/parameters:
+    get:
+      summary: Get the current parameters of the hard module
+      tags:
+        - Hard
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Hard module parameters
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/HardParams"
+        500:
+          description: Server internal error
+  /hard/total-deposited:
+    get:
+      summary: Get total coins deposited to hard liquidity pools
+      tags:
+        - Hard
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: denom
+          description: Coin denom
+          required: false
+          type: string
+          x-example: btc
+      responses:
+        200:
+          description: total coins deposited
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Server internal error
+  /hard/total-borrowed:
+    get:
+      summary: Get total coins borrowed from hard liquidity pools
+      tags:
+        - Hard
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: denom
+          description: Coin denom
+          required: false
+          type: string
+          x-example: btc
+      responses:
+        200:
+          description: total coins borrowed
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Server internal error
+  /hard/reserves:
+    get:
+      summary: Get total hard reserve coins
+      tags:
+        - Hard
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: denom
+          description: Coin denom
+          required: false
+          type: string
+          x-example: btc
+      responses:
+        200:
+          description: reserve coins
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Server internal error
+  /hard/interest-rate:
+    get:
+      summary: Get total hard reserve coins
+      tags:
+        - Hard
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: denom
+          description: Money market denom
+          required: false
+          type: string
+          x-example: bnb
+      responses:
+        200:
+          description: money market interest rates
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/MoneyMarketInterestRate"
+        500:
+          description: Server internal error
+  /hard/accounts:
+    get:
+      summary: Get the hard module accounts
+      tags:
+        - Hard
+      produces:
+        - application/json
+      responses:
+        200:
+          description: The hard module accounts
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    account_number:
+                      type: number
+                    address:
+                      $ref: "#/definitions/Address"
+                    coins:
+                      type: array
+                      items:
+                        $ref: "#/definitions/Coin"
+                    name:
                       type: string
-          500:
-            description: Server internal error
-    /staking/delegators/{delegatorAddr}/delegations:
+                    permissions:
+                      type: array
+                      items:
+                        type: string
+                    public_key:
+                      $ref: "#/definitions/PublicKey"
+                    sequence:
+                      type: number
+        500:
+          description: Server internal error
+  /hard/deposits:
+    get:
+      summary: Get hard deposits
+      tags:
+        - Hard
+      produces:
+        - application/json
       parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
+        - in: query
+          name: denom
+          description: Deposit coin denom
+          required: false
           type: string
-          x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-      get:
-        summary: Get all delegations from a delegator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Delegation"
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-
-      # THE BELOW ENDPOINT IS NOT IMPLEMENTED IN COSMOS, SEE:
-      # https://github.com/cosmos/cosmos-sdk/blob/18de630d0ae1887113e266982b51c2bf1f662edb/x/staking/client/rest/query.go
-
-      # post:
-      #   summary: Submit delegation
-      #   parameters:
-      #     - in: body
-      #       name: delegation
-      #       description: The password of the account to remove from the KMS
-      #       schema:
-      #         type: object
-      #         properties:
-      #           base_req:
-      #             $ref: "#/definitions/BaseReq"
-      #           delegator_address:
-      #             $ref: "#/definitions/Address"
-      #           validator_address:
-      #             $ref: "#/definitions/ValidatorAddress"
-      #           delegation:
-      #             $ref: "#/definitions/Coin"
-      #   tags:
-      #     - Staking
-      #   consumes:
-      #     - application/json
-      #   produces:
-      #     - application/json
-      #   responses:
-      #     200:
-      #       description: OK
-      #       schema:
-      #         $ref: "#/definitions/BroadcastTxCommitResult"
-      #     400:
-      #       description: Invalid delegator address or delegation request body
-      #     401:
-      #       description: Key password is wrong
-      #     500:
-      #       description: Internal Server Error
-    /staking/delegators/{delegatorAddr}/delegations/{validatorAddr}:
+          x-example: btc
+        - in: query
+          name: owner
+          description: Owner address in bech32 format
+          required: false
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: query
+          name: page
+          description: The page number.
+          type: integer
+          x-example: 1
+        - in: query
+          name: limit
+          description: The maximum number of items per page.
+          type: integer
+          x-example: 100
+      responses:
+        200:
+          description: hard deposits
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/HardDepositResponse"
+        500:
+          description: Server internal error
+  /hard/borrows:
+    get:
+      summary: Get hard borrows
+      tags:
+        - Hard
+      produces:
+        - application/json
+      parameters:
+        - in: query
+          name: denom
+          description: Borrow coin denom
+          required: false
+          type: string
+          x-example: btc
+        - in: query
+          name: owner
+          description: Owner address in bech32 format
+          required: false
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: query
+          name: page
+          description: The page number.
+          type: integer
+          x-example: 1
+        - in: query
+          name: limit
+          description: The maximum number of items per page.
+          type: integer
+          x-example: 100
+      responses:
+        200:
+          description: hard borrows
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/HardBorrowResponse"
+        500:
+          description: Server internal error
+  /issuance/issue:
+    post:
+      summary: Issue tokens
+      tags:
+        - Issuance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Issue tokens body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              tokens:
+                $ref: "#/definitions/Coin"
+              receiver:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /issuance/redeem:
+    post:
+      summary: Redeem tokens
+      tags:
+        - Issuance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Redeem tokens body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              tokens:
+                $ref: "#/definitions/Coin"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /issuance/block:
+    post:
+      summary: Block an address from using an issued token
+      tags:
+        - Issuance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Block address body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              denom:
+                type: string
+                example: "usdt"
+              blocked_address:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /issuance/unblock:
+    post:
+      summary: Unblock an address from using an issued token
+      tags:
+        - Issuance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Unblock address body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              denom:
+                type: string
+                example: "usdt"
+              address:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /issuance/pause:
+    post:
+      summary: Set an issued token's pause status
+      tags:
+        - Issuance
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Set pause status body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              denom:
+                type: string
+                example: "usdt"
+              status:
+                type: boolean
+                example: true
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /issuance/parameters:
+    get:
+      summary: Get the current parameters of the Issuance module
+      tags:
+        - Issuance
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Issuance parameters
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                x-nullable: true
+                items:
+                  $ref: "#/definitions/IssuanceParams"
+        500:
+          description: Server internal error
+  /bank/balances/{address}:
+    get:
+      summary: Get the account balances
+      tags:
+        - Bank
+      produces:
+        - application/json
       parameters:
         - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
+          name: address
+          description: Account address in bech32 format
           required: true
           type: string
           x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Query the current delegation between a delegator and a validator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/Delegation"
-          400:
-            description: Invalid delegator address or validator address
-          500:
-            description: Internal Server Error
-    /staking/delegators/{delegatorAddr}/unbonding_delegations:
+      responses:
+        200:
+          description: Account balances
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Server internal error
+
+  /bank/accounts/{address}/transfers:
+    post:
+      summary: Send coins from one account to another
+      tags:
+        - Bank
+      consumes:
+        - application/json
+      produces:
+        - application/json
       parameters:
         - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
+          name: address
+          description: Account address in bech32 format
           required: true
           type: string
           x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-      get:
-        summary: Get all unbonding delegations from a delegator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/UnbondingDelegation"
-
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-
-      # THE BELOW ENDPOINT IS NOT IMPLEMENTED IN COSMOS, SEE:
-      # https://github.com/cosmos/cosmos-sdk/blob/18de630d0ae1887113e266982b51c2bf1f662edb/x/staking/client/rest/query.go
-
-      # post:
-      #   summary: Submit an unbonding delegation
-      #   parameters:
-      #     - in: body
-      #       name: delegation
-      #       description: The password of the account to remove from the KMS
-      #       schema:
-      #         type: object
-      #         properties:
-      #           base_req:
-      #             $ref: "#/definitions/BaseReq"
-      #           delegator_address:
-      #             $ref: "#/definitions/Address"
-      #           validator_address:
-      #             $ref: "#/definitions/ValidatorAddress"
-      #           shares:
-      #             type: string
-      #             example: "100"
-      #   tags:
-      #     - Staking
-      #   consumes:
-      #     - application/json
-      #   produces:
-      #     - application/json
-      #   responses:
-      #     200:
-      #       description: OK
-      #       schema:
-      #         $ref: "#/definitions/BroadcastTxCommitResult"
-      #     400:
-      #       description: Invalid delegator address or unbonding delegation request body
-      #     401:
-      #       description: Key password is wrong
-      #     500:
-      #       description: Internal Server Error
-    /staking/delegators/{delegatorAddr}/unbonding_delegations/{validatorAddr}:
+        - in: body
+          name: account
+          description: The sender and tx information
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              amount:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
+  /auth/accounts/{address}:
+    get:
+      summary: Get the account information on blockchain
+      tags:
+        - Auth
+      produces:
+        - application/json
       parameters:
         - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
+          name: address
+          description: Account address
           required: true
           type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Query all unbonding delegations between a delegator and a validator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/UnbondingDelegationPair"
-          400:
-            description: Invalid delegator address or validator address
-          500:
-            description: Internal Server Error
-    /staking/redelegations:
-      parameters:
-        - in: query
-          name: delegator
-          description: Bech32 AccAddress of Delegator
-          required: false
-          type: string
-        - in: query
-          name: validator_from
-          description: Bech32 ValAddress of SrcValidator
-          required: false
-          type: string
-        - in: query
-          name: validator_to
-          description: Bech32 ValAddress of DstValidator
-          required: false
-          type: string
-      get:
-        summary: Get all redelegations (filter by query params)
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Redelegation"
-          500:
-            description: Internal Server Error
+          x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+      responses:
+        200:
+          description: Account information on the blockchain
+          schema:
+            type: object
+            properties:
+              type:
+                type: string
+              value:
+                type: object
+                properties:
+                  account_number:
+                    type: string
+                  address:
+                    type: string
+                  coins:
+                    type: array
+                    items:
+                      $ref: "#/definitions/Coin"
+                  public_key:
+                    $ref: "#/definitions/PublicKey"
+                  sequence:
+                    type: string
+        500:
+          description: Server internal error
+  /staking/delegators/{delegatorAddr}/delegations:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+    get:
+      summary: Get all delegations from a delegator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Delegation"
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
 
     # THE BELOW ENDPOINT IS NOT IMPLEMENTED IN COSMOS, SEE:
     # https://github.com/cosmos/cosmos-sdk/blob/18de630d0ae1887113e266982b51c2bf1f662edb/x/staking/client/rest/query.go
 
-    # /staking/delegators/{delegatorAddr}/redelegations:
+    # post:
+    #   summary: Submit delegation
     #   parameters:
-    #     - in: path
-    #       name: delegatorAddr
-    #       description: Bech32 AccAddress of Delegator
-    #       required: true
-    #       type: string
-    #       x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-    #   post:
-    #     summary: Submit a redelegation
-    #     parameters:
-    #       - in: body
-    #         name: delegation
-    #         description: The sender and tx information
-    #         schema:
-    #           type: object
-    #           properties:
-    #             base_req:
-    #               $ref: "#/definitions/BaseReq"
-    #             delegator_address:
-    #               $ref: "#/definitions/Address"
-    #             validator_src_addresses:
-    #               $ref: "#/definitions/ValidatorAddress"
-    #             validator_dst_address:
-    #               $ref: "#/definitions/ValidatorAddress"
-    #             shares:
-    #               type: string
-    #               example: "100"
-    #     tags:
-    #       - Staking
-    #     consumes:
-    #       - application/json
-    #     produces:
-    #       - application/json
-    #     responses:
-    #       200:
-    #         description: Tx was successfully generated
-    #         schema:
-    #           $ref: "#/definitions/StdTx"
-    #       400:
-    #         description: Invalid delegator address or redelegation request body
-    #       500:
-    #         description: Internal Server Error
-    /staking/delegators/{delegatorAddr}/validators:
-      parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
-          type: string
-          x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-      get:
-        summary: Query all validators that a delegator is bonded to
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Validator"
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-    /staking/delegators/{delegatorAddr}/validators/{validatorAddr}:
-      parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
-          type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: path
-          name: validatorAddr
-          description: Bech32 ValAddress of Delegator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Query a validator that a delegator is bonded to
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/Validator"
-          400:
-            description: Invalid delegator address or validator address
-          500:
-            description: Internal Server Error
-    /staking/validators:
-      get:
-        summary: Get all validator candidates. By default it returns only the bonded validators.
-        parameters:
-          - in: query
-            name: status
-            type: string
-            description: The validator bond status. Must be either 'bonded', 'unbonded', or 'unbonding'.
-            x-example: bonded
-          - in: query
-            name: page
-            description: The page number.
-            type: integer
-            x-example: 1
-          - in: query
-            name: limit
-            description: The maximum number of items per page.
-            type: integer
-            x-example: 1
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Validator"
-          500:
-            description: Internal Server Error
-    /staking/validators/{validatorAddr}:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Query the information from a single validator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Validator'
-          400:
-            description: Invalid validator address
-          500:
-            description: Internal Server Error
-    /staking/validators/{validatorAddr}/delegations:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1q53rwutgpzx7szcrgzqguxyccjpzt9j44jzrtj
-      get:
-        summary: Get all delegations from a validator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/Delegation"
-          400:
-            description: Invalid validator address
-          500:
-            description: Internal Server Error
-    /staking/validators/{validatorAddr}/unbonding_delegations:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1q53rwutgpzx7szcrgzqguxyccjpzt9j44jzrtj
-      get:
-        summary: Get all unbonding delegations from a validator
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  items:
-                    $ref: "#/definitions/UnbondingDelegation"
-          400:
-            description: Invalid validator address
-          500:
-            description: Internal Server Error
-    /staking/pool:
-      get:
-        summary: Get the current state of the staking pool
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                loose_tokens:
-                  type: string
-                bonded_tokens:
-                  type: string
-                inflation_last_time:
-                  type: string
-                inflation:
-                  type: string
-                date_last_commission_reset:
-                  type: string
-                prev_bonded_shares:
-                  type: string
-          500:
-            description: Internal Server Error
-    /staking/parameters:
-      get:
-        summary: Get the current staking parameter values
-        tags:
-          - Staking
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                inflation_rate_change:
-                  type: string
-                inflation_max:
-                  type: string
-                inflation_min:
-                  type: string
-                goal_bonded:
-                  type: string
-                unbonding_time:
-                  type: string
-                max_validators:
-                  type: integer
-                bond_denom:
-                  type: string
-          500:
-            description: Internal Server Error
-    # TODO: We need to either fix this route when the validator is not found or add a slashed validator in the contract tests
-    #  /slashing/validators/{validatorPubKey}/signing_info:
-    #    get:
-    #      summary: Get sign info of given validator
-    #      description: Get sign info of given validator
-    #      produces:
-    #        - application/json
-    #      tags:
-    #        - Slashing
-    #      parameters:
-    #        - type: string
-    #          description: Bech32 validator public key
-    #          name: validatorPubKey
-    #          required: true
-    #          in: path
-    #          x-example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
-    #      responses:
-    #        200:
-    #          description: OK
-    #          schema:
-    #            $ref: "#/definitions/SigningInfo"
-    #        400:
-    #          description: Invalid validator public key
-    #        500:
-    #          description: Internal Server Error
-    /slashing/signing_infos:
-      get:
-        summary: Get sign info of given all validators
-        description: Get sign info of all validators
-        produces:
-          - application/json
-        tags:
-          - Slashing
-        parameters:
-          - in: query
-            name: page
-            description: Page number
-            type: integer
-            required: true
-            x-example: 1
-          - in: query
-            name: limit
-            description: Maximum number of items per page
-            type: integer
-            required: true
-            x-example: 5
-        responses:
-          200:
-            description: OK
-            schema:
-              items:
-                type: object
-                properties:
-                  height:
-                    type: string
-                  result:
-                    items:
-                      $ref: "#/definitions/SigningInfo"
-          400:
-            description: Invalid validator public key for one of the validators
-          500:
-            description: Internal Server Error
-    /slashing/validators/{validatorAddr}/unjail:
-      post:
-        summary: Unjail a jailed validator
-        description: Send transaction to unjail a jailed validator
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Slashing
-        parameters:
-          - type: string
-            description: Bech32 validator address
-            name: validatorAddr
-            required: true
-            in: path
-            x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-          - description: ""
-            name: UnjailBody
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: "#/definitions/BaseReq"
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              $ref: "#/definitions/BroadcastTxCommitResult"
-          400:
-            description: Invalid validator address or base_req
-          500:
-            description: Internal Server Error
-    /slashing/parameters:
-      get:
-        summary: Get the current slashing parameters
-        tags:
-          - Slashing
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                max_evidence_age:
-                  type: string
-                signed_blocks_window:
-                  type: string
-                min_signed_per_window:
-                  type: string
-                double_sign_unbond_duration:
-                  type: string
-                downtime_unbond_duration:
-                  type: string
-                slash_fraction_double_sign:
-                  type: string
-                slash_fraction_downtime:
-                  type: string
-          500:
-            description: Internal Server Error
-    /gov/proposals:
-      post:
-        summary: Submit a proposal
-        description: Send transaction to submit a proposal
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - description: valid value of `"proposal_type"` can be `"text"`, `"parameter_change"`, `"software_upgrade"`
-            name: post_proposal_body
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: "#/definitions/BaseReq"
-                title:
-                  type: string
-                  example: Test_title
-                description:
-                  type: string
-                  example: my_test_description
-                proposal_type:
-                  type: string
-                  example: "text"
-                proposer:
-                  $ref: "#/definitions/Address"
-                initial_deposit:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Coin"
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/TextProposal"
-          400:
-            description: Invalid proposal body
-          500:
-            description: Internal Server Error
-      get:
-        summary: Query proposals
-        description: Query proposals information with parameters
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - in: query
-            name: voter
-            description: voter address
-            required: false
-            type: string
-          - in: query
-            name: depositor
-            description: depositor address
-            required: false
-            type: string
-          - in: query
-            name: status
-            description: proposal status, valid values can be `"deposit_period"`, `"voting_period"`, `"passed"`, `"rejected"`
-            required: false
-            type: string
-        responses:
-          200:
-            description: Tx was successfully generated
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/TextProposal"
-          400:
-            description: Invalid query parameters
-          500:
-            description: Internal Server Error
-    /gov/proposals/param_change:
-      post:
-        summary: Generate a parameter change proposal transaction
-        description: Generate a parameter change proposal transaction
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - description: The parameter change proposal body that contains all parameter changes
-            name: post_proposal_body
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: "#/definitions/BaseReq"
-                title:
-                  type: string
-                  example: Param_Change
-                description:
-                  type: string
-                  example: Update_max_validators
-                proposer:
-                  $ref: "#/definitions/Address"
-                deposit:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Coin"
-                changes:
-                  type: array
-                  items:
-                    $ref: "#/definitions/ParamChange"
-        responses:
-          200:
-            description: The transaction was successfully generated
-            schema:
-              $ref: '#/definitions/StdTx'
-          400:
-            description: Invalid proposal body
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}:
-      get:
-        summary: Query a proposal
-        description: Query a proposal by id
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/TextProposal'
-          400:
-            description: Invalid proposal id
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/proposer:
-      get:
-        summary: Query proposer
-        description: Query for the proposer for a proposal
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Proposer'
-          400:
-            description: Invalid proposal ID
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/deposits:
-      get:
-        summary: Query deposits
-        description: Query deposits by proposalId
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Deposit'
-          400:
-            description: Invalid proposal id
-          500:
-            description: Internal Server Error
-      post:
-        summary: Deposit tokens to a proposal
-        description: Send transaction to deposit tokens to a proposal
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-          - description: ''
-            name: post_deposit_body
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                depositor:
-                  $ref: '#/definitions/Address'
-                amount:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Coin'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid proposal id or deposit body
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/deposits/{depositor}:
-      get:
-        summary: Query deposit
-        description: Query deposit by proposalId and depositor address
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: "1"
-          - type: string
-            description: Bech32 depositor address
-            name: depositor
-            required: true
-            in: path
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Deposit'
-          400:
-            description: Invalid proposal id or depositor address
-          404:
-            description: Found no deposit
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/votes:
-      get:
-        summary: Query voters
-        description: Query voters information by proposalId
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Vote'
-          400:
-            description: Invalid proposal id
-          500:
-            description: Internal Server Error
-      post:
-        summary: Vote a proposal
-        description: Send transaction to vote a proposal
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-          - description: valid value of `"option"` field can be `"yes"`, `"no"`, `"no_with_veto"` and `"abstain"`
-            name: post_vote_body
-            in: body
-            required: true
-            schema:
-              type: object
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                voter:
-                  $ref: '#/definitions/Address'
-                option:
-                  type: string
-                  example: 'yes'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid proposal id or vote body
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/votes/{voter}:
-      get:
-        summary: Query vote
-        description: Query vote information by proposal Id and voter address
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-          - type: string
-            description: Bech32 voter address
-            name: voter
-            required: true
-            in: path
-            x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Vote'
-          400:
-            description: Invalid proposal id or voter address
-          404:
-            description: Found no vote
-          500:
-            description: Internal Server Error
-    /gov/proposals/{proposalId}/tally:
-      get:
-        summary: Get a proposal's tally result at the current time
-        description: Gets a proposal's tally result at the current time. If the proposal is pending deposits (i.e status 'DepositPeriod') it returns an empty tally result.
-        produces:
-          - application/json
-        tags:
-          - Governance
-        parameters:
-          - type: string
-            description: proposal id
-            name: proposalId
-            required: true
-            in: path
-            x-example: '1'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/TallyResult'
-          400:
-            description: Invalid proposal id
-          500:
-            description: Internal Server Error
-    /gov/parameters/deposit:
-      get:
-        summary: Query governance deposit parameters
-        description: Query governance deposit parameters. The max_deposit_period units are in nanoseconds.
-        produces:
-          - application/json
-        tags:
-          - Governance
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                min_deposit:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Coin'
-                max_deposit_period:
-                  type: string
-                  example: '86400000000000'
-          400:
-            description: <other_path> is not a valid query request path
-          404:
-            description: Found no deposit parameters
-          500:
-            description: Internal Server Error
-    /gov/parameters/tallying:
-      get:
-        summary: Query governance tally parameters
-        description: Query governance tally parameters
-        produces:
-          - application/json
-        tags:
-          - Governance
-        responses:
-          200:
-            description: OK
-            schema:
-              properties:
-                threshold:
-                  type: string
-                  example: '0.5000000000'
-                veto:
-                  type: string
-                  example: '0.3340000000'
-                governance_penalty:
-                  type: string
-                  example: '0.0100000000'
-          400:
-            description: <other_path> is not a valid query request path
-          404:
-            description: Found no tally parameters
-          500:
-            description: Internal Server Error
-    /gov/parameters/voting:
-      get:
-        summary: Query governance voting parameters
-        description: Query governance voting parameters. The voting_period units are in nanoseconds.
-        produces:
-          - application/json
-        tags:
-          - Governance
-        responses:
-          200:
-            description: OK
-            schema:
-              properties:
-                voting_period:
-                  type: string
-                  example: '86400000000000'
-          400:
-            description: <other_path> is not a valid query request path
-          404:
-            description: Found no voting parameters
-          500:
-            description: Internal Server Error
-    /distribution/delegators/{delegatorAddr}/rewards:
-      parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
-          type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-      get:
-        summary: Get the total rewards balance from all delegations
-        description: Get the sum of all the rewards earned by delegations by a single delegator
-        produces:
-          - application/json
-        tags:
-          - Distribution
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  $ref: '#/definitions/DelegatorTotalRewards'
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-      post:
-        summary: Withdraw all the delegator's delegation rewards
-        description: Withdraw all the delegator's delegation rewards
-        tags:
-          - Distribution
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Withdraw request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid delegator address
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /distribution/delegators/{delegatorAddr}/rewards/{validatorAddr}:
-      parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
-          type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Query a delegation reward
-        description: Query a single delegation reward by a delegator
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Coin"
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-      post:
-        summary: Withdraw a delegation reward
-        description: Withdraw a delegator's delegation reward from a single validator
-        tags:
-          - Distribution
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Withdraw request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid delegator address or delegation body
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /distribution/delegators/{delegatorAddr}/withdraw_address:
-      parameters:
-        - in: path
-          name: delegatorAddr
-          description: Bech32 AccAddress of Delegator
-          required: true
-          type: string
-          x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-      get:
-        summary: Get the rewards withdrawal address
-        description: Get the delegations' rewards withdrawal address. This is the address in which the user will receive the reward funds
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  $ref: "#/definitions/Address"
-          400:
-            description: Invalid delegator address
-          500:
-            description: Internal Server Error
-      post:
-        summary: Replace the rewards withdrawal address
-        description: Replace the delegations' rewards withdrawal address for a new one.
-        tags:
-          - Distribution
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Withdraw request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-                withdraw_address:
-                  $ref: '#/definitions/Address'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid delegator or withdraw address
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /distribution/validators/{validatorAddr}:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Validator distribution information
-        description: Query the distribution information of a single validator
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/ValidatorDistInfo'
-          400:
-            description: Invalid validator address
-          500:
-            description: Internal Server Error
-    /distribution/validators/{validatorAddr}/outstanding_rewards:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Fee distribution outstanding rewards of a single validator
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Coin'
-          500:
-            description: Internal Server Error
-    /distribution/validators/{validatorAddr}/rewards:
-      parameters:
-        - in: path
-          name: validatorAddr
-          description: Bech32 OperatorAddress of validator
-          required: true
-          type: string
-          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-      get:
-        summary: Commission and self-delegation rewards of a single validator
-        description: Query the commission and self-delegation rewards of validator.
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: '#/definitions/Coin'
-          400:
-            description: Invalid validator address
-          500:
-            description: Internal Server Error
-      post:
-        summary: Withdraw the validator's rewards
-        description: Withdraw the validator's self-delegation and commissions rewards
-        tags:
-          - Distribution
-        consumes:
-          - application/json
-        produces:
-          - application/json
-        parameters:
-          - in: body
-            name: Withdraw request body
-            schema:
-              properties:
-                base_req:
-                  $ref: '#/definitions/BaseReq'
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/BroadcastTxCommitResult'
-          400:
-            description: Invalid validator address
-          401:
-            description: Key password is wrong
-          500:
-            description: Internal Server Error
-    /distribution/community_pool:
-      get:
-        summary: Community pool parameters
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                height:
-                  type: string
-                  example: "100"
-                result:
-                  type: array
-                  items:
-                    $ref: "#/definitions/Coin"
-          500:
-            description: Internal Server Error
-    /distribution/parameters:
-      get:
-        summary: Fee distribution parameters
-        tags:
-          - Distribution
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              properties:
-                base_proposer_reward:
-                  type: string
-                bonus_proposer_reward:
-                  type: string
-                community_tax:
-                  type: string
-          500:
-            description: Internal Server Error
-    /minting/parameters:
-      get:
-        summary: Minting module parameters
-        tags:
-          - Mint
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              properties:
-                mint_denom:
-                  type: string
-                inflation_rate_change:
-                  type: string
-                inflation_max:
-                  type: string
-                inflation_min:
-                  type: string
-                goal_bonded:
-                  type: string
-                blocks_per_year:
-                  type: string
-          500:
-            description: Internal Server Error
-    /minting/inflation:
-      get:
-        summary: Current minting inflation value
-        tags:
-          - Mint
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/StandardResponse"
-          500:
-            description: Internal Server Error
-    /minting/annual-provisions:
-      get:
-        summary: Current minting annual provisions value
-        tags:
-          - Mint
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/StandardResponse"
-          500:
-            description: Internal Server Error
-    /supply/total:
-      get:
-        summary: Total supply of coins in the chain
-        tags:
-          - Supply
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: '#/definitions/Supply'
-          500:
-            description: Internal Server Error
-    /supply/total/{denomination}:
-      parameters:
-        - in: path
-          name: denomination
-          description: Coin denomination
-          required: true
-          type: string
-          x-example: uatom
-      get:
-        summary: Total supply of a single coin denomination
-        tags:
-          - Supply
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              $ref: "#/definitions/StandardResponse"
-          400:
-            description: Invalid coin denomination
-          500:
-            description: Internal Server Error
-    /kavadist/parameters:
-      get:
-        summary: Get the current kavadist parameter values
-        tags:
-          - Kavadist
-        produces:
-          - application/json
-        responses:
-          200:
-            description: OK
-            schema:
-              type: object
-              properties:
-                active:
-                  type: string
-                periods:
-                  type: array
-                  items:
-                    $ref: "#/definitions/KavadistPeriod"
-          500:
-            description: Internal Server Error
+    #     - in: body
+    #       name: delegation
+    #       description: The password of the account to remove from the KMS
+    #       schema:
+    #         type: object
+    #         properties:
+    #           base_req:
+    #             $ref: "#/definitions/BaseReq"
+    #           delegator_address:
+    #             $ref: "#/definitions/Address"
+    #           validator_address:
+    #             $ref: "#/definitions/ValidatorAddress"
+    #           delegation:
+    #             $ref: "#/definitions/Coin"
+    #   tags:
+    #     - Staking
+    #   consumes:
+    #     - application/json
+    #   produces:
+    #     - application/json
+    #   responses:
+    #     200:
+    #       description: OK
+    #       schema:
+    #         $ref: "#/definitions/BroadcastTxCommitResult"
+    #     400:
+    #       description: Invalid delegator address or delegation request body
+    #     401:
+    #       description: Key password is wrong
+    #     500:
+    #       description: Internal Server Error
+  /staking/delegators/{delegatorAddr}/delegations/{validatorAddr}:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Query the current delegation between a delegator and a validator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Delegation"
+        400:
+          description: Invalid delegator address or validator address
+        500:
+          description: Internal Server Error
+  /staking/delegators/{delegatorAddr}/unbonding_delegations:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+    get:
+      summary: Get all unbonding delegations from a delegator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/UnbondingDelegation"
 
-  definitions:
-    CheckTxResult:
-      type: object
-      properties:
-        code:
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
+
+    # THE BELOW ENDPOINT IS NOT IMPLEMENTED IN COSMOS, SEE:
+    # https://github.com/cosmos/cosmos-sdk/blob/18de630d0ae1887113e266982b51c2bf1f662edb/x/staking/client/rest/query.go
+
+    # post:
+    #   summary: Submit an unbonding delegation
+    #   parameters:
+    #     - in: body
+    #       name: delegation
+    #       description: The password of the account to remove from the KMS
+    #       schema:
+    #         type: object
+    #         properties:
+    #           base_req:
+    #             $ref: "#/definitions/BaseReq"
+    #           delegator_address:
+    #             $ref: "#/definitions/Address"
+    #           validator_address:
+    #             $ref: "#/definitions/ValidatorAddress"
+    #           shares:
+    #             type: string
+    #             example: "100"
+    #   tags:
+    #     - Staking
+    #   consumes:
+    #     - application/json
+    #   produces:
+    #     - application/json
+    #   responses:
+    #     200:
+    #       description: OK
+    #       schema:
+    #         $ref: "#/definitions/BroadcastTxCommitResult"
+    #     400:
+    #       description: Invalid delegator address or unbonding delegation request body
+    #     401:
+    #       description: Key password is wrong
+    #     500:
+    #       description: Internal Server Error
+  /staking/delegators/{delegatorAddr}/unbonding_delegations/{validatorAddr}:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Query all unbonding delegations between a delegator and a validator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/UnbondingDelegationPair"
+        400:
+          description: Invalid delegator address or validator address
+        500:
+          description: Internal Server Error
+  /staking/redelegations:
+    parameters:
+      - in: query
+        name: delegator
+        description: Bech32 AccAddress of Delegator
+        required: false
+        type: string
+      - in: query
+        name: validator_from
+        description: Bech32 ValAddress of SrcValidator
+        required: false
+        type: string
+      - in: query
+        name: validator_to
+        description: Bech32 ValAddress of DstValidator
+        required: false
+        type: string
+    get:
+      summary: Get all redelegations (filter by query params)
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Redelegation"
+        500:
+          description: Internal Server Error
+
+  # THE BELOW ENDPOINT IS NOT IMPLEMENTED IN COSMOS, SEE:
+  # https://github.com/cosmos/cosmos-sdk/blob/18de630d0ae1887113e266982b51c2bf1f662edb/x/staking/client/rest/query.go
+
+  # /staking/delegators/{delegatorAddr}/redelegations:
+  #   parameters:
+  #     - in: path
+  #       name: delegatorAddr
+  #       description: Bech32 AccAddress of Delegator
+  #       required: true
+  #       type: string
+  #       x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+  #   post:
+  #     summary: Submit a redelegation
+  #     parameters:
+  #       - in: body
+  #         name: delegation
+  #         description: The sender and tx information
+  #         schema:
+  #           type: object
+  #           properties:
+  #             base_req:
+  #               $ref: "#/definitions/BaseReq"
+  #             delegator_address:
+  #               $ref: "#/definitions/Address"
+  #             validator_src_addresses:
+  #               $ref: "#/definitions/ValidatorAddress"
+  #             validator_dst_address:
+  #               $ref: "#/definitions/ValidatorAddress"
+  #             shares:
+  #               type: string
+  #               example: "100"
+  #     tags:
+  #       - Staking
+  #     consumes:
+  #       - application/json
+  #     produces:
+  #       - application/json
+  #     responses:
+  #       200:
+  #         description: Tx was successfully generated
+  #         schema:
+  #           $ref: "#/definitions/StdTx"
+  #       400:
+  #         description: Invalid delegator address or redelegation request body
+  #       500:
+  #         description: Internal Server Error
+  /staking/delegators/{delegatorAddr}/validators:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+    get:
+      summary: Query all validators that a delegator is bonded to
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Validator"
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
+  /staking/delegators/{delegatorAddr}/validators/{validatorAddr}:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      - in: path
+        name: validatorAddr
+        description: Bech32 ValAddress of Delegator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Query a validator that a delegator is bonded to
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Validator"
+        400:
+          description: Invalid delegator address or validator address
+        500:
+          description: Internal Server Error
+  /staking/validators:
+    get:
+      summary: Get all validator candidates. By default it returns only the bonded validators.
+      parameters:
+        - in: query
+          name: status
+          type: string
+          description: The validator bond status. Must be either 'bonded', 'unbonded', or 'unbonding'.
+          x-example: bonded
+        - in: query
+          name: page
+          description: The page number.
           type: integer
-        data:
-          type: string
-        gas_used:
+          x-example: 1
+        - in: query
+          name: limit
+          description: The maximum number of items per page.
           type: integer
-        gas_wanted:
+          x-example: 1
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Validator"
+        500:
+          description: Internal Server Error
+  /staking/validators/{validatorAddr}:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Query the information from a single validator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Validator"
+        400:
+          description: Invalid validator address
+        500:
+          description: Internal Server Error
+  /staking/validators/{validatorAddr}/delegations:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1q53rwutgpzx7szcrgzqguxyccjpzt9j44jzrtj
+    get:
+      summary: Get all delegations from a validator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/Delegation"
+        400:
+          description: Invalid validator address
+        500:
+          description: Internal Server Error
+  /staking/validators/{validatorAddr}/unbonding_delegations:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1q53rwutgpzx7szcrgzqguxyccjpzt9j44jzrtj
+    get:
+      summary: Get all unbonding delegations from a validator
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                items:
+                  $ref: "#/definitions/UnbondingDelegation"
+        400:
+          description: Invalid validator address
+        500:
+          description: Internal Server Error
+  /staking/pool:
+    get:
+      summary: Get the current state of the staking pool
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              loose_tokens:
+                type: string
+              bonded_tokens:
+                type: string
+              inflation_last_time:
+                type: string
+              inflation:
+                type: string
+              date_last_commission_reset:
+                type: string
+              prev_bonded_shares:
+                type: string
+        500:
+          description: Internal Server Error
+  /staking/parameters:
+    get:
+      summary: Get the current staking parameter values
+      tags:
+        - Staking
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              inflation_rate_change:
+                type: string
+              inflation_max:
+                type: string
+              inflation_min:
+                type: string
+              goal_bonded:
+                type: string
+              unbonding_time:
+                type: string
+              max_validators:
+                type: integer
+              bond_denom:
+                type: string
+        500:
+          description: Internal Server Error
+  # TODO: We need to either fix this route when the validator is not found or add a slashed validator in the contract tests
+  #  /slashing/validators/{validatorPubKey}/signing_info:
+  #    get:
+  #      summary: Get sign info of given validator
+  #      description: Get sign info of given validator
+  #      produces:
+  #        - application/json
+  #      tags:
+  #        - Slashing
+  #      parameters:
+  #        - type: string
+  #          description: Bech32 validator public key
+  #          name: validatorPubKey
+  #          required: true
+  #          in: path
+  #          x-example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
+  #      responses:
+  #        200:
+  #          description: OK
+  #          schema:
+  #            $ref: "#/definitions/SigningInfo"
+  #        400:
+  #          description: Invalid validator public key
+  #        500:
+  #          description: Internal Server Error
+  /slashing/signing_infos:
+    get:
+      summary: Get sign info of given all validators
+      description: Get sign info of all validators
+      produces:
+        - application/json
+      tags:
+        - Slashing
+      parameters:
+        - in: query
+          name: page
+          description: Page number
           type: integer
-        info:
-          type: string
-        log:
-          type: string
-        tags:
-          type: array
-          items:
-            $ref: '#/definitions/KVPair'
-      example:
-        code: 0
-        data: data
-        log: log
-        gas_used: 5000
-        gas_wanted: 10000
-        info: info
-        tags:
-          - ''
-          - ''
-    DeliverTxResult:
-      type: object
-      properties:
-        code:
+          required: true
+          x-example: 1
+        - in: query
+          name: limit
+          description: Maximum number of items per page
           type: integer
-        data:
-          type: string
-        gas_used:
-          type: integer
-        gas_wanted:
-          type: integer
-        info:
-          type: string
-        log:
-          type: string
-        tags:
-          type: array
-          items:
-            $ref: '#/definitions/KVPair'
-      example:
-        code: 5
-        data: data
-        log: log
-        gas_used: 5000
-        gas_wanted: 10000
-        info: info
-        tags:
-          - ''
-          - ''
-    BroadcastTxCommitResult:
-      type: object
-      properties:
-        check_tx:
-          $ref: '#/definitions/CheckTxResult'
-        deliver_tx:
-          $ref: '#/definitions/DeliverTxResult'
-        hash:
-          $ref: '#/definitions/Hash'
-        height:
-          type: string
-    KVPair:
-      type: object
-      properties:
-        key:
-          type: string
-        value:
-          type: string
-    Msg:
-      type: object
-      properties:
-        type:
-          type: string
-          example: "cosmos-sdk/MsgSend"
-        value:
-          type: object
-          properties:
-            from_address:
-              type: string
-              example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-            to_address:
-              type: string
-              example: kava1ls82zzghsx0exkpr52m8vht5jqs3un0ceysshz
-            amount:
-              type: array
-              items:
-                $ref: "#/definitions/Coin"
-    Address:
-      type: string
-      description: bech32 encoded address
-      example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-    Address2:
-      type: string
-      description: bech32 encoded address
-      example: kava1atsrkjac6ulgmwhudfc36lnjfgv340vlvm757z
-    BinanceChainAddress:
-      type: string
-      description: address on another chain (binance)
-      example: bnb1uky3me9ggqypmrsvxk7ur6hqkzq7zmv4ed4ng7
-    BinanceChainAddress2:
-      type: string
-      description: address on another chain (binance)
-      example: bnb10uypsspvl6jlxcx5xse02pag39l8xpe7a3468h
-    RandomNumberHash:
-      type: string
-      description: hex-encoded sha256 hash of a 64bit random number
-      example: c0544b7f4b890a673ea3f61bdb4650fbfe2f3e56bda1b397d6d592fca7163c8c
-    Timestamp:
-      type: string
-      description: unix timestamp
-      example: "1585252531"
-    HeightSpan:
-      type: string
-      description: span of blocks for which an atomic swap is valid
-      example: "3600"
-    DeputyAddress:
-      type: string
-      description: bep3 deputy
-      example: kava1xy7hrjy9r0algz9w3gzm8u6mrpq97kwta747gj
-    ValidatorAddress:
-      type: string
-      description: bech32 encoded address
-      example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
-    Coin:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: ukava
-        amount:
-          type: string
-          example: '50000'
-    CoinBNB:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: bnb
-        amount:
-          type: string
-          example: '555555'
-    CollateralType:
-      type: string
-      example: xrpb-a
-    CoinCollateral:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "xrp"
-        amount:
-          type: string
-          example: '10000000000'
-    CoinPrincipal:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "usdx"
-        amount:
-          type: string
-          example: '10000000'
-    CoinBid:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "usdx"
-        amount:
-          type: string
-          example: '100000000'
-    Hash:
-      type: string
-      example: EE5F3404034C524501629B56E0DDC38FAD651F04
-    Signature:
-      type: object
-      properties:
-        signature:
-          type: string
-          example: 'W1HfKcc4F0rCSoxheZ7fsrB5nGK58U4gKysuzsmUwhloVnCxmbCx289uVMMvQN6tOcQsz7hMVTJrXSA1xzevvw=='
-        pubkey:
-          type: object
-          properties:
-            type:
-              type: string
-              example: 'tendermint/PubKeySecp256k1'
-            value:
-              type: string
-              example: 'Agey31h/NYpcy0sYm4liHMrXJMzbQUrgV4uHd/w09CXN'
-    TxQuery:
-      type: object
-      properties:
-        hash:
-          type: string
-          example: 'D085138D913993919295FF4B0A9107F1F2CDE0D37A87CE0644E217CBF3B49656'
-        height:
-          type: string
-          example: "368"
-        tx:
-          $ref: '#/definitions/StdTx'
-        result:
-          type: object
-          properties:
-            log:
-              type: string
-            gas_wanted:
-              type: string
-              example: '200000'
-            gas_used:
-              type: string
-              example: '26354'
-            tags:
-              type: array
-              items:
-                $ref: '#/definitions/KVPair'
-    PaginatedQueryTxs:
-      type: object
-      properties:
-        total_count:
-          type: string
-          example: "1"
-        count:
-          type: string
-          example: "1"
-        page_number:
-          type: string
-          example: "1"
-        page_total:
-          type: string
-          example: "1"
-        limit:
-          type: string
-          example: "30"
-        txs:
-          type: array
-          items:
-            $ref: '#/definitions/TxQuery'
-    StdTx:
-      type: object
-      properties:
-        msg:
-          type: array
-          items:
-            $ref: "#/definitions/Msg"
-        fee:
-          type: object
-          properties:
-            gas:
-              type: string
-              example: "200000"
-            amount:
-              type: array
-              items:
-                $ref: "#/definitions/Coin"
-        memo:
-          type: string
-        signatures:
-          type: array
-          items:
-            $ref: '#/definitions/Signature'
-    BlockID:
-      type: object
-      properties:
-        hash:
-          $ref: '#/definitions/Hash'
-        parts:
-          type: object
-          properties:
-            total:
-              type: string
-              example: "0"
-            hash:
-              $ref: '#/definitions/Hash'
-    BlockHeader:
-      type: object
-      properties:
-        chain_id:
-          type: string
-          example: testing
-        height:
-          type: string
-          example: "1"
-        time:
-          type: string
-          example: '2017-12-30T05:53:09.287+01:00'
-        num_txs:
-          type: string
-          example: "0"
-        last_block_id:
-          $ref: '#/definitions/BlockID'
-        total_txs:
-          type: string
-          example: "35"
-        last_commit_hash:
-          $ref: '#/definitions/Hash'
-        data_hash:
-          $ref: '#/definitions/Hash'
-        validators_hash:
-          $ref: '#/definitions/Hash'
-        next_validators_hash:
-          $ref: '#/definitions/Hash'
-        consensus_hash:
-          $ref: '#/definitions/Hash'
-        app_hash:
-          $ref: '#/definitions/Hash'
-        last_results_hash:
-          $ref: '#/definitions/Hash'
-        evidence_hash:
-          $ref: '#/definitions/Hash'
-        proposer_address:
-          $ref: '#/definitions/Address'
-        version:
-          type: object
-          properties:
-            block:
-              type: string
-              example: 10
-            app:
-              type: string
-              example: 0
-    Block:
-      type: object
-      properties:
-        header:
-          $ref: '#/definitions/BlockHeader'
-        txs:
-          type: array
-          items:
-            type: string
-        evidence:
-          type: object
-          # type: array
-          # items:
-          #   type: string
-        last_commit:
-          type: object
-          properties:
-            block_id:
-              $ref: '#/definitions/BlockID'
-            precommits:
-              type: array
-              x-nullable: true
-              items:
-                type: object
-                properties:
-                  validator_address:
-                    type: string
-                  validator_index:
-                    type: string
-                    example: '0'
-                  height:
-                    type: string
-                    example: '0'
-                  round:
-                    type: string
-                    example: '0'
-                  timestamp:
-                    type: string
-                    example: '2017-12-30T05:53:09.287+01:00'
-                  type:
-                    type: number
-                    example: 2
-                  block_id:
-                    $ref: '#/definitions/BlockID'
-                  signature:
-                    type: string
-                    example: '7uTC74QlknqYWEwg7Vn6M8Om7FuZ0EO4bjvuj6rwH1mTUJrRuMMZvAAqT9VjNgP0RA/TDp6u/92AqrZfXJSpBQ=='
-    BlockQuery:
-      type: object
-      properties:
-        block_meta:
-          type: object
-          properties:
-            header:
-              $ref: '#/definitions/BlockHeader'
-            block_id:
-              $ref: '#/definitions/BlockID'
-        block:
-          $ref: '#/definitions/Block'
-    DelegationDelegatorReward:
-      type: object
-      properties:
-        validator_address:
-          $ref: '#/definitions/ValidatorAddress'
-        reward:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-    DelegatorTotalRewards:
-      type: object
-      properties:
-        rewards:
-          type: array
-          items:
-            $ref: '#/definitions/DelegationDelegatorReward'
-        total:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-    BaseReq:
-      type: object
-      properties:
-        from:
-          type: string
-          example: 'kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c'
-          description: Sender address or Keybase name to generate a transaction
-        memo:
-          type: string
-          example: 'a memo'
-        chain_id:
-          type: string
-          example: 'testing'
-        account_number:
-          type: string
-          example: '1'
-        sequence:
-          type: string
-          example: '0'
-        gas:
-          type: string
-          example: '200000'
-        gas_adjustment:
-          type: string
-          example: '1.0'
-        fees:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        simulate:
-          type: boolean
-          example: false
-          description: Estimate gas for a transaction (cannot be used in conjunction with generate_only)
-    TendermintValidator:
-      type: object
-      properties:
-        address:
-          $ref: '#/definitions/ValidatorAddress'
-        pub_key:
-          type: string
-          example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
-        voting_power:
-          type: string
-          example: '1000'
-        proposer_priority:
-          type: string
-          example: '1000'
-    AtomicSwapResponse:
-      type: object
-      properties:
-        id:
-          type: string
-          example: FFEA80A3D9A42427CC12DB957866C6D428C16AA5EA6D9A4A756EF04BF9F2FF06
-        status:
-          type: string
-          example: Completed
-        amount:
-          $ref: '#/definitions/CoinBNB'
-        random_number_hash:
-          type: string
-          example: 0b1e35e991bf052be230ae8dd3ff90b69a610160d28a9eb3c0701395f9d2b291
-        expire_hieght:
-          type: string
-          example: 532463
-        timestamp:
-          type: string
-          example: 1589020884
-        sender:
-          $ref: '#/definitions/Address'
-        recipient:
-          $ref: '#/definitions/Address2'
-        sender_other_chain:
-          $ref: '#/definitions/BinanceChainAddress'
-        recipient_other_chain:
-          $ref: '#/definitions/BinanceChainAddress2'
-        closed_block:
-          type: string
-          example: 532105
-        cross_chain:
-          $ref: '#/definitions/CrossChain'
-        direction:
-          type: string
-          example: Incoming
-    AssetSupplyResponse:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: bnb
-        incoming_supply:
-          $ref: '#/definitions/CoinBNB'
-        outgoing_supply:
-          $ref: '#/definitions/CoinBNB'
-        current_supply:
-          $ref: '#/definitions/CoinBNB'
-        limit:
-          $ref: '#/definitions/CoinBNB'
-    Bep3ParamsResponse:
-      type: object
-      properties:
-        bnb_deputy_address:
-          type: string
-          example: kava1aphsdnz5hu2t5ty2au6znprug5kx3zpy6zwq29
-        min_block_lock:
-          type: string
-          example: 80
-        max_block_lock:
-          type: string
-          example: 3600
-        supported_assets:
-          type: array
-          items:
-            $ref: '#/definitions/Bep3Asset'
-    Bep3Asset:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: bnb
-        coin_id:
-          type: string
-          example: 714
-        limit:
-          type: string
-          example: "100"
-        active:
-          type: boolean
-          example: true
-    ClaimResponse:
-      type: object
-      properties:
-        owner:
-          type: string
-          example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-        reward:
-          $ref: '#/definitions/Coin'
-        denom:
-          type: string
-          example: bnb
-        claim_period_id:
-          type: string
-          example: 1
-    IncentiveParams:
-      type: object
-      properties:
-        active:
-          type: boolean
-          example: true
-        rewards:
-          type: array
-          items:
-            $ref: '#/definitions/Reward'
-    Reward:
-      type: object
-      properties:
-        active:
-          type: boolean
-          example: true
-        denom:
-          type: string
-          example: bnb
-        available_rewards:
-          $ref: '#/definitions/Coin'
-        duration:
-          type: string
-          example: 36800000000000
-        time_lock:
-          type: string
-          example: 36800000000000
-        claim_duration:
-          type: string
-          example: 36800000000000
-    PubProposal:
-      type: object
-      properties:
-        title:
-          type: string
-          example: "the title of the proposal"
-        description:
-          type: string
-          example: "the description of the proposal"
-    CdpResponse:
-      type: object
-      properties:
-        id:
-          type: string
-          example: 1
-        owner:
-          type: string
-          example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-        collateral:
-          $ref: '#/definitions/CoinCollateral'
-        type:
-          type: string
-          example: "xrpb-a"
-        principal:
-          $ref: '#/definitions/CoinPrincipal'
-        accumulated_fees:
-          $ref: '#/definitions/CoinPrincipal'
-        fees_updated:
-          type: string
-          example: '2020-02-05T23:45:55.761435272Z'
-        collateral_value:
-          $ref: '#/definitions/CoinPrincipal'
-        collateralization_ratio:
-          type: string
-          example: '2.721734157907653857'
-    CdpDepositResponse:
-      type: object
-      properties:
-        cdp_id:
-          type: string
-          example: 1
-        depositor:
-          type: string
-          example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
-        amount:
-          $ref: '#/definitions/CoinCollateral'
-    PricefeedParameters:
-      type: object
-      properties:
-        markets:
-          type: array
-          items:
-            $ref: '#/definitions/Market'
-    Price:
-      type: object
-      properties:
-        market_id:
-          type: string
-          example: 'xrp:usd'
-        price:
-          type: string
-          example: '0.298758999999999997'
-    PostedPrice:
-      type: object
-      properties:
-        market_id:
-          type: string
-          example: 'xrp:usd'
-        oracle_address:
-          type: string
-          example: kava10cw2m04528dwlc44k0myd7strj3eq5jr6s8pxs
-        price:
-          type: string
-          example: '0.298758999999999997'
-        expiry:
-          type: string
-          example: '2021-02-12T23:10:00Z'
-    Market:
-      type: object
-      properties:
-        market_id:
-          type: string
-          example: 'xrp:usd'
-        base_asset:
-          type: string
-          example: 'xrp'
-        quote_asset:
-          type: string
-          example: 'usd'
-        oracles:
-          type: array
-          x-nullable: true
-          items:
-            $ref: '#/definitions/Address'
-        active:
-          type: boolean
-          example: true
-    HardParams:
-      type: object
-      properties:
-        money_markets:
-          type: array
-          items:
-            $ref: '#/definitions/MoneyMarket'
-        minimum_borrow_usd_value:
-          type: string
-          example: "10"
-    MoneyMarket:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "bnb"
-        borrow_limit:
-          $ref: '#/definitions/BorrowLimit'
-        spot_market_id:
-          type: string
-          example: 'bnb:usd'
-        conversion_factor:
-          type: string
-          example: "100000000"
-        interest_rate_model:
-          $ref: '#/definitions/InterestRateModel'
-        reserve_factor:
-          type: string
-          example: "0.05"
-        keeper_reward_percentage:
-          type: string
-          example: "0.05"
-    BorrowLimit:
-      type: object
-      properties:
-        has_max_limit:
-          type: boolean
-          example: true
-        maximum_limit:
-          type: string
-          example: "100000000000000"
-        loan_to_value:
-          type: string
-          example: "0.8"
-    InterestRateModel:
-      type: object
-      properties:
-        base_rate_apy:
-          type: string
-          example: "0"
-        base_multiplier:
-          type: string
-          example: "0.1"
-        kink:
-          type: string
-          example: "0.8"
-        jump_multiplier:
-          type: string
-          example: "0.5"
-    HardDepositResponse:
-      type: object
-      properties:
-        depositor:
-          $ref: '#/definitions/Address'
-        amount:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        index:
-          type: array
-          items:
-            $ref: '#/definitions/SupplyInterestFactor'
-    HardBorrowResponse:
-      type: object
-      properties:
-        borrower:
-          $ref: '#/definitions/Address'
-        amount:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        index:
-          type: array
-          items:
-            $ref: '#/definitions/BorrowInterestFactor'
-    SupplyInterestFactor:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "bnb"
-        value:
-          type: string
-          example: "0.1258"
-    BorrowInterestFactor:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "bnb"
-        value:
-          type: string
-          example: "0.1258"
-    MoneyMarketInterestRate:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: "bnb"
-        supply_interest_rate:
-          type: string
-          example: "5.25"
-        borrow_interest_rate:
-          type: string
-          example: "5.25"
-    MultiplierName:
-      type: string
-      example: "small"
-    IssuanceParams:
-      type: object
-      properties:
-        assets:
-          type: array
-          items:
-            $ref: '#/definitions/IssuanceAsset'
-    IssuanceAsset:
-      type: object
-      properties:
-        owner:
-          $ref: '#/definitions/Address'
-        denom:
-          type: string
-          example: "btc"
-        blocked_addresses:
-          type: array
-          items:
-            $ref: '#/definitions/Address'
-        paused:
-          type: boolean
-          example: false
-        blockable:
-          type: boolean
-          example: true
-        rate_limit:
-          $ref: '#/definitions/RateLimit'
-    RateLimit:
-      type: object
-      properties:
-        active:
-          type: boolean
-          example: true
-        limit:
-          type: string
-          example: 500000000
-        time_period:
-          type: string
-          example: 518400000000000
-    AuctionParameters:
-      type: object
-      properties:
-        max_auction_duration:
-          type: string
-          example: 172800000000000
-        bid_duration:
-          type: string
-          example: 600000000000
-        increment_surplus:
-          type: string
-          example: "0.05"
-        increment_debt:
-          type: string
-          example: "0.05"
-        increment_collateral:
-          type: string
-          example: "0.05"
-    AuctionResponse:
-      type: object
-      properties:
-        id:
-          type: string
-          example: 1
-        initiator:
-          type: string
-          example: liquidator
-        lot:
-          $ref: '#/definitions/CoinCollateral'
-        bidder:
-          $ref: '#/definitions/Address'
-        bid:
-          $ref: '#/definitions/Coin'
-        has_received_bids:
-          type: boolean
-          example: false
-        end_time:
-          type: string
-          example: '2020-02-05T23:45:55.761435272Z'
-        max_end_time:
-          type: string
-          example: '2020-02-05T23:45:55.761435272Z'
-        type:
-          type: string
-          example: collateral
-        phase:
-          type: string
-          example: forward
-    CollateralParam:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: xrp
-        liquidation_ratio:
-          type: string
-          example: '2.000000000000000000'
-        debt_limit:
-          $ref: '#/definitions/CoinPrincipal'
-        stability_fee:
-          type: string
-          example: '1.000000001547126000'
-        auction_size:
-          type: string
-          example: '5000000000'
-        liquidation_penalty:
-          type: string
-          example: '0.050000000000000000'
-        prefix:
-          type: integer
-          example: 0
-        market_id:
-          type: string
-          example: 'xrp:usd'
-        conversion_factor:
-          type: string
-          example: '6'
-    DebtParam:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: usdx
-        reference_asset:
-          type: string
-          example: 'usd'
-        conversion_factor:
-          type: string
-          example: '6'
-        debt_floor:
-          type: string
-          example: '10000000'
-    TextProposal:
-      type: object
-      properties:
-        proposal_id:
-          type: integer
-        title:
-          type: string
-        description:
-          type: string
-        proposal_type:
-          type: string
-        proposal_status:
-          type: string
-        final_tally_result:
-          $ref: '#/definitions/TallyResult'
-        submit_time:
-          type: string
-        total_deposit:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        voting_start_time:
-          type: string
-    Proposer:
-      type: object
-      properties:
-        proposal_id:
-          type: string
-          example: 1
-        proposer:
-          type: string
-          example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-    Deposit:
-      type: object
-      properties:
-        amount:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        proposal_id:
-          type: string
-        depositor:
-          $ref: '#/definitions/Address'
-    TallyResult:
-      type: object
-      properties:
-        yes:
-          type: string
-          example: '0.0000000000'
-        abstain:
-          type: string
-          example: '0.0000000000'
-        no:
-          type: string
-          example: '0.0000000000'
-        no_with_veto:
-          type: string
-          example: '0.0000000000'
-    Vote:
-      type: object
-      properties:
-        voter:
-          type: string
-        proposal_id:
-          type: string
-        option:
-          type: string
-    CommitteeVote:
-      type: object
-      properties:
-        voter:
-          type: string
-        proposal_id:
-          type: string
-    CommitteeProposal:
-      type: object
-      properties:
-        pub_proposal:
-          $ref: '#/definitions/PubProposal'
-        id:
-          type: string
-          example: 1
-        committee_id:
-          type: string
-          example: 1
-        deadline:
-          type: string
-          example: '2020-05-10T16:18:43.752522893Z'
-    Committee:
+          required: true
+          x-example: 5
+      responses:
+        200:
+          description: OK
+          schema:
+            items:
+              type: object
+              properties:
+                height:
+                  type: string
+                result:
+                  items:
+                    $ref: "#/definitions/SigningInfo"
+        400:
+          description: Invalid validator public key for one of the validators
+        500:
+          description: Internal Server Error
+  /slashing/validators/{validatorAddr}/unjail:
+    post:
+      summary: Unjail a jailed validator
+      description: Send transaction to unjail a jailed validator
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Slashing
+      parameters:
+        - type: string
+          description: Bech32 validator address
+          name: validatorAddr
+          required: true
+          in: path
+          x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+        - description: ""
+          name: UnjailBody
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid validator address or base_req
+        500:
+          description: Internal Server Error
+  /slashing/parameters:
+    get:
+      summary: Get the current slashing parameters
+      tags:
+        - Slashing
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              max_evidence_age:
+                type: string
+              signed_blocks_window:
+                type: string
+              min_signed_per_window:
+                type: string
+              double_sign_unbond_duration:
+                type: string
+              downtime_unbond_duration:
+                type: string
+              slash_fraction_double_sign:
+                type: string
+              slash_fraction_downtime:
+                type: string
+        500:
+          description: Internal Server Error
+  /gov/proposals:
+    post:
+      summary: Submit a proposal
+      description: Send transaction to submit a proposal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - description: valid value of `"proposal_type"` can be `"text"`, `"parameter_change"`, `"software_upgrade"`
+          name: post_proposal_body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              title:
+                type: string
+                example: Test_title
+              description:
+                type: string
+                example: my_test_description
+              proposal_type:
+                type: string
+                example: "text"
+              proposer:
+                $ref: "#/definitions/Address"
+              initial_deposit:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/TextProposal"
+        400:
+          description: Invalid proposal body
+        500:
+          description: Internal Server Error
+    get:
+      summary: Query proposals
+      description: Query proposals information with parameters
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - in: query
+          name: voter
+          description: voter address
+          required: false
+          type: string
+        - in: query
+          name: depositor
+          description: depositor address
+          required: false
+          type: string
+        - in: query
+          name: status
+          description: proposal status, valid values can be `"deposit_period"`, `"voting_period"`, `"passed"`, `"rejected"`
+          required: false
+          type: string
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/TextProposal"
+        400:
+          description: Invalid query parameters
+        500:
+          description: Internal Server Error
+  /gov/proposals/param_change:
+    post:
+      summary: Generate a parameter change proposal transaction
+      description: Generate a parameter change proposal transaction
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - description: The parameter change proposal body that contains all parameter changes
+          name: post_proposal_body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              title:
+                type: string
+                example: Param_Change
+              description:
+                type: string
+                example: Update_max_validators
+              proposer:
+                $ref: "#/definitions/Address"
+              deposit:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+              changes:
+                type: array
+                items:
+                  $ref: "#/definitions/ParamChange"
+      responses:
+        200:
+          description: The transaction was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid proposal body
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}:
+    get:
+      summary: Query a proposal
+      description: Query a proposal by id
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/TextProposal"
+        400:
+          description: Invalid proposal id
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/proposer:
+    get:
+      summary: Query proposer
+      description: Query for the proposer for a proposal
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Proposer"
+        400:
+          description: Invalid proposal ID
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/deposits:
+    get:
+      summary: Query deposits
+      description: Query deposits by proposalId
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Deposit"
+        400:
+          description: Invalid proposal id
+        500:
+          description: Internal Server Error
+    post:
+      summary: Deposit tokens to a proposal
+      description: Send transaction to deposit tokens to a proposal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+        - description: ""
+          name: post_deposit_body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              depositor:
+                $ref: "#/definitions/Address"
+              amount:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid proposal id or deposit body
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/deposits/{depositor}:
+    get:
+      summary: Query deposit
+      description: Query deposit by proposalId and depositor address
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+        - type: string
+          description: Bech32 depositor address
+          name: depositor
+          required: true
+          in: path
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Deposit"
+        400:
+          description: Invalid proposal id or depositor address
+        404:
+          description: Found no deposit
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/votes:
+    get:
+      summary: Query voters
+      description: Query voters information by proposalId
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Vote"
+        400:
+          description: Invalid proposal id
+        500:
+          description: Internal Server Error
+    post:
+      summary: Vote a proposal
+      description: Send transaction to vote a proposal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+        - description: valid value of `"option"` field can be `"yes"`, `"no"`, `"no_with_veto"` and `"abstain"`
+          name: post_vote_body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              voter:
+                $ref: "#/definitions/Address"
+              option:
+                type: string
+                example: "yes"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid proposal id or vote body
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/votes/{voter}:
+    get:
+      summary: Query vote
+      description: Query vote information by proposal Id and voter address
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+        - type: string
+          description: Bech32 voter address
+          name: voter
+          required: true
+          in: path
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Vote"
+        400:
+          description: Invalid proposal id or voter address
+        404:
+          description: Found no vote
+        500:
+          description: Internal Server Error
+  /gov/proposals/{proposalId}/tally:
+    get:
+      summary: Get a proposal's tally result at the current time
+      description: Gets a proposal's tally result at the current time. If the proposal is pending deposits (i.e status 'DepositPeriod') it returns an empty tally result.
+      produces:
+        - application/json
+      tags:
+        - Governance
+      parameters:
+        - type: string
+          description: proposal id
+          name: proposalId
+          required: true
+          in: path
+          x-example: "1"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/TallyResult"
+        400:
+          description: Invalid proposal id
+        500:
+          description: Internal Server Error
+  /gov/parameters/deposit:
+    get:
+      summary: Query governance deposit parameters
+      description: Query governance deposit parameters. The max_deposit_period units are in nanoseconds.
+      produces:
+        - application/json
+      tags:
+        - Governance
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              min_deposit:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+              max_deposit_period:
+                type: string
+                example: "86400000000000"
+        400:
+          description: <other_path> is not a valid query request path
+        404:
+          description: Found no deposit parameters
+        500:
+          description: Internal Server Error
+  /gov/parameters/tallying:
+    get:
+      summary: Query governance tally parameters
+      description: Query governance tally parameters
+      produces:
+        - application/json
+      tags:
+        - Governance
+      responses:
+        200:
+          description: OK
+          schema:
+            properties:
+              threshold:
+                type: string
+                example: "0.5000000000"
+              veto:
+                type: string
+                example: "0.3340000000"
+              governance_penalty:
+                type: string
+                example: "0.0100000000"
+        400:
+          description: <other_path> is not a valid query request path
+        404:
+          description: Found no tally parameters
+        500:
+          description: Internal Server Error
+  /gov/parameters/voting:
+    get:
+      summary: Query governance voting parameters
+      description: Query governance voting parameters. The voting_period units are in nanoseconds.
+      produces:
+        - application/json
+      tags:
+        - Governance
+      responses:
+        200:
+          description: OK
+          schema:
+            properties:
+              voting_period:
+                type: string
+                example: "86400000000000"
+        400:
+          description: <other_path> is not a valid query request path
+        404:
+          description: Found no voting parameters
+        500:
+          description: Internal Server Error
+  /distribution/delegators/{delegatorAddr}/rewards:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+    get:
+      summary: Get the total rewards balance from all delegations
+      description: Get the sum of all the rewards earned by delegations by a single delegator
+      produces:
+        - application/json
+      tags:
+        - Distribution
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                $ref: "#/definitions/DelegatorTotalRewards"
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
+    post:
+      summary: Withdraw all the delegator's delegation rewards
+      description: Withdraw all the delegator's delegation rewards
+      tags:
+        - Distribution
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Withdraw request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid delegator address
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /distribution/delegators/{delegatorAddr}/rewards/{validatorAddr}:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Query a delegation reward
+      description: Query a single delegation reward by a delegator
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
+    post:
+      summary: Withdraw a delegation reward
+      description: Withdraw a delegator's delegation reward from a single validator
+      tags:
+        - Distribution
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Withdraw request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid delegator address or delegation body
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /distribution/delegators/{delegatorAddr}/withdraw_address:
+    parameters:
+      - in: path
+        name: delegatorAddr
+        description: Bech32 AccAddress of Delegator
+        required: true
+        type: string
+        x-example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+    get:
+      summary: Get the rewards withdrawal address
+      description: Get the delegations' rewards withdrawal address. This is the address in which the user will receive the reward funds
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                $ref: "#/definitions/Address"
+        400:
+          description: Invalid delegator address
+        500:
+          description: Internal Server Error
+    post:
+      summary: Replace the rewards withdrawal address
+      description: Replace the delegations' rewards withdrawal address for a new one.
+      tags:
+        - Distribution
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Withdraw request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              withdraw_address:
+                $ref: "#/definitions/Address"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid delegator or withdraw address
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /distribution/validators/{validatorAddr}:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Validator distribution information
+      description: Query the distribution information of a single validator
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/ValidatorDistInfo"
+        400:
+          description: Invalid validator address
+        500:
+          description: Internal Server Error
+  /distribution/validators/{validatorAddr}/outstanding_rewards:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Fee distribution outstanding rewards of a single validator
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Internal Server Error
+  /distribution/validators/{validatorAddr}/rewards:
+    parameters:
+      - in: path
+        name: validatorAddr
+        description: Bech32 OperatorAddress of validator
+        required: true
+        type: string
+        x-example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+    get:
+      summary: Commission and self-delegation rewards of a single validator
+      description: Query the commission and self-delegation rewards of validator.
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+        400:
+          description: Invalid validator address
+        500:
+          description: Internal Server Error
+    post:
+      summary: Withdraw the validator's rewards
+      description: Withdraw the validator's self-delegation and commissions rewards
+      tags:
+        - Distribution
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Withdraw request body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/BroadcastTxCommitResult"
+        400:
+          description: Invalid validator address
+        401:
+          description: Key password is wrong
+        500:
+          description: Internal Server Error
+  /distribution/community_pool:
+    get:
+      summary: Community pool parameters
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              height:
+                type: string
+                example: "100"
+              result:
+                type: array
+                items:
+                  $ref: "#/definitions/Coin"
+        500:
+          description: Internal Server Error
+  /distribution/parameters:
+    get:
+      summary: Fee distribution parameters
+      tags:
+        - Distribution
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            properties:
+              base_proposer_reward:
+                type: string
+              bonus_proposer_reward:
+                type: string
+              community_tax:
+                type: string
+        500:
+          description: Internal Server Error
+  /minting/parameters:
+    get:
+      summary: Minting module parameters
+      tags:
+        - Mint
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            properties:
+              mint_denom:
+                type: string
+              inflation_rate_change:
+                type: string
+              inflation_max:
+                type: string
+              inflation_min:
+                type: string
+              goal_bonded:
+                type: string
+              blocks_per_year:
+                type: string
+        500:
+          description: Internal Server Error
+  /minting/inflation:
+    get:
+      summary: Current minting inflation value
+      tags:
+        - Mint
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StandardResponse"
+        500:
+          description: Internal Server Error
+  /minting/annual-provisions:
+    get:
+      summary: Current minting annual provisions value
+      tags:
+        - Mint
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StandardResponse"
+        500:
+          description: Internal Server Error
+  /supply/total:
+    get:
+      summary: Total supply of coins in the chain
+      tags:
+        - Supply
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/Supply"
+        500:
+          description: Internal Server Error
+  /supply/total/{denomination}:
+    parameters:
+      - in: path
+        name: denomination
+        description: Coin denomination
+        required: true
+        type: string
+        x-example: uatom
+    get:
+      summary: Total supply of a single coin denomination
+      tags:
+        - Supply
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StandardResponse"
+        400:
+          description: Invalid coin denomination
+        500:
+          description: Internal Server Error
+  /kavadist/parameters:
+    get:
+      summary: Get the current kavadist parameter values
+      tags:
+        - Kavadist
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              active:
+                type: string
+              periods:
+                type: array
+                items:
+                  $ref: "#/definitions/KavadistPeriod"
+        500:
+          description: Internal Server Error
+
+definitions:
+  CheckTxResult:
+    type: object
+    properties:
+      code:
+        type: integer
+      data:
+        type: string
+      gas_used:
+        type: integer
+      gas_wanted:
+        type: integer
+      info:
+        type: string
+      log:
+        type: string
+      tags:
+        type: array
+        items:
+          $ref: "#/definitions/KVPair"
+    example:
+      code: 0
+      data: data
+      log: log
+      gas_used: 5000
+      gas_wanted: 10000
+      info: info
+      tags:
+        - ""
+        - ""
+  DeliverTxResult:
+    type: object
+    properties:
+      code:
+        type: integer
+      data:
+        type: string
+      gas_used:
+        type: integer
+      gas_wanted:
+        type: integer
+      info:
+        type: string
+      log:
+        type: string
+      tags:
+        type: array
+        items:
+          $ref: "#/definitions/KVPair"
+    example:
+      code: 5
+      data: data
+      log: log
+      gas_used: 5000
+      gas_wanted: 10000
+      info: info
+      tags:
+        - ""
+        - ""
+  BroadcastTxCommitResult:
+    type: object
+    properties:
+      check_tx:
+        $ref: "#/definitions/CheckTxResult"
+      deliver_tx:
+        $ref: "#/definitions/DeliverTxResult"
+      hash:
+        $ref: "#/definitions/Hash"
+      height:
+        type: string
+  KVPair:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+  Msg:
+    type: object
+    properties:
       type:
-        object
-      properties:
-        id:
+        type: string
+        example: "cosmos-sdk/MsgSend"
+      value:
+        type: object
+        properties:
+          from_address:
+            type: string
+            example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+          to_address:
+            type: string
+            example: kava1ls82zzghsx0exkpr52m8vht5jqs3un0ceysshz
+          amount:
+            type: array
+            items:
+              $ref: "#/definitions/Coin"
+  Address:
+    type: string
+    description: bech32 encoded address
+    example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+  Address2:
+    type: string
+    description: bech32 encoded address
+    example: kava1atsrkjac6ulgmwhudfc36lnjfgv340vlvm757z
+  BinanceChainAddress:
+    type: string
+    description: address on another chain (binance)
+    example: bnb1uky3me9ggqypmrsvxk7ur6hqkzq7zmv4ed4ng7
+  BinanceChainAddress2:
+    type: string
+    description: address on another chain (binance)
+    example: bnb10uypsspvl6jlxcx5xse02pag39l8xpe7a3468h
+  RandomNumberHash:
+    type: string
+    description: hex-encoded sha256 hash of a 64bit random number
+    example: c0544b7f4b890a673ea3f61bdb4650fbfe2f3e56bda1b397d6d592fca7163c8c
+  Timestamp:
+    type: string
+    description: unix timestamp
+    example: "1585252531"
+  HeightSpan:
+    type: string
+    description: span of blocks for which an atomic swap is valid
+    example: "3600"
+  DeputyAddress:
+    type: string
+    description: bep3 deputy
+    example: kava1xy7hrjy9r0algz9w3gzm8u6mrpq97kwta747gj
+  ValidatorAddress:
+    type: string
+    description: bech32 encoded address
+    example: kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0
+  Coin:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: ukava
+      amount:
+        type: string
+        example: "50000"
+  CoinBNB:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: bnb
+      amount:
+        type: string
+        example: "555555"
+  CollateralType:
+    type: string
+    example: xrpb-a
+  CoinCollateral:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "xrp"
+      amount:
+        type: string
+        example: "10000000000"
+  CoinPrincipal:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "usdx"
+      amount:
+        type: string
+        example: "10000000"
+  CoinBid:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "usdx"
+      amount:
+        type: string
+        example: "100000000"
+  Hash:
+    type: string
+    example: EE5F3404034C524501629B56E0DDC38FAD651F04
+  Signature:
+    type: object
+    properties:
+      signature:
+        type: string
+        example: "W1HfKcc4F0rCSoxheZ7fsrB5nGK58U4gKysuzsmUwhloVnCxmbCx289uVMMvQN6tOcQsz7hMVTJrXSA1xzevvw=="
+      pubkey:
+        type: object
+        properties:
+          type:
+            type: string
+            example: "tendermint/PubKeySecp256k1"
+          value:
+            type: string
+            example: "Agey31h/NYpcy0sYm4liHMrXJMzbQUrgV4uHd/w09CXN"
+  TxQuery:
+    type: object
+    properties:
+      hash:
+        type: string
+        example: "D085138D913993919295FF4B0A9107F1F2CDE0D37A87CE0644E217CBF3B49656"
+      height:
+        type: string
+        example: "368"
+      tx:
+        $ref: "#/definitions/StdTx"
+      result:
+        type: object
+        properties:
+          log:
+            type: string
+          gas_wanted:
+            type: string
+            example: "200000"
+          gas_used:
+            type: string
+            example: "26354"
+          tags:
+            type: array
+            items:
+              $ref: "#/definitions/KVPair"
+  PaginatedQueryTxs:
+    type: object
+    properties:
+      total_count:
+        type: string
+        example: "1"
+      count:
+        type: string
+        example: "1"
+      page_number:
+        type: string
+        example: "1"
+      page_total:
+        type: string
+        example: "1"
+      limit:
+        type: string
+        example: "30"
+      txs:
+        type: array
+        items:
+          $ref: "#/definitions/TxQuery"
+  StdTx:
+    type: object
+    properties:
+      msg:
+        type: array
+        items:
+          $ref: "#/definitions/Msg"
+      fee:
+        type: object
+        properties:
+          gas:
+            type: string
+            example: "200000"
+          amount:
+            type: array
+            items:
+              $ref: "#/definitions/Coin"
+      memo:
+        type: string
+      signatures:
+        type: array
+        items:
+          $ref: "#/definitions/Signature"
+  BlockID:
+    type: object
+    properties:
+      hash:
+        $ref: "#/definitions/Hash"
+      parts:
+        type: object
+        properties:
+          total:
+            type: string
+            example: "0"
+          hash:
+            $ref: "#/definitions/Hash"
+  BlockHeader:
+    type: object
+    properties:
+      chain_id:
+        type: string
+        example: testing
+      height:
+        type: string
+        example: "1"
+      time:
+        type: string
+        example: "2017-12-30T05:53:09.287+01:00"
+      num_txs:
+        type: string
+        example: "0"
+      last_block_id:
+        $ref: "#/definitions/BlockID"
+      total_txs:
+        type: string
+        example: "35"
+      last_commit_hash:
+        $ref: "#/definitions/Hash"
+      data_hash:
+        $ref: "#/definitions/Hash"
+      validators_hash:
+        $ref: "#/definitions/Hash"
+      next_validators_hash:
+        $ref: "#/definitions/Hash"
+      consensus_hash:
+        $ref: "#/definitions/Hash"
+      app_hash:
+        $ref: "#/definitions/Hash"
+      last_results_hash:
+        $ref: "#/definitions/Hash"
+      evidence_hash:
+        $ref: "#/definitions/Hash"
+      proposer_address:
+        $ref: "#/definitions/Address"
+      version:
+        type: object
+        properties:
+          block:
+            type: string
+            example: 10
+          app:
+            type: string
+            example: 0
+  Block:
+    type: object
+    properties:
+      header:
+        $ref: "#/definitions/BlockHeader"
+      txs:
+        type: array
+        items:
           type: string
-          example: 1
-        description:
-          type: string
-          example: description of committee
-        members:
-          type: array
-          items:
-            $ref: '#/definitions/Address'
-        permissions:
-          type: array
-          items:
-            $ref: '#/definitions/Permission'
-        vote_threshold:
-          type: string
-          example: "0.5"
-        proposal_duration:
-          type: string
-          example: "3600000000000"
-    Permission:
-      type: object
-      properties:
-        type:
-          type: string
-          example: "param_change_permission"
-        allowed_params:
-          type: array
-          items:
-            $ref: '#/definitions/AllowedParam'
-    AllowedParam:
-      type: object
-      properties:
-        subspace:
-          type: string
-          example: cdp
-        key:
-          type: string
-          example: collateral_params
-    Validator:
-      type: object
-      properties:
-        operator_address:
-          $ref: '#/definitions/ValidatorAddress'
-        consensus_pubkey:
-          type: string
-          example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
-        jailed:
-          type: boolean
-        status:
-          type: integer
-        tokens:
-          type: string
-        delegator_shares:
-          type: string
-        description:
-          type: object
-          properties:
-            moniker:
-              type: string
-            identity:
-              type: string
-            website:
-              type: string
-            security_contact:
-              type: string
-            details:
-              type: string
-        bond_height:
-          type: string
-          example: '0'
-        bond_intra_tx_counter:
-          type: integer
-          example: 0
-        unbonding_height:
-          type: string
-          example: '0'
-        unbonding_time:
-          type: string
-          example: '1970-01-01T00:00:00Z'
-        commission:
-          type: object
-          properties:
-            rate:
-              type: string
-              example: '0'
-            max_rate:
-              type: string
-              example: '0'
-            max_change_rate:
-              type: string
-              example: '0'
-            update_time:
-              type: string
-              example: '1970-01-01T00:00:00Z'
-    Delegation:
-      type: object
-      properties:
-        delegator_address:
-          type: string
-        validator_address:
-          type: string
-        shares:
-          type: string
-        balance:
-          $ref: '#/definitions/Coin'
-    UnbondingDelegationPair:
-      type: object
-      properties:
-        delegator_address:
-          type: string
-        validator_address:
-          type: string
-        entries:
-          type: array
-          items:
-            $ref: '#/definitions/UnbondingEntries'
-    UnbondingEntries:
-      type: object
-      properties:
-        initial_balance:
-          type: string
-        balance:
-          type: string
-        creation_height:
-          type: string
-        min_time:
-          type: string
-    UnbondingDelegation:
-      type: object
-      properties:
-        delegator_address:
-          type: string
-        validator_address:
-          type: string
-        initial_balance:
-          type: string
-        balance:
-          type: string
-        creation_height:
-          type: integer
-        min_time:
-          type: integer
-    Redelegation:
-      type: object
-      properties:
-        delegator_address:
-          type: string
-        validator_src_address:
-          type: string
-        validator_dst_address:
-          type: string
-        entries:
-          type: array
-          items:
-            $ref: '#/definitions/Redelegation'
-    RedelegationEntry:
-      type: object
-      properties:
-        creation_height:
-          type: integer
-        completion_time:
-          type: integer
-        initial_balance:
-          type: string
-        balance:
-          type: string
-        shares_dst:
-          type: string
-    ValidatorDistInfo:
-      type: object
-      properties:
-        operator_address:
-          $ref: '#/definitions/ValidatorAddress'
-        self_bond_rewards:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-        val_commission:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-    PublicKey:
-      type: object
-      properties:
-        type:
-          type: string
-        value:
-          type: string
-    SigningInfo:
-      type: object
-      properties:
-        start_height:
-          type: string
-        index_offset:
-          type: string
-        jailed_until:
-          type: string
-        missed_blocks_counter:
-          type: string
-    ParamChange:
-      type: object
-      properties:
-        subspace:
-          type: string
-          example: 'staking'
-        key:
-          type: string
-          example: 'MaxValidators'
-        subkey:
-          type: string
-          example: ''
-        value:
-          type: object
-    Supply:
-      type: object
-      properties:
-        total:
-          type: array
-          items:
-            $ref: '#/definitions/Coin'
-    StandardResponse:
-      type: object
-      properties:
-        height:
-          type: string
-        result:
-          type: string
-    KavadistPeriod:
-      type: object
-      properties:
-        start:
-          type: string
-          example: "2020-06-01:14:00:00Z"
-        end:
-          type: string
-          example: "2020-06-01:14:00:00Z"
-        inflation:
-          type: string
-          example: "1.000000001167363430"
-    PostStdTx:
-      type: object
-      properties:
-        msg:
-          type: array
-          items:
-            $ref: "#/definitions/PostMsg"
-        fee:
-          type: object
-          properties:
-            gas:
-              type: string
-              example: "200000"
-            amount:
-              type: array
-              items:
-                $ref: "#/definitions/PostCoin2"
-        memo:
-          type: string
-          example: ""
-        signatures:
-          type: array
-          items:
-            $ref: "#/definitions/PostSignature"
+      evidence:
+        type: object
+        # type: array
+        # items:
+        #   type: string
+      last_commit:
+        type: object
+        properties:
+          block_id:
+            $ref: "#/definitions/BlockID"
+          precommits:
+            type: array
+            x-nullable: true
+            items:
+              type: object
+              properties:
+                validator_address:
+                  type: string
+                validator_index:
+                  type: string
+                  example: "0"
+                height:
+                  type: string
+                  example: "0"
+                round:
+                  type: string
+                  example: "0"
+                timestamp:
+                  type: string
+                  example: "2017-12-30T05:53:09.287+01:00"
+                type:
+                  type: number
+                  example: 2
+                block_id:
+                  $ref: "#/definitions/BlockID"
+                signature:
+                  type: string
+                  example: "7uTC74QlknqYWEwg7Vn6M8Om7FuZ0EO4bjvuj6rwH1mTUJrRuMMZvAAqT9VjNgP0RA/TDp6u/92AqrZfXJSpBQ=="
+  BlockQuery:
+    type: object
+    properties:
+      block_meta:
+        type: object
+        properties:
+          header:
+            $ref: "#/definitions/BlockHeader"
+          block_id:
+            $ref: "#/definitions/BlockID"
+      block:
+        $ref: "#/definitions/Block"
+  DelegationDelegatorReward:
+    type: object
+    properties:
+      validator_address:
+        $ref: "#/definitions/ValidatorAddress"
+      reward:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+  DelegatorTotalRewards:
+    type: object
+    properties:
+      rewards:
+        type: array
+        items:
+          $ref: "#/definitions/DelegationDelegatorReward"
+      total:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+  BaseReq:
+    type: object
+    properties:
+      from:
+        type: string
+        example: "kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c"
+        description: Sender address or Keybase name to generate a transaction
+      memo:
+        type: string
+        example: "a memo"
+      chain_id:
+        type: string
+        example: "testing"
+      account_number:
+        type: string
+        example: "1"
+      sequence:
+        type: string
+        example: "0"
+      gas:
+        type: string
+        example: "200000"
+      gas_adjustment:
+        type: string
+        example: "1.0"
+      fees:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      simulate:
+        type: boolean
+        example: false
+        description: Estimate gas for a transaction (cannot be used in conjunction with generate_only)
+  TendermintValidator:
+    type: object
+    properties:
+      address:
+        $ref: "#/definitions/ValidatorAddress"
+      pub_key:
+        type: string
+        example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
+      voting_power:
+        type: string
+        example: "1000"
+      proposer_priority:
+        type: string
+        example: "1000"
+  AtomicSwapResponse:
+    type: object
+    properties:
+      id:
+        type: string
+        example: FFEA80A3D9A42427CC12DB957866C6D428C16AA5EA6D9A4A756EF04BF9F2FF06
+      status:
+        type: string
+        example: Completed
+      amount:
+        $ref: "#/definitions/CoinBNB"
+      random_number_hash:
+        type: string
+        example: 0b1e35e991bf052be230ae8dd3ff90b69a610160d28a9eb3c0701395f9d2b291
+      expire_hieght:
+        type: string
+        example: 532463
+      timestamp:
+        type: string
+        example: 1589020884
+      sender:
+        $ref: "#/definitions/Address"
+      recipient:
+        $ref: "#/definitions/Address2"
+      sender_other_chain:
+        $ref: "#/definitions/BinanceChainAddress"
+      recipient_other_chain:
+        $ref: "#/definitions/BinanceChainAddress2"
+      closed_block:
+        type: string
+        example: 532105
+      cross_chain:
+        $ref: "#/definitions/CrossChain"
+      direction:
+        type: string
+        example: Incoming
+  AssetSupplyResponse:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: bnb
+      incoming_supply:
+        $ref: "#/definitions/CoinBNB"
+      outgoing_supply:
+        $ref: "#/definitions/CoinBNB"
+      current_supply:
+        $ref: "#/definitions/CoinBNB"
+      limit:
+        $ref: "#/definitions/CoinBNB"
+  Bep3ParamsResponse:
+    type: object
+    properties:
+      bnb_deputy_address:
+        type: string
+        example: kava1aphsdnz5hu2t5ty2au6znprug5kx3zpy6zwq29
+      min_block_lock:
+        type: string
+        example: 80
+      max_block_lock:
+        type: string
+        example: 3600
+      supported_assets:
+        type: array
+        items:
+          $ref: "#/definitions/Bep3Asset"
+  Bep3Asset:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: bnb
+      coin_id:
+        type: string
+        example: 714
+      limit:
+        type: string
+        example: "100"
+      active:
+        type: boolean
+        example: true
+  ClaimResponse:
+    type: object
+    properties:
+      owner:
+        type: string
+        example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+      reward:
+        $ref: "#/definitions/Coin"
+      denom:
+        type: string
+        example: bnb
+      claim_period_id:
+        type: string
+        example: 1
+  IncentiveParams:
+    type: object
+    properties:
+      active:
+        type: boolean
+        example: true
+      rewards:
+        type: array
+        items:
+          $ref: "#/definitions/Reward"
+  Reward:
+    type: object
+    properties:
+      active:
+        type: boolean
+        example: true
+      denom:
+        type: string
+        example: bnb
+      available_rewards:
+        $ref: "#/definitions/Coin"
+      duration:
+        type: string
+        example: 36800000000000
+      time_lock:
+        type: string
+        example: 36800000000000
+      claim_duration:
+        type: string
+        example: 36800000000000
+  PubProposal:
+    type: object
+    properties:
+      title:
+        type: string
+        example: "the title of the proposal"
+      description:
+        type: string
+        example: "the description of the proposal"
+  CdpResponse:
+    type: object
+    properties:
+      id:
+        type: string
+        example: 1
+      owner:
+        type: string
+        example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+      collateral:
+        $ref: "#/definitions/CoinCollateral"
+      type:
+        type: string
+        example: "xrpb-a"
+      principal:
+        $ref: "#/definitions/CoinPrincipal"
+      accumulated_fees:
+        $ref: "#/definitions/CoinPrincipal"
+      fees_updated:
+        type: string
+        example: "2020-02-05T23:45:55.761435272Z"
+      collateral_value:
+        $ref: "#/definitions/CoinPrincipal"
+      collateralization_ratio:
+        type: string
+        example: "2.721734157907653857"
+  CdpDepositResponse:
+    type: object
+    properties:
+      cdp_id:
+        type: string
+        example: 1
+      depositor:
+        type: string
+        example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+      amount:
+        $ref: "#/definitions/CoinCollateral"
+  PricefeedParameters:
+    type: object
+    properties:
+      markets:
+        type: array
+        items:
+          $ref: "#/definitions/Market"
+  Price:
+    type: object
+    properties:
+      market_id:
+        type: string
+        example: "xrp:usd"
+      price:
+        type: string
+        example: "0.298758999999999997"
+  PostedPrice:
+    type: object
+    properties:
+      market_id:
+        type: string
+        example: "xrp:usd"
+      oracle_address:
+        type: string
+        example: kava10cw2m04528dwlc44k0myd7strj3eq5jr6s8pxs
+      price:
+        type: string
+        example: "0.298758999999999997"
+      expiry:
+        type: string
+        example: "2021-02-12T23:10:00Z"
+  Market:
+    type: object
+    properties:
+      market_id:
+        type: string
+        example: "xrp:usd"
+      base_asset:
+        type: string
+        example: "xrp"
+      quote_asset:
+        type: string
+        example: "usd"
+      oracles:
+        type: array
+        x-nullable: true
+        items:
+          $ref: "#/definitions/Address"
+      active:
+        type: boolean
+        example: true
+  HardParams:
+    type: object
+    properties:
+      money_markets:
+        type: array
+        items:
+          $ref: "#/definitions/MoneyMarket"
+      minimum_borrow_usd_value:
+        type: string
+        example: "10"
+  MoneyMarket:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "bnb"
+      borrow_limit:
+        $ref: "#/definitions/BorrowLimit"
+      spot_market_id:
+        type: string
+        example: "bnb:usd"
+      conversion_factor:
+        type: string
+        example: "100000000"
+      interest_rate_model:
+        $ref: "#/definitions/InterestRateModel"
+      reserve_factor:
+        type: string
+        example: "0.05"
+      keeper_reward_percentage:
+        type: string
+        example: "0.05"
+  BorrowLimit:
+    type: object
+    properties:
+      has_max_limit:
+        type: boolean
+        example: true
+      maximum_limit:
+        type: string
+        example: "100000000000000"
+      loan_to_value:
+        type: string
+        example: "0.8"
+  InterestRateModel:
+    type: object
+    properties:
+      base_rate_apy:
+        type: string
+        example: "0"
+      base_multiplier:
+        type: string
+        example: "0.1"
+      kink:
+        type: string
+        example: "0.8"
+      jump_multiplier:
+        type: string
+        example: "0.5"
+  HardDepositResponse:
+    type: object
+    properties:
+      depositor:
+        $ref: "#/definitions/Address"
+      amount:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      index:
+        type: array
+        items:
+          $ref: "#/definitions/SupplyInterestFactor"
+  HardBorrowResponse:
+    type: object
+    properties:
+      borrower:
+        $ref: "#/definitions/Address"
+      amount:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      index:
+        type: array
+        items:
+          $ref: "#/definitions/BorrowInterestFactor"
+  SupplyInterestFactor:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "bnb"
+      value:
+        type: string
+        example: "0.1258"
+  BorrowInterestFactor:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "bnb"
+      value:
+        type: string
+        example: "0.1258"
+  MoneyMarketInterestRate:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: "bnb"
+      supply_interest_rate:
+        type: string
+        example: "5.25"
+      borrow_interest_rate:
+        type: string
+        example: "5.25"
+  MultiplierName:
+    type: string
+    example: "small"
+  IssuanceParams:
+    type: object
+    properties:
+      assets:
+        type: array
+        items:
+          $ref: "#/definitions/IssuanceAsset"
+  IssuanceAsset:
+    type: object
+    properties:
+      owner:
+        $ref: "#/definitions/Address"
+      denom:
+        type: string
+        example: "btc"
+      blocked_addresses:
+        type: array
+        items:
+          $ref: "#/definitions/Address"
+      paused:
+        type: boolean
+        example: false
+      blockable:
+        type: boolean
+        example: true
+      rate_limit:
+        $ref: "#/definitions/RateLimit"
+  RateLimit:
+    type: object
+    properties:
+      active:
+        type: boolean
+        example: true
+      limit:
+        type: string
+        example: 500000000
+      time_period:
+        type: string
+        example: 518400000000000
+  AuctionParameters:
+    type: object
+    properties:
+      max_auction_duration:
+        type: string
+        example: 172800000000000
+      bid_duration:
+        type: string
+        example: 600000000000
+      increment_surplus:
+        type: string
+        example: "0.05"
+      increment_debt:
+        type: string
+        example: "0.05"
+      increment_collateral:
+        type: string
+        example: "0.05"
+  AuctionResponse:
+    type: object
+    properties:
+      id:
+        type: string
+        example: 1
+      initiator:
+        type: string
+        example: liquidator
+      lot:
+        $ref: "#/definitions/CoinCollateral"
+      bidder:
+        $ref: "#/definitions/Address"
+      bid:
+        $ref: "#/definitions/Coin"
+      has_received_bids:
+        type: boolean
+        example: false
+      end_time:
+        type: string
+        example: "2020-02-05T23:45:55.761435272Z"
+      max_end_time:
+        type: string
+        example: "2020-02-05T23:45:55.761435272Z"
+      type:
+        type: string
+        example: collateral
+      phase:
+        type: string
+        example: forward
+  CollateralParam:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: xrp
+      liquidation_ratio:
+        type: string
+        example: "2.000000000000000000"
+      debt_limit:
+        $ref: "#/definitions/CoinPrincipal"
+      stability_fee:
+        type: string
+        example: "1.000000001547126000"
+      auction_size:
+        type: string
+        example: "5000000000"
+      liquidation_penalty:
+        type: string
+        example: "0.050000000000000000"
+      prefix:
+        type: integer
+        example: 0
+      market_id:
+        type: string
+        example: "xrp:usd"
+      conversion_factor:
+        type: string
+        example: "6"
+  DebtParam:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: usdx
+      reference_asset:
+        type: string
+        example: "usd"
+      conversion_factor:
+        type: string
+        example: "6"
+      debt_floor:
+        type: string
+        example: "10000000"
+  TextProposal:
+    type: object
+    properties:
+      proposal_id:
+        type: integer
+      title:
+        type: string
+      description:
+        type: string
+      proposal_type:
+        type: string
+      proposal_status:
+        type: string
+      final_tally_result:
+        $ref: "#/definitions/TallyResult"
+      submit_time:
+        type: string
+      total_deposit:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      voting_start_time:
+        type: string
+  Proposer:
+    type: object
+    properties:
+      proposal_id:
+        type: string
+        example: 1
+      proposer:
+        type: string
+        example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+  Deposit:
+    type: object
+    properties:
+      amount:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      proposal_id:
+        type: string
+      depositor:
+        $ref: "#/definitions/Address"
+  TallyResult:
+    type: object
+    properties:
+      yes:
+        type: string
+        example: "0.0000000000"
+      abstain:
+        type: string
+        example: "0.0000000000"
+      no:
+        type: string
+        example: "0.0000000000"
+      no_with_veto:
+        type: string
+        example: "0.0000000000"
+  Vote:
+    type: object
+    properties:
+      voter:
+        type: string
+      proposal_id:
+        type: string
+      option:
+        type: string
+  CommitteeVote:
+    type: object
+    properties:
+      voter:
+        type: string
+      proposal_id:
+        type: string
+  CommitteeProposal:
+    type: object
+    properties:
+      pub_proposal:
+        $ref: "#/definitions/PubProposal"
+      id:
+        type: string
+        example: 1
+      committee_id:
+        type: string
+        example: 1
+      deadline:
+        type: string
+        example: "2020-05-10T16:18:43.752522893Z"
+  Committee:
+    type: object
+    properties:
+      id:
+        type: string
+        example: 1
+      description:
+        type: string
+        example: description of committee
+      members:
+        type: array
+        items:
+          $ref: "#/definitions/Address"
+      permissions:
+        type: array
+        items:
+          $ref: "#/definitions/Permission"
+      vote_threshold:
+        type: string
+        example: "0.5"
+      proposal_duration:
+        type: string
+        example: "3600000000000"
+  Permission:
+    type: object
+    properties:
+      type:
+        type: string
+        example: "param_change_permission"
+      allowed_params:
+        type: array
+        items:
+          $ref: "#/definitions/AllowedParam"
+  AllowedParam:
+    type: object
+    properties:
+      subspace:
+        type: string
+        example: cdp
+      key:
+        type: string
+        example: collateral_params
+  Validator:
+    type: object
+    properties:
+      operator_address:
+        $ref: "#/definitions/ValidatorAddress"
+      consensus_pubkey:
+        type: string
+        example: kavavalconspub1zcjduepq0vu2zgkgk49efa0nqwzndanq5m4c7pa3u4apz4g2r9gspqg6g9cs3k9cuf
+      jailed:
+        type: boolean
+      status:
+        type: integer
+      tokens:
+        type: string
+      delegator_shares:
+        type: string
+      description:
+        type: object
+        properties:
+          moniker:
+            type: string
+          identity:
+            type: string
+          website:
+            type: string
+          security_contact:
+            type: string
+          details:
+            type: string
+      bond_height:
+        type: string
+        example: "0"
+      bond_intra_tx_counter:
+        type: integer
+        example: 0
+      unbonding_height:
+        type: string
+        example: "0"
+      unbonding_time:
+        type: string
+        example: "1970-01-01T00:00:00Z"
+      commission:
+        type: object
+        properties:
+          rate:
+            type: string
+            example: "0"
+          max_rate:
+            type: string
+            example: "0"
+          max_change_rate:
+            type: string
+            example: "0"
+          update_time:
+            type: string
+            example: "1970-01-01T00:00:00Z"
+  Delegation:
+    type: object
+    properties:
+      delegator_address:
+        type: string
+      validator_address:
+        type: string
+      shares:
+        type: string
+      balance:
+        $ref: "#/definitions/Coin"
+  UnbondingDelegationPair:
+    type: object
+    properties:
+      delegator_address:
+        type: string
+      validator_address:
+        type: string
+      entries:
+        type: array
+        items:
+          $ref: "#/definitions/UnbondingEntries"
+  UnbondingEntries:
+    type: object
+    properties:
+      initial_balance:
+        type: string
+      balance:
+        type: string
+      creation_height:
+        type: string
+      min_time:
+        type: string
+  UnbondingDelegation:
+    type: object
+    properties:
+      delegator_address:
+        type: string
+      validator_address:
+        type: string
+      initial_balance:
+        type: string
+      balance:
+        type: string
+      creation_height:
+        type: integer
+      min_time:
+        type: integer
+  Redelegation:
+    type: object
+    properties:
+      delegator_address:
+        type: string
+      validator_src_address:
+        type: string
+      validator_dst_address:
+        type: string
+      entries:
+        type: array
+        items:
+          $ref: "#/definitions/Redelegation"
+  RedelegationEntry:
+    type: object
+    properties:
+      creation_height:
+        type: integer
+      completion_time:
+        type: integer
+      initial_balance:
+        type: string
+      balance:
+        type: string
+      shares_dst:
+        type: string
+  ValidatorDistInfo:
+    type: object
+    properties:
+      operator_address:
+        $ref: "#/definitions/ValidatorAddress"
+      self_bond_rewards:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+      val_commission:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+  PublicKey:
+    type: object
+    properties:
+      type:
+        type: string
+      value:
+        type: string
+  SigningInfo:
+    type: object
+    properties:
+      start_height:
+        type: string
+      index_offset:
+        type: string
+      jailed_until:
+        type: string
+      missed_blocks_counter:
+        type: string
+  ParamChange:
+    type: object
+    properties:
+      subspace:
+        type: string
+        example: "staking"
+      key:
+        type: string
+        example: "MaxValidators"
+      subkey:
+        type: string
+        example: ""
+      value:
+        type: object
+  Supply:
+    type: object
+    properties:
+      total:
+        type: array
+        items:
+          $ref: "#/definitions/Coin"
+  StandardResponse:
+    type: object
+    properties:
+      height:
+        type: string
+      result:
+        type: string
+  KavadistPeriod:
+    type: object
+    properties:
+      start:
+        type: string
+        example: "2020-06-01:14:00:00Z"
+      end:
+        type: string
+        example: "2020-06-01:14:00:00Z"
+      inflation:
+        type: string
+        example: "1.000000001167363430"
+  PostStdTx:
+    type: object
+    properties:
+      msg:
+        type: array
+        items:
+          $ref: "#/definitions/PostMsg"
+      fee:
+        type: object
+        properties:
+          gas:
+            type: string
+            example: "200000"
+          amount:
+            type: array
+            items:
+              $ref: "#/definitions/PostCoin2"
+      memo:
+        type: string
+        example: ""
+      signatures:
+        type: array
+        items:
+          $ref: "#/definitions/PostSignature"
 
-    PostMsg:
-      type: object
-      properties:
-        type:
-          type: string
-          example: "cosmos-sdk/MsgSend"
-        value:
-          type: object
-          properties:
-            from_address:
-              type: string
-              example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-            to_address:
-              type: string
-              example: kava1ls82zzghsx0exkpr52m8vht5jqs3un0ceysshz
-            amount:
-              type: array
-              items:
-                $ref: "#/definitions/PostCoin1"
-    PostCoin1:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: stake
-        amount:
-          type: string
-          example: "2000000"
-    PostCoin2:
-      type: object
-      properties:
-        denom:
-          type: string
-          example: stake
-        amount:
-          type: string
-          example: "2000"
-    PostSignature:
-      type: object
-      properties:
-        signature:
-          type: string
-          example: "KzBeQp/2+47oiqc16BImnOYidSAesZ3kgR3S8Fy+baFlvDlDv7goU/+rm4c7+woudNte3uZAG0CuUeHsF+Ld8Q=="
-        pubkey:
-          type: object
-          properties:
-            type:
-              type: string
-              example: "tendermint/PubKeySecp256k1"
-            value:
-              type: string
-              example: "AmWAim83Qp+kIcj3RT7i327b3l0EHwzCrGVGXusb70B7"
-    EncodeTx:
-      type: object
-      properties:
-        type:
-          type: string
-          example: "cosmos-sdk/StdTx"
-        value:
-          type: object
-          $ref: "#/definitions/StdTx"
+  PostMsg:
+    type: object
+    properties:
+      type:
+        type: string
+        example: "cosmos-sdk/MsgSend"
+      value:
+        type: object
+        properties:
+          from_address:
+            type: string
+            example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+          to_address:
+            type: string
+            example: kava1ls82zzghsx0exkpr52m8vht5jqs3un0ceysshz
+          amount:
+            type: array
+            items:
+              $ref: "#/definitions/PostCoin1"
+  PostCoin1:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: stake
+      amount:
+        type: string
+        example: "2000000"
+  PostCoin2:
+    type: object
+    properties:
+      denom:
+        type: string
+        example: stake
+      amount:
+        type: string
+        example: "2000"
+  PostSignature:
+    type: object
+    properties:
+      signature:
+        type: string
+        example: "KzBeQp/2+47oiqc16BImnOYidSAesZ3kgR3S8Fy+baFlvDlDv7goU/+rm4c7+woudNte3uZAG0CuUeHsF+Ld8Q=="
+      pubkey:
+        type: object
+        properties:
+          type:
+            type: string
+            example: "tendermint/PubKeySecp256k1"
+          value:
+            type: string
+            example: "AmWAim83Qp+kIcj3RT7i327b3l0EHwzCrGVGXusb70B7"
+  EncodeTx:
+    type: object
+    properties:
+      type:
+        type: string
+        example: "cosmos-sdk/StdTx"
+      value:
+        type: object
+        $ref: "#/definitions/StdTx"

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -19,8 +19,8 @@
       description: Incentive module APIs
     - name: Pricefeed
       description: Auction module APIs
-    - name: Harvest
-      description: Harvest module APIs
+    - name: Hard
+      description: Hard module APIs
     - name: Committee
       description: Committee module APIs
     - name: Auth
@@ -1720,18 +1720,18 @@
             description: Invalid query parameters
           500:
             description: Internal Server Error
-    /harvest/deposit:
+    /hard/deposit:
       post:
-        summary: Deposit funds to harvest liquidity pool
+        summary: Deposit funds to hard liquidity pool
         tags:
-          - Harvest
+          - Hard
         consumes:
           - application/json
         produces:
           - application/json
         parameters:
           - in: body
-            name: harvest deposit body
+            name: hard deposit body
             schema:
               properties:
                 base_req:
@@ -1739,10 +1739,7 @@
                 depositor:
                   $ref: '#/definitions/Address'
                 amount:
-                  $ref: '#/definitions/Coin'
-                deposit_type:
-                  type: string
-                  example: lp
+                  $ref: '#/definitions/Coins'
         responses:
           200:
             description: OK
@@ -1752,18 +1749,18 @@
             description: Invalid request
           500:
             description: Internal server error
-    /harvest/withdraw:
+    /hard/withdraw:
       post:
-        summary: Withdraw funds from harvest liquidity pool
+        summary: Withdraw funds from hard liquidity pool
         tags:
-          - Harvest
+          - Hard
         consumes:
           - application/json
         produces:
           - application/json
         parameters:
           - in: body
-            name: harvest withdraw body
+            name: hard withdraw body
             schema:
               properties:
                 base_req:
@@ -1771,10 +1768,7 @@
                 depositor:
                   $ref: '#/definitions/Address'
                 amount:
-                  $ref: '#/definitions/Coin'
-                deposit_type:
-                  type: string
-                  example: lp
+                  $ref: '#/definitions/Coins'
         responses:
           200:
             description: OK
@@ -1784,35 +1778,28 @@
             description: Invalid request
           500:
             description: Internal server error
-    /harvest/claim:
+
+            TODO: add claim to incentive
+    /hard/borrow:
       post:
-        summary: Claim rewards from harvest liquidity pool
+        summary: Borrow funds from hard liquidity pool
         tags:
-          - Harvest
+          - Hard
         consumes:
           - application/json
         produces:
           - application/json
         parameters:
           - in: body
-            name: harvest claim body
+            name: hard borrow body
             schema:
               properties:
                 base_req:
                   $ref: '#/definitions/BaseReq'
-                sender:
+                depositor:
                   $ref: '#/definitions/Address'
-                receiver:
-                  $ref: '#/definitions/Address'
-                deposit_denom:
-                  type: string
-                  example: bnb
-                multiplier_name:
-                  type: string
-                  example: small
-                deposit_type:
-                  type: string
-                  example: lp
+                amount:
+                  $ref: '#/definitions/Coins'
         responses:
           200:
             description: OK
@@ -1822,16 +1809,72 @@
             description: Invalid request
           500:
             description: Internal server error
-    /harvest/parameters:
+  /hard/repay:
+      post:
+        summary: Repay funds borrowed from hard liquidity pool
+        tags:
+          - Hard
+        consumes:
+          - application/json
+        produces:
+          - application/json
+        parameters:
+          - in: body
+            name: hard repay body
+            schema:
+              properties:
+                base_req:
+                  $ref: '#/definitions/BaseReq'
+                owner:
+                  $ref: '#/definitions/Address'
+                amount:
+                  $ref: '#/definitions/Coins'
+        responses:
+          200:
+            description: OK
+            schema:
+              $ref: '#/definitions/StdTx'
+          400:
+            description: Invalid request
+          500:
+            description: Internal server error
+  /hard/liquidate:
+      post:
+        summary: Attempt to liquidate a borrower that is over their loan-to-value
+        tags:
+          - Hard
+        consumes:
+          - application/json
+        produces:
+          - application/json
+        parameters:
+          - in: body
+            name: hard liquidate body
+            schema:
+              properties:
+                base_req:
+                  $ref: '#/definitions/BaseReq'
+                borrower:
+                  $ref: '#/definitions/Address'
+        responses:
+          200:
+            description: OK
+            schema:
+              $ref: '#/definitions/StdTx'
+          400:
+            description: Invalid request
+          500:
+            description: Internal server error
+    /hard/parameters:
       get:
-        summary: Get the current parameters of the harvest module
+        summary: Get the current parameters of the hard module
         tags:
-          - Harvest
+          - Hard
         produces:
           - application/json
         responses:
           200:
-            description: Harvest module parameters
+            description: Hard module parameters
             schema:
               type: object
               properties:
@@ -1842,19 +1885,139 @@
                   type: array
                   x-nullable: true
                   items:
-                    $ref: '#/definitions/HarvestParams'
+                    $ref: '#/definitions/HardParams'
           500:
             description: Server internal error
-    /harvest/accounts:
+    /hard/total-deposited:
       get:
-        summary: Get the harvest module accounts
+        summary: Get total coins deposited to hard liquidity pools
         tags:
-          - Harvest
+          - Hard
+        produces:
+          - application/json
+        parameters:
+          - in: query
+            name: denom
+            description: Coin denom
+            required: false
+            type: string
+            x-example: btc
+        responses:
+          200:
+            description: total coins deposited
+            schema:
+              type: object
+              properties:
+                height:
+                  type: string
+                  example: "100"
+                result:
+                  type: array
+                  x-nullable: true
+                  items:
+                    $ref: '#/definitions/Coin'
+          500:
+            description: Server internal error
+    /hard/total-borrowed:
+      get:
+        summary: Get total coins borrowed from hard liquidity pools
+        tags:
+          - Hard
+        produces:
+          - application/json
+        parameters:
+          - in: query
+            name: denom
+            description: Coin denom
+            required: false
+            type: string
+            x-example: btc
+        responses:
+          200:
+            description: total coins borrowed
+            schema:
+              type: object
+              properties:
+                height:
+                  type: string
+                  example: "100"
+                result:
+                  type: array
+                  x-nullable: true
+                  items:
+                    $ref: '#/definitions/Coin'
+          500:
+            description: Server internal error
+    /hard/reserves:
+      get:
+        summary: Get total hard reserve coins
+        tags:
+          - Hard
+        produces:
+          - application/json
+        parameters:
+          - in: query
+            name: denom
+            description: Coin denom
+            required: false
+            type: string
+            x-example: btc
+        responses:
+          200:
+            description: reserve coins
+            schema:
+              type: object
+              properties:
+                height:
+                  type: string
+                  example: "100"
+                result:
+                  type: array
+                  x-nullable: true
+                  items:
+                    $ref: '#/definitions/Coin'
+          500:
+            description: Server internal error
+    /hard/interest-rate:
+      get:
+        summary: Get total hard reserve coins
+        tags:
+          - Hard
+        produces:
+          - application/json
+        parameters:
+          - in: query
+            name: denom
+            description: Money market denom
+            required: false
+            type: string
+            x-example: bnb
+        responses:
+          200:
+            description: money market interest rates
+            schema:
+              type: object
+              properties:
+                height:
+                  type: string
+                  example: "100"
+                result:
+                  type: array
+                  x-nullable: true
+                  items:
+                    $ref: '#/definitions/MoneyMarketInterestRate'
+          500:
+            description: Server internal error
+    /hard/accounts:
+      get:
+        summary: Get the hard module accounts
+        tags:
+          - Hard
         produces:
           - application/json
         responses:
           200:
-            description: The harvest module accounts
+            description: The hard module accounts
             schema:
               type: object
               properties:
@@ -1886,26 +2049,20 @@
                         type: number
           500:
             description: Server internal error
-    /harvest/deposits:
+    /hard/deposits:
       get:
-        summary: Get harvest deposits
+        summary: Get hard deposits
         tags:
-          - Harvest
+          - Hard
         produces:
           - application/json
         parameters:
           - in: query
-            name: deposit_denom
+            name: denom
             description: Deposit coin denom
             required: false
             type: string
             x-example: btc
-          - in: query
-            name: deposit_type
-            description: Deposit type
-            required: false
-            type: string
-            x-example: lp
           - in: query
             name: owner
             description: Owner address in bech32 format
@@ -1924,7 +2081,7 @@
             x-example: 100
         responses:
           200:
-            description: harvest deposits
+            description: hard deposits
             schema:
               type: object
               properties:
@@ -1935,29 +2092,23 @@
                   type: array
                   x-nullable: true
                   items:
-                    $ref: '#/definitions/HarvestDepositResponse'
+                    $ref: '#/definitions/HardDepositResponse'
           500:
             description: Server internal error
-    /harvest/claims:
+    /hard/borrows:
       get:
-        summary: Get outstanding harvest claims
+        summary: Get hard borrows
         tags:
-          - Harvest
+          - Hard
         produces:
           - application/json
         parameters:
           - in: query
-            name: deposit_denom
-            description: Deposit coin denom
+            name: denom
+            description: Borrow coin denom
             required: false
             type: string
             x-example: btc
-          - in: query
-            name: deposit_type
-            description: Deposit type
-            required: false
-            type: string
-            x-example: lp
           - in: query
             name: owner
             description: Owner address in bech32 format
@@ -1976,7 +2127,7 @@
             x-example: 100
         responses:
           200:
-            description: harvest claims
+            description: hard borrows
             schema:
               type: object
               properties:
@@ -1987,7 +2138,7 @@
                   type: array
                   x-nullable: true
                   items:
-                    $ref: '#/definitions/HarvestClaimResponse'
+                    $ref: '#/definitions/HardBorrowResponse'
           500:
             description: Server internal error
     /issuance/issue:
@@ -4536,87 +4687,121 @@
         active:
           type: boolean
           example: true
-    HarvestParams:
+    HardParams:
       type: object
       properties:
-        active:
+        money_markets:
+          type: array
+          items:
+            $ref: '#/definitions/MoneyMarket'
+        minimum_borrow_usd_value:
+          type: string
+          example: "10"
+    MoneyMarket:
+      type: object
+      properties:
+        denom:
+          type: string
+          example: "bnb"
+        borrow_limit:
+          $ref: '#/definitions/BorrowLimit'
+        spot_market_id:
+          type: string
+          example: 'bnb:usd'
+        conversion_factor:
+          type: string
+          example: "100000000"
+        interest_rate_model:
+          $ref: '#/definitions/InterestRateModel'
+        reserve_factor:
+          type: string
+          example: "0.05"
+        keeper_reward_percentage:
+          type: string
+          example: "0.05"
+    BorrowLimit:
+      type: object
+      properties:
+        has_max_limit:
           type: boolean
           example: true
-        liquidity_provider_schedules:
-          type: array
-          items:
-            $ref: '#/definitions/DistributionSchedule'
-        delegator_distribution_schedules:
-          type: array
-          items:
-            $ref: '#/definitions/DelegatorDistributionSchedule'
-    DistributionSchedule:
+        maximum_limit:
+          type: string
+          example: "100000000000000"
+        loan_to_value:
+          type: string
+          example: "0.8"
+    InterestRateModel:
       type: object
       properties:
-        active:
-          type: boolean
-          example: true
-        deposit_denom:
+        base_rate_apy:
           type: string
-          example: 'xrp'
-        start:
+          example: "0"
+        base_multiplier:
           type: string
-          example: 1601220026
-        end:
+          example: "0.1"
+        kink:
           type: string
-          example: 1601930050
-        rewards_per_second:
-          $ref: '#/definitions/Coin'
-        claim_end:
+          example: "0.8"
+        jump_multiplier:
           type: string
-          example: 1602227044
-        claim_multipliers:
-          type: array
-          items:
-            $ref: '#/definitions/ClaimMultipliers'
-    ClaimMultipliers:
-      type: object
-      properties:
-        name:
-          $ref: '#/definitions/MultiplierName'
-        months_lockup:
-          type: string
-          example: 6
-        factor:
-          type: string
-          example: '0.5'
-    DelegatorDistributionSchedule:
-      type: object
-      properties:
-        distribution_schedule:
-          $ref: '#/definitions/DistributionSchedule'
-        distribution_frequency:
-          type: string
-          example: 2958000000000000
-    HarvestDepositResponse:
+          example: "0.5"
+    HardDepositResponse:
       type: object
       properties:
         depositor:
           $ref: '#/definitions/Address'
         amount:
-          $ref: '#/definitions/Coin'
-        type:
-          $ref: '#/definitions/Address'
-    HarvestClaimResponse:
+          type: array
+          items:
+            $ref: '#/definitions/Coin'
+        index:
+          type: array
+          items:
+            $ref: '#/definitions/SupplyInterestFactor'
+    HardBorrowResponse:
       type: object
       properties:
-        owner:
+        borrower:
           $ref: '#/definitions/Address'
-        deposit_denom:
-          type: string
-          example: 'xrp'
         amount:
-          $ref: '#/definitions/Coin'
-        type:
-          $ref: '#/definitions/DepositType'
-    DepositType:
-      type: string
-      example: "lp"
+          type: array
+          items:
+            $ref: '#/definitions/Coin'
+        index:
+          type: array
+          items:
+            $ref: '#/definitions/BorrowInterestFactor'
+    SupplyInterestFactor:
+      type: object
+      properties:
+        denom:
+          type: string
+          example: "bnb"
+        value:
+          type: string
+          example: "0.1258"
+    BorrowInterestFactor:
+      type: object
+      properties:
+        denom:
+          type: string
+          example: "bnb"
+        value:
+          type: string
+          example: "0.1258"
+    MoneyMarketInterestRate:
+      type: object
+      properties:
+        denom:
+          type: string
+          example: "bnb"
+        supply_interest_rate:
+          type: string
+          example: "5.25"
+        borrow_interest_rate:
+          type: string
+          example: "5.25"
     MultiplierName:
       type: string
       example: "small"

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -613,6 +613,50 @@ paths:
           description: Invalid request
         500:
           description: Server internal error
+  /cdp/{owner}/{collateral-type}/liquidate:
+    post:
+      summary: Attempt to liquidate a CDP that is collateralization ratio is under its liquidaiton ratio
+      tags:
+        - CDP
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: owner
+          description: Owner address in bech32 format
+          required: true
+          type: string
+          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
+        - in: path
+          name: collateral_type
+          description: Collateral type
+          required: true
+          type: string
+          x-example: xrpb-a
+        - description: liquidate cdp post parameters
+          name: post_liquidate_req
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              owner:
+                $ref: "#/definitions/Address"
+              collateral_type:
+                $ref: "#/definitions/CollateralType"
+      responses:
+        200:
+          description: Tx was successfully generated
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Server internal error
   /cdp/accounts:
     get:
       summary: Get the cdp module accounts
@@ -5009,12 +5053,33 @@ definitions:
       phase:
         type: string
         example: forward
+
+type CollateralParam struct {
+	Denom                            string   `json:"denom" yaml:"denom"` // Coin name of collateral type
+	Type                             string   `json:"type" yaml:"type"`
+	LiquidationRatio                 sdk.Dec  `json:"liquidation_ratio" yaml:"liquidation_ratio"`     // The ratio (Collateral (priced in stable coin) / Debt) under which a CDP will be liquidated
+	DebtLimit                        sdk.Coin `json:"debt_limit" yaml:"debt_limit"`                   // Maximum amount of debt allowed to be drawn from this collateral type
+	StabilityFee                     sdk.Dec  `json:"stability_fee" yaml:"stability_fee"`             // per second stability fee for loans opened using this collateral
+	AuctionSize                      sdk.Int  `json:"auction_size" yaml:"auction_size"`               // Max amount of collateral to sell off in any one auction.
+	LiquidationPenalty               sdk.Dec  `json:"liquidation_penalty" yaml:"liquidation_penalty"` // percentage penalty (between [0, 1]) applied to a cdp if it is liquidated
+	Prefix                           byte     `json:"prefix" yaml:"prefix"`
+	SpotMarketID                     string   `json:"spot_market_id" yaml:"spot_market_id"`                                           // marketID of the spot price of the asset from the pricefeed - used for opening CDPs, depositing, withdrawing
+	LiquidationMarketID              string   `json:"liquidation_market_id" yaml:"liquidation_market_id"`                             // marketID of the pricefeed used for liquidation
+	KeeperRewardPercentage           sdk.Dec  `json:"keeper_reward_percentage" yaml:"keeper_reward_percentage"`                       // the percentage of a CDPs collateral that gets rewarded to a keeper that liquidates the position
+	CheckCollateralizationIndexCount sdk.Int  `json:"check_collateralization_index_count" yaml:"check_collateralization_index_count"` // the number of cdps that will be checked for liquidation in the begin blocker
+	ConversionFactor                 sdk.Int  `json:"conversion_factor" yaml:"conversion_factor"`                                     // factor for converting internal units to one base unit of collateral
+}
+
+
   CollateralParam:
     type: object
     properties:
       denom:
         type: string
         example: xrp
+      type:
+        type: string
+        example: xrp-a
       liquidation_ratio:
         type: string
         example: "2.000000000000000000"
@@ -5032,9 +5097,18 @@ definitions:
       prefix:
         type: integer
         example: 0
-      market_id:
+      spot_market_id:
         type: string
         example: "xrp:usd"
+      liquidation_market_id:
+        type: string
+        example: "xrp:usd:30"
+      keeper_reward_percentage:
+        type: string
+        example: "0.05"
+      check_collateralization_index_count:
+        type: string
+        example: "10"
       conversion_factor:
         type: string
         example: "6"

--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -1361,9 +1361,9 @@ paths:
             $ref: "#/definitions/Price"
         500:
           description: Internal Server Error
-  /incentive/claim:
+  /incentive/claim-cdp:
     post:
-      summary: Claim USDX incentive rewards
+      summary: Claim USDX incentive rewards from earned from CDPs
       tags:
         - Incentive
       consumes:
@@ -1372,16 +1372,16 @@ paths:
         - application/json
       parameters:
         - in: body
-          name: Incentive claim body
+          name: Incentive claim CDP body
           schema:
             properties:
               base_req:
                 $ref: "#/definitions/BaseReq"
-              owner:
+              sender:
                 $ref: "#/definitions/Address"
-              type:
+              multiplier_name:
                 type: string
-                example: bnb
+                example: "small"
       responses:
         200:
           description: OK
@@ -1391,28 +1391,46 @@ paths:
           description: Invalid request
         500:
           description: Internal server error
-  /incentive/claims/{owner}/{collateral-type}:
+  /incentive/claim-hard:
+    post:
+      summary: Claim Hard supply/borrow and Kava staking rewards
+      tags:
+        - Incentive
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: Incentive claim Hard body
+          schema:
+            properties:
+              base_req:
+                $ref: "#/definitions/BaseReq"
+              sender:
+                $ref: "#/definitions/Address"
+              multiplier_name:
+                type: string
+                example: "small"
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: "#/definitions/StdTx"
+        400:
+          description: Invalid request
+        500:
+          description: Internal server error
+  /incentive/rewards:
     get:
-      summary: Get outstanding claims for the input owner and collateral type
+      summary: Get earned Incentive rewards
       tags:
         - Incentive
       produces:
         - application/json
-      parameters:
-        - in: path
-          name: owner
-          required: true
-          type: string
-          x-example: kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
-        - in: path
-          name: type
-          description: Collateral type
-          required: true
-          type: string
-          x-example: bnb-a
       responses:
         200:
-          description: USDX Incentive Claims
+          description: Incentive rewards
           schema:
             type: object
             properties:
@@ -1423,7 +1441,7 @@ paths:
                 type: array
                 x-nullable: true
                 items:
-                  $ref: "#/definitions/ClaimResponse"
+                  $ref: "#/definitions/RewardResult"
         500:
           description: Server internal error
   /incentive/parameters:
@@ -4544,20 +4562,78 @@ definitions:
       active:
         type: boolean
         example: true
-  ClaimResponse:
+  RewardResult:
     type: object
     properties:
+      hard_claims:
+        type: array
+          items:
+            $ref: "#/definitions/HardLiquidityProviderClaim"
+      usdx_minting_claims:
+        type: array
+          items:
+            $ref: "#/definitions/USDXMintingClaims"
+  HardLiquidityProviderClaim:
+   type: object
+    properties:
+      base_claim:
+        $ref: "#/definitions/BaseMultiClaim"
+      supply_reward_indexes:
+        type: array
+          items:
+            $ref: "#/definitions/MultiRewardIndex"
+      borrow_reward_indexes:
+        type: array
+          items:
+            $ref: "#/definitions/MultiRewardIndex"
+      delegator_reward_indexes:
+        type: array
+          items:
+            $ref: "#/definitions/RewardIndex"
+  USDXMintingClaims:
+   type: object
+    properties:
+      base_claim:
+        $ref: "#/definitions/BaseClaim"
+      reward_indexes:
+        type: array
+          items:
+            $ref: "#/definitions/RewardIndex"
+ BaseClaim:
+   type: object
+    properties:
       owner:
-        type: string
-        example: kava1q53rwutgpzx7szcrgzqguxyccjpzt9j4cyctn9
+        $ref: "#/definitions/AccAddress"
       reward:
         $ref: "#/definitions/Coin"
-      denom:
+  BaseMultiClaim:
+   type: object
+    properties:
+      owner:
+        $ref: "#/definitions/AccAddress"
+      reward:
+        type: array
+          items:
+            $ref: "#/definitions/Coin"
+  MultiRewardIndex:
+   type: object
+    properties:
+      collateral_type:
         type: string
-        example: bnb
-      claim_period_id:
+        example: 'bnb'
+      reward_indexes:
+        type: array
+          items:
+            $ref: "#/definitions/RewardIndex"
+  RewardIndex:
+   type: object
+    properties:
+      collateral_type:
         type: string
-        example: 1
+        example: 'bnb'
+      reward_factor:
+        type: string
+        example: '1.2581'
   IncentiveParams:
     type: object
     properties:

--- a/x/cdp/client/rest/tx.go
+++ b/x/cdp/client/rest/tx.go
@@ -20,7 +20,7 @@ func registerTxRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc("/cdp/{owner}/{collateralType}/withdraw", postWithdrawHandlerFn(cliCtx)).Methods("POST")
 	r.HandleFunc("/cdp/{owner}/{collateralType}/draw", postDrawHandlerFn(cliCtx)).Methods("POST")
 	r.HandleFunc("/cdp/{owner}/{collateralType}/repay", postRepayHandlerFn(cliCtx)).Methods("POST")
-	r.HandleFunc("/cdp/{owner}/collateralType}/liquidate", postLiquidateHandlerFn(cliCtx)).Methods("POST")
+	r.HandleFunc("/cdp/{owner}/{collateralType}/liquidate", postLiquidateHandlerFn(cliCtx)).Methods("POST")
 }
 
 func postCdpHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {


### PR DESCRIPTION
Updates Swagger to match latest post/get API routes + any data types returned as the result of queries. Most changes were to the Hard, Incentive, and CDP modules. I did some formatting that edited every line, so it'll be impossible to review unless you browse individual commits.

Extras: fixed a bug with the CDP module MsgLiquidate post REST API route 