### PR TITLE
feat: add filter by denom for hard rewards query

### DIFF
--- a/x/incentive/client/cli/query.go
+++ b/x/incentive/client/cli/query.go
@@ -65,6 +65,7 @@ func queryRewardsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			limit := viper.GetInt(flags.FlagLimit)
 			strOwner := viper.GetString(flagOwner)
 			strType := viper.GetString(flagType)
+			denom := viper.GetString(flagDenom)
 			boolUnsynced := viper.GetBool(flagUnsynced)
 
 			// Prepare params for querier
@@ -83,7 +84,7 @@ func queryRewardsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 						return err
 					}
 				} else {
-					params := types.NewQueryHardRewardsParams(page, limit, owner)
+					params := types.NewQueryHardRewardsParams(page, limit, owner, denom)
 					claims, err = executeHardRewardsQuery(queryRoute, cdc, cliCtx, params)
 					if err != nil {
 						return err
@@ -121,7 +122,7 @@ func queryRewardsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 						return err
 					}
 				} else {
-					paramsHard := types.NewQueryHardRewardsParams(page, limit, owner)
+					paramsHard := types.NewQueryHardRewardsParams(page, limit, owner, denom)
 					hardClaims, err = executeHardRewardsQuery(queryRoute, cdc, cliCtx, paramsHard)
 					if err != nil {
 						return err
@@ -143,6 +144,7 @@ func queryRewardsCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		},
 	}
 	cmd.Flags().String(flagOwner, "", "(optional) filter by owner address")
+	cmd.Flags().String(flagDenom, "", "(optional) filter by denom for hard queries (query must also specify owner flag)")
 	cmd.Flags().String(flagType, "", "(optional) filter by reward type")
 	cmd.Flags().String(flagUnsynced, "", "(optional) get unsynced claims")
 	cmd.Flags().Int(flags.FlagPage, 1, "pagination page rewards of to to query for")

--- a/x/incentive/client/rest/query.go
+++ b/x/incentive/client/rest/query.go
@@ -43,6 +43,11 @@ func queryRewardsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			}
 		}
 
+		var denom string
+		if x := r.URL.Query().Get(types.RestClaimDenom); len(x) != 0 {
+			denom = strings.ToLower(strings.TrimSpace(x))
+		}
+
 		var rewardType string
 		if x := r.URL.Query().Get(types.RestClaimType); len(x) != 0 {
 			rewardType = strings.ToLower(strings.TrimSpace(x))
@@ -74,13 +79,13 @@ func queryRewardsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		} else {
 			switch strings.ToLower(rewardType) {
 			case "hard":
-				params := types.NewQueryHardRewardsParams(page, limit, owner)
+				params := types.NewQueryHardRewardsParams(page, limit, owner, denom)
 				executeHardRewardsQuery(w, cliCtx, params)
 			case "usdx_minting":
 				params := types.NewQueryUSDXMintingRewardsParams(page, limit, owner)
 				executeUSDXMintingRewardsQuery(w, cliCtx, params)
 			default:
-				hardParams := types.NewQueryHardRewardsParams(page, limit, owner)
+				hardParams := types.NewQueryHardRewardsParams(page, limit, owner, denom)
 				usdxMintingParams := types.NewQueryUSDXMintingRewardsParams(page, limit, owner)
 				executeBothRewardQueries(w, cliCtx, hardParams, usdxMintingParams)
 			}

--- a/x/incentive/types/querier.go
+++ b/x/incentive/types/querier.go
@@ -76,6 +76,7 @@ type QueryHardRewardsParams struct {
 	Page  int `json:"page" yaml:"page"`
 	Limit int `json:"limit" yaml:"limit"`
 	Owner sdk.AccAddress
+	Denom string
 }
 
 // NewQueryHardRewardsParams returns QueryHardRewardsParams

--- a/x/incentive/types/querier.go
+++ b/x/incentive/types/querier.go
@@ -17,25 +17,28 @@ const (
 	QueryGetClaimPeriods               = "claim-periods"
 	RestClaimCollateralType            = "collateral_type"
 	RestClaimOwner                     = "owner"
+	RestClaimDenom                     = "denom"
 	RestClaimType                      = "type"
 	RestUnsynced                       = "unsynced"
 )
 
 // QueryRewardsParams params for query /incentive/rewards
 type QueryRewardsParams struct {
-	Page  int `json:"page" yaml:"page"`
-	Limit int `json:"limit" yaml:"limit"`
-	Owner sdk.AccAddress
-	Type  string
+	Page  int            `json:"page" yaml:"page"`
+	Limit int            `json:"limit" yaml:"limit"`
+	Owner sdk.AccAddress `json:"owner" yaml:"owner"`
+	Denom string         `json:"denon" yaml:"denon"`
+	Type  string         `json:"type" yaml:"type"`
 }
 
 // NewQueryRewardsParams returns QueryRewardsParams
-func NewQueryRewardsParams(page, limit int, owner sdk.AccAddress, rewardType string) QueryRewardsParams {
+func NewQueryRewardsParams(page, limit int, owner sdk.AccAddress, rewardType, denom string) QueryRewardsParams {
 	return QueryRewardsParams{
 		Page:  page,
 		Limit: limit,
 		Owner: owner,
 		Type:  rewardType,
+		Denom: denom,
 	}
 }
 
@@ -80,11 +83,12 @@ type QueryHardRewardsParams struct {
 }
 
 // NewQueryHardRewardsParams returns QueryHardRewardsParams
-func NewQueryHardRewardsParams(page, limit int, owner sdk.AccAddress) QueryHardRewardsParams {
+func NewQueryHardRewardsParams(page, limit int, owner sdk.AccAddress, denom string) QueryHardRewardsParams {
 	return QueryHardRewardsParams{
 		Page:  page,
 		Limit: limit,
 		Owner: owner,
+		Denom: denom,
 	}
 }
 


### PR DESCRIPTION
Adds the ability to filter hard rewards by denom

example

```
# get hard rewards associated with usdx for the input owner. Any rewards accumulated for denoms other than usdx will not be returned
kvcli q incentive rewards --type hard --owner <owner_addr>  --denom usdx
```