### PR TITLE
Fix hard/committee begin blocker order

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -432,8 +432,8 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts AppOptio
 	// So it should be run before cdp.BeginBlocker which cancels out debt with stable and starts more auctions.
 	app.mm.SetOrderBeginBlockers(
 		upgrade.ModuleName, mint.ModuleName, distr.ModuleName, slashing.ModuleName,
-		validatorvesting.ModuleName, kavadist.ModuleName, auction.ModuleName, cdp.ModuleName,
-		bep3.ModuleName, committee.ModuleName, hard.ModuleName, issuance.ModuleName, incentive.ModuleName,
+		validatorvesting.ModuleName, kavadist.ModuleName, auction.ModuleName, committee.ModuleName, cdp.ModuleName,
+		bep3.ModuleName, hard.ModuleName, issuance.ModuleName, incentive.ModuleName,
 	)
 
 	app.mm.SetOrderEndBlockers(crisis.ModuleName, gov.ModuleName, staking.ModuleName, pricefeed.ModuleName)

--- a/app/app.go
+++ b/app/app.go
@@ -433,7 +433,7 @@ func NewApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts AppOptio
 	app.mm.SetOrderBeginBlockers(
 		upgrade.ModuleName, mint.ModuleName, distr.ModuleName, slashing.ModuleName,
 		validatorvesting.ModuleName, kavadist.ModuleName, auction.ModuleName, cdp.ModuleName,
-		bep3.ModuleName, hard.ModuleName, committee.ModuleName, issuance.ModuleName, incentive.ModuleName,
+		bep3.ModuleName, committee.ModuleName, hard.ModuleName, issuance.ModuleName, incentive.ModuleName,
 	)
 
 	app.mm.SetOrderEndBlockers(crisis.ModuleName, gov.ModuleName, staking.ModuleName, pricefeed.ModuleName)

--- a/x/hard/keeper/interest.go
+++ b/x/hard/keeper/interest.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 	"github.com/kava-labs/kava/x/hard/types"
 )
 

--- a/x/hard/keeper/interest_test.go
+++ b/x/hard/keeper/interest_test.go
@@ -192,6 +192,21 @@ func (suite *InterestTestSuite) TestCalculateBorrowRate() {
 				expectedValue: sdk.MustNewDecFromStr("0.797457627118644068"),
 			},
 		},
+		{
+			"zero model returns zero",
+			args{
+				cash:     sdk.MustNewDecFromStr("1000"),
+				borrows:  sdk.MustNewDecFromStr("5000"),
+				reserves: sdk.MustNewDecFromStr("100"),
+				model: types.NewInterestRateModel(
+					sdk.MustNewDecFromStr("0.0"),
+					sdk.MustNewDecFromStr("0.0"),
+					sdk.MustNewDecFromStr("0.8"),
+					sdk.MustNewDecFromStr("0.0"),
+				),
+				expectedValue: sdk.MustNewDecFromStr("0.0"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/hard/spec/02_state.md
+++ b/x/hard/spec/02_state.md
@@ -6,11 +6,11 @@ order: 2
 
 ## Parameters and Genesis State
 
-`Parameters` define the governance parameters and default behavior of each money market. **Money markets should not be removed from params without careful procedures** as it will disable withdraws and liquidations. To deprecate a money market, the following steps should be observed:
+`Parameters` define the governance parameters and default behavior of each money market. **Money markets should not be removed from params without careful procedures** as it will disable withdraws and liquidations. Deposits can not be explicitly turned off, but these steps remove the economic incentives to do so. In advance of deprecating a money market, the following steps should be observed:
 
-1. Borrowing: prevent new borrows by setting param MoneyMarket.BorrowLimit.MaximumLimit to 0.
-2. Interest: turn off interest accumulation by setting params MoneyMarket.InterestRateModel.BaseRateAPY and MoneyMarket.InterestRateModel.Kink to 0.
-3. Rewards: turn off supply side and/or borrow side rewards by removing any coins in the relevant RewardsPerSecond param in the Incentive module.
+1. Borrowing: prevent new borrows by setting param `MoneyMarket.BorrowLimit.MaximumLimit` to 0. `HasMaxLimit` must also be set to true to enable limit checks.
+2. Interest: turn off interest accumulation by setting params `MoneyMarket.InterestRateModel.BaseRateAPY`, `MoneyMarket.InterestRateModel.BaseMultiplier`, and `MoneyMarket.InterestRateModel.JumpMultiplier` to 0.
+3. Rewards: turn off supply side and/or borrow side rewards by removing any coins in the relevant `RewardsPerSecond` param in the Incentive module.
 
 Without financial incentives, borrowers and suppliers will withdraw their funds from the money market over time. Once the balances have reached an acceptable level the money market can be deprecated and removed from params, with any additional lingering user funds reimbursed/reallocated as appropriate via a chain upgrade.
 

--- a/x/hard/types/params.go
+++ b/x/hard/types/params.go
@@ -184,19 +184,19 @@ func NewInterestRateModel(baseRateAPY, baseMultiplier, kink, jumpMultiplier sdk.
 // Validate InterestRateModel param
 func (irm InterestRateModel) Validate() error {
 	if irm.BaseRateAPY.IsNegative() || irm.BaseRateAPY.GT(sdk.OneDec()) {
-		return fmt.Errorf("Base rate APY must be between 0.0-1.0")
+		return fmt.Errorf("Base rate APY must be in the inclusive range 0.0-1.0")
 	}
 
 	if irm.BaseMultiplier.IsNegative() {
-		return fmt.Errorf("Base multiplier must be positive")
+		return fmt.Errorf("Base multiplier must not be negative")
 	}
 
 	if irm.Kink.IsNegative() || irm.Kink.GT(sdk.OneDec()) {
-		return fmt.Errorf("Kink must be between 0.0-1.0")
+		return fmt.Errorf("Kink must be in the inclusive range 0.0-1.0")
 	}
 
 	if irm.JumpMultiplier.IsNegative() {
-		return fmt.Errorf("Jump multiplier must be positive")
+		return fmt.Errorf("Jump multiplier must not be negative")
 	}
 
 	return nil


### PR DESCRIPTION
This PR verified and updated the money market deprecation steps.

As part of this the committee / hard begin blocker order was switched to ensure interest was accrued correctly around param changes. For small blocks this is minor, but long blocks, say due to a chain halt, it could be larger.