### PR TITLE
Add KavaScan explorer to docs

### DIFF
--- a/docs/communitytools.md
+++ b/docs/communitytools.md
@@ -15,6 +15,7 @@ The Kava community has developed some amazing tools and services. If you've buil
 - [Mintscan](https://kava.mintscan.io/) by Cosmostation
 - [Big Dipper](https://kava.bigdipper.live/) by Forbole
 - [PING.pub](https://kava.ping.pub/#/parameter)
+- [KAVAScan](https://kavascan.com)
 
 ## For Validators
 - [QuickSync](https://kava.quicksync.io/) chain snapshots


### PR DESCRIPTION
We've been running this explorer for a while and would love to have it listed on Kava's documentation website.

Thanks.