### PR TITLE
Prevent panic-causing param values

### DIFF
--- a/x/cdp/keeper/cdp.go
+++ b/x/cdp/keeper/cdp.go
@@ -615,7 +615,7 @@ type pricefeedType string
 
 const (
 	spot        pricefeedType = "spot"
-	liquidation               = "liquidation"
+	liquidation pricefeedType = "liquidation"
 )
 
 func (pft pricefeedType) IsValid() error {

--- a/x/cdp/types/params.go
+++ b/x/cdp/types/params.go
@@ -362,6 +362,10 @@ func validateCollateralParams(i interface{}) error {
 			return fmt.Errorf("debt limit for all collaterals should be positive, is %s for %s", cp.DebtLimit, cp.Denom)
 		}
 
+		if cp.LiquidationRatio.IsNil() || !cp.LiquidationRatio.IsPositive() {
+			return fmt.Errorf("liquidation ratio must be > 0")
+		}
+
 		if cp.LiquidationPenalty.LT(sdk.ZeroDec()) || cp.LiquidationPenalty.GT(sdk.OneDec()) {
 			return fmt.Errorf("liquidation penalty should be between 0 and 1, is %s for %s", cp.LiquidationPenalty, cp.Denom)
 		}

--- a/x/cdp/types/params_test.go
+++ b/x/cdp/types/params_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -716,6 +715,39 @@ func (suite *ParamsTestSuite) TestParamValidation() {
 			},
 		},
 		{
+			name: "invalid collateral params zero liquidation ratio",
+			args: args{
+				globalDebtLimit: sdk.NewInt64Coin("usdx", 2000000000000),
+				collateralParams: types.CollateralParams{
+					{
+						Denom:                            "bnb",
+						Type:                             "bnb-a",
+						LiquidationRatio:                 sdk.MustNewDecFromStr("0.0"),
+						DebtLimit:                        sdk.NewInt64Coin("usdx", 1_000_000_000_000),
+						StabilityFee:                     sdk.MustNewDecFromStr("1.1"),
+						LiquidationPenalty:               sdk.MustNewDecFromStr("0.05"),
+						AuctionSize:                      sdk.NewInt(50_000_000_000),
+						Prefix:                           0x20,
+						SpotMarketID:                     "bnb:usd",
+						LiquidationMarketID:              "bnb:usd",
+						KeeperRewardPercentage:           sdk.MustNewDecFromStr("0.01"),
+						ConversionFactor:                 sdk.NewInt(8),
+						CheckCollateralizationIndexCount: sdk.NewInt(10),
+					},
+				},
+				debtParam:        types.DefaultDebtParam,
+				surplusThreshold: types.DefaultSurplusThreshold,
+				surplusLot:       types.DefaultSurplusLot,
+				debtThreshold:    types.DefaultDebtThreshold,
+				debtLot:          types.DefaultDebtLot,
+				breaker:          types.DefaultCircuitBreaker,
+			},
+			errArgs: errArgs{
+				expectPass: false,
+				contains:   "liquidation ratio must be > 0",
+			},
+		},
+		{
 			name: "invalid debt param empty denom",
 			args: args{
 				globalDebtLimit: sdk.NewInt64Coin("usdx", 2000000000000),
@@ -847,7 +879,7 @@ func (suite *ParamsTestSuite) TestParamValidation() {
 				suite.Require().NoError(err)
 			} else {
 				suite.Require().Error(err)
-				suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
+				suite.Require().Contains(err.Error(), tc.errArgs.contains)
 			}
 		})
 	}

--- a/x/hard/types/params.go
+++ b/x/hard/types/params.go
@@ -109,6 +109,10 @@ func (mm MoneyMarket) Validate() error {
 		return err
 	}
 
+	if mm.ConversionFactor.IsNil() || mm.ConversionFactor.LT(sdk.OneInt()) {
+		return fmt.Errorf("conversion '%s' factor must be ≥ one", mm.ConversionFactor)
+	}
+
 	if err := mm.InterestRateModel.Validate(); err != nil {
 		return err
 	}

--- a/x/hard/types/params_test.go
+++ b/x/hard/types/params_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"strings"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -34,6 +33,29 @@ func (suite *ParamTestSuite) TestParamValidation() {
 			expectPass:  true,
 			expectedErr: "",
 		},
+		{
+			name: "invalid: conversion factor < one",
+			args: args{
+				minBorrowVal: types.DefaultMinimumBorrowUSDValue,
+				mms: types.MoneyMarkets{
+					{
+						Denom: "btcb",
+						BorrowLimit: types.NewBorrowLimit(
+							false,
+							sdk.MustNewDecFromStr("100000000000"),
+							sdk.MustNewDecFromStr("0.5"),
+						),
+						SpotMarketID:           "btc:usd",
+						ConversionFactor:       sdk.NewInt(0),
+						InterestRateModel:      types.InterestRateModel{},
+						ReserveFactor:          sdk.MustNewDecFromStr("0.05"),
+						KeeperRewardPercentage: sdk.MustNewDecFromStr("0.05"),
+					},
+				},
+			},
+			expectPass:  false,
+			expectedErr: "conversion '0' factor must be ≥ one",
+		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
@@ -43,7 +65,7 @@ func (suite *ParamTestSuite) TestParamValidation() {
 				suite.NoError(err)
 			} else {
 				suite.Error(err)
-				suite.Require().True(strings.Contains(err.Error(), tc.expectedErr))
+				suite.Require().Contains(err.Error(), tc.expectedErr)
 			}
 		})
 	}


### PR DESCRIPTION
In hard and cdp there was a couple of params that would cause panics if their value was zero.
This adds param validation to protect against this happening.

Also if the keeper reward percent in hard is 100%, the `SeizeDeposit` method would panic as it would try and calculate the ltv with zero collateral. We added an early exit if there is no collateral to auction.