### PR TITLE
Don't sync borrow on deposit - it's redundant

### DIFF
--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -23,19 +23,14 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 		}
 	}
 
-	// Call incentive hooks
+	// Call incentive hook
 	existingDeposit, hasExistingDeposit := k.GetDeposit(ctx, depositor)
 	if hasExistingDeposit {
 		k.BeforeDepositModified(ctx, existingDeposit)
 	}
-	existingBorrow, hasExistingBorrow := k.GetBorrow(ctx, depositor)
-	if hasExistingBorrow {
-		k.BeforeBorrowModified(ctx, existingBorrow)
-	}
 
 	// Sync any outstanding interest
 	k.SyncSupplyInterest(ctx, depositor)
-	k.SyncBorrowInterest(ctx, depositor)
 
 	err := k.ValidateDeposit(ctx, coins)
 	if err != nil {


### PR DESCRIPTION
In the deposit function, the borrow used to be fetched in order to calculate the LTV for to insert into the LTV index. Since the LTV index was removed, we no longer need to fetch/sync the borrow object when a user deposits.