### PR TITLE
Incentive refactor: low risk refactors

### DIFF
--- a/app/test_common.go
+++ b/app/test_common.go
@@ -41,6 +41,11 @@ import (
 	validatorvesting "github.com/kava-labs/kava/x/validator-vesting"
 )
 
+var (
+	emptyTime    time.Time
+	emptyChainID string
+)
+
 // TestApp is a simple wrapper around an App. It exposes internal keepers for use in integration tests.
 // This file also contains test helpers. Ideally they would be in separate package.
 // Basic Usage:
@@ -90,55 +95,12 @@ func (tApp TestApp) GetIssuanceKeeper() issuance.Keeper   { return tApp.issuance
 
 // InitializeFromGenesisStates calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states
 func (tApp TestApp) InitializeFromGenesisStates(genesisStates ...GenesisState) TestApp {
-	// Create a default genesis state and overwrite with provided values
-	genesisState := NewDefaultGenesisState()
-	for _, state := range genesisStates {
-		for k, v := range state {
-			genesisState[k] = v
-		}
-	}
-
-	// Initialize the chain
-	stateBytes, err := codec.MarshalJSONIndent(tApp.cdc, genesisState)
-	if err != nil {
-		panic(err)
-	}
-	tApp.InitChain(
-		abci.RequestInitChain{
-			Validators:    []abci.ValidatorUpdate{},
-			AppStateBytes: stateBytes,
-		},
-	)
-	tApp.Commit()
-	tApp.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: tApp.LastBlockHeight() + 1}})
-	return tApp
+	return tApp.InitializeFromGenesisStatesWithTimeAndChainID(emptyTime, emptyChainID, genesisStates...)
 }
 
 // InitializeFromGenesisStatesWithTime calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states and genesis Time
 func (tApp TestApp) InitializeFromGenesisStatesWithTime(genTime time.Time, genesisStates ...GenesisState) TestApp {
-	// Create a default genesis state and overwrite with provided values
-	genesisState := NewDefaultGenesisState()
-	for _, state := range genesisStates {
-		for k, v := range state {
-			genesisState[k] = v
-		}
-	}
-
-	// Initialize the chain
-	stateBytes, err := codec.MarshalJSONIndent(tApp.cdc, genesisState)
-	if err != nil {
-		panic(err)
-	}
-	tApp.InitChain(
-		abci.RequestInitChain{
-			Time:          genTime,
-			Validators:    []abci.ValidatorUpdate{},
-			AppStateBytes: stateBytes,
-		},
-	)
-	tApp.Commit()
-	tApp.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: tApp.LastBlockHeight() + 1, Time: genTime}})
-	return tApp
+	return tApp.InitializeFromGenesisStatesWithTimeAndChainID(genTime, emptyChainID, genesisStates...)
 }
 
 // InitializeFromGenesisStatesWithTimeAndChainID calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states and genesis Time

--- a/app/test_common.go
+++ b/app/test_common.go
@@ -18,6 +18,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
@@ -137,18 +138,6 @@ func (tApp TestApp) CheckBalance(t *testing.T, ctx sdk.Context, owner sdk.AccAdd
 	require.Equal(t, expectedCoins, acc.GetCoins())
 }
 
-// Create a new auth genesis state from some addresses and coins. The state is returned marshalled into a map.
-func NewAuthGenState(addresses []sdk.AccAddress, coins []sdk.Coins) GenesisState {
-	// Create GenAccounts
-	accounts := authexported.GenesisAccounts{}
-	for i := range addresses {
-		accounts = append(accounts, auth.NewBaseAccount(addresses[i], coins[i], nil, 0, 0))
-	}
-	// Create the auth genesis state
-	authGenesis := auth.NewGenesisState(auth.DefaultParams(), accounts)
-	return GenesisState{auth.ModuleName: auth.ModuleCdc.MustMarshalJSON(authGenesis)}
-}
-
 // GeneratePrivKeyAddressPairsFromRand generates (deterministically) a total of n secp256k1 private keys and addresses.
 func GeneratePrivKeyAddressPairs(n int) (keys []crypto.PrivKey, addrs []sdk.AccAddress) {
 	r := rand.New(rand.NewSource(12345)) // make the generation deterministic
@@ -164,4 +153,103 @@ func GeneratePrivKeyAddressPairs(n int) (keys []crypto.PrivKey, addrs []sdk.AccA
 		addrs[i] = sdk.AccAddress(keys[i].PubKey().Address())
 	}
 	return
+}
+
+// Create a new auth genesis state from some addresses and coins. The state is returned marshalled into a map.
+func NewAuthGenState(addresses []sdk.AccAddress, coins []sdk.Coins) GenesisState {
+	// Create GenAccounts
+	accounts := authexported.GenesisAccounts{}
+	for i := range addresses {
+		accounts = append(accounts, auth.NewBaseAccount(addresses[i], coins[i], nil, 0, 0))
+	}
+	// Create the auth genesis state
+	authGenesis := auth.NewGenesisState(auth.DefaultParams(), accounts)
+	return GenesisState{auth.ModuleName: auth.ModuleCdc.MustMarshalJSON(authGenesis)}
+}
+
+// AuthGenesisBuilder is a tool for creating an auth genesis state.
+// Helper methods create basic accounts types and add them to a default genesis state.
+// All methods are immutable and return updated copies of the builder.
+// The builder inherits from auth.GenesisState, so fields can be accessed directly if a helper method doesn't exist.
+//
+// Example:
+//     // create a single account genesis state
+//     builder := NewAuthGenesisBuilder().WithSimpleAccount(testUserAddress, testCoins)
+//     genesisState := builder.Build()
+//
+type AuthGenesisBuilder struct {
+	auth.GenesisState
+}
+
+// NewAuthGenesisBuilder creates a AuthGenesisBuilder containing a default genesis state.
+func NewAuthGenesisBuilder() AuthGenesisBuilder {
+	return AuthGenesisBuilder{
+		GenesisState: auth.DefaultGenesisState(),
+	}
+}
+
+// Build assembles and returns the final GenesisState
+func (builder AuthGenesisBuilder) Build() auth.GenesisState {
+	return builder.GenesisState
+}
+
+// BuildMarshalled assembles the final GenesisState and json encodes it into a generic genesis type.
+func (builder AuthGenesisBuilder) BuildMarshalled() GenesisState {
+	return GenesisState{
+		auth.ModuleName: auth.ModuleCdc.MustMarshalJSON(builder.Build()),
+	}
+}
+
+// WithAccounts adds accounts of any type to the genesis state.
+func (builder AuthGenesisBuilder) WithAccounts(account ...authexported.GenesisAccount) AuthGenesisBuilder {
+	builder.Accounts = append(builder.Accounts, account...)
+	return builder
+}
+
+// WithSimpleAccount adds a standard account to the genesis state.
+func (builder AuthGenesisBuilder) WithSimpleAccount(address sdk.AccAddress, balance sdk.Coins) AuthGenesisBuilder {
+	return builder.WithAccounts(auth.NewBaseAccount(address, balance, nil, 0, 0))
+}
+
+// WithSimpleModuleAccount adds a module account to the genesis state.
+func (builder AuthGenesisBuilder) WithSimpleModuleAccount(moduleName string, balance sdk.Coins, permissions ...string) AuthGenesisBuilder {
+	account := supply.NewEmptyModuleAccount(moduleName, permissions...)
+	account.SetCoins(balance)
+	return builder.WithAccounts(account)
+}
+
+// WithSimplePeriodicVestingAccount adds a periodic vesting account to the genesis state.
+func (builder AuthGenesisBuilder) WithSimplePeriodicVestingAccount(address sdk.AccAddress, balance sdk.Coins, periods vesting.Periods, firstPeriodStartTimestamp int64) AuthGenesisBuilder {
+	baseAccount := auth.NewBaseAccount(address, balance, nil, 0, 0)
+
+	originalVesting := sdk.NewCoins()
+	for _, p := range periods {
+		originalVesting = originalVesting.Add(p.Amount...)
+	}
+
+	var totalPeriods int64
+	for _, p := range periods {
+		totalPeriods += p.Length
+	}
+	endTime := firstPeriodStartTimestamp + totalPeriods
+
+	baseVestingAccount, err := vesting.NewBaseVestingAccount(baseAccount, originalVesting, endTime)
+	if err != nil {
+		panic(err.Error())
+	}
+	periodicVestingAccount := vesting.NewPeriodicVestingAccountRaw(baseVestingAccount, firstPeriodStartTimestamp, periods)
+
+	return builder.WithAccounts(periodicVestingAccount)
+}
+
+// WithEmptyValidatorVestingAccount adds a stub validator vesting account to the genesis state.
+func (builder AuthGenesisBuilder) WithEmptyValidatorVestingAccount(address sdk.AccAddress) AuthGenesisBuilder {
+	// TODO create a validator vesting account builder and remove this method
+	bacc := auth.NewBaseAccount(address, nil, nil, 0, 0)
+	bva, err := vesting.NewBaseVestingAccount(bacc, nil, 1)
+	if err != nil {
+		panic(err.Error())
+	}
+	account := validatorvesting.NewValidatorVestingAccountRaw(bva, 0, nil, sdk.ConsAddress{}, nil, 90)
+	return builder.WithAccounts(account)
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/kava-labs/kava/x/pricefeed"
 )
 
+// Avoid cluttering test cases with long function names
+func i(in int64) sdk.Int                    { return sdk.NewInt(in) }
+func d(str string) sdk.Dec                  { return sdk.MustNewDecFromStr(str) }
+func c(denom string, amount int64) sdk.Coin { return sdk.NewInt64Coin(denom, amount) }
+func cs(coins ...sdk.Coin) sdk.Coins        { return sdk.NewCoins(coins...) }
+
 func NewCDPGenStateMulti() app.GenesisState {
 	cdpGenesis := cdp.GenesisState{
 		Params: cdp.Params{

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -114,10 +114,6 @@ func NewCDPGenStateMulti() app.GenesisState {
 	return app.GenesisState{cdp.ModuleName: cdp.ModuleCdc.MustMarshalJSON(cdpGenesis)}
 }
 
-func NewPricefeedGenStateMulti() app.GenesisState {
-	return NewPricefeedGenStateMultiFromTime(time.Now())
-}
-
 func NewPricefeedGenStateMultiFromTime(t time.Time) app.GenesisState {
 	pfGenesis := pricefeed.GenesisState{
 		Params: pricefeed.Params{

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -209,38 +209,38 @@ func NewCommitteeGenesisState(members []sdk.AccAddress) app.GenesisState {
 	}
 }
 
-// incentiveGenesisBuilder is a tool for creating an incentive genesis state.
+// IncentiveGenesisBuilder is a tool for creating an incentive genesis state.
 // Helper methods add values onto a default genesis state.
 // All methods are immutable and return updated copies of the builder.
-type incentiveGenesisBuilder struct {
+type IncentiveGenesisBuilder struct {
 	types.GenesisState
 	genesisTime time.Time
 }
 
-func newIncentiveGenesisBuilder() incentiveGenesisBuilder {
-	return incentiveGenesisBuilder{
+func NewIncentiveGenesisBuilder() IncentiveGenesisBuilder {
+	return IncentiveGenesisBuilder{
 		GenesisState: types.DefaultGenesisState(),
 		genesisTime:  time.Time{},
 	}
 }
 
-func (builder incentiveGenesisBuilder) build() types.GenesisState {
+func (builder IncentiveGenesisBuilder) Build() types.GenesisState {
 	return builder.GenesisState
 }
 
-func (builder incentiveGenesisBuilder) buildMarshalled() app.GenesisState {
+func (builder IncentiveGenesisBuilder) BuildMarshalled() app.GenesisState {
 	return app.GenesisState{
-		types.ModuleName: types.ModuleCdc.MustMarshalJSON(builder.build()),
+		types.ModuleName: types.ModuleCdc.MustMarshalJSON(builder.Build()),
 	}
 }
 
-func (builder incentiveGenesisBuilder) withGenesisTime(time time.Time) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithGenesisTime(time time.Time) IncentiveGenesisBuilder {
 	builder.genesisTime = time
 	builder.Params.ClaimEnd = time.Add(5 * oneYear)
 	return builder
 }
 
-func (builder incentiveGenesisBuilder) withInitializedBorrowRewardPeriod(period types.MultiRewardPeriod) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithInitializedBorrowRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
 	builder.Params.HardBorrowRewardPeriods = append(builder.Params.HardBorrowRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
@@ -248,8 +248,8 @@ func (builder incentiveGenesisBuilder) withInitializedBorrowRewardPeriod(period 
 	return builder
 }
 
-func (builder incentiveGenesisBuilder) withSimpleBorrowRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) incentiveGenesisBuilder {
-	return builder.withInitializedBorrowRewardPeriod(types.NewMultiRewardPeriod(
+func (builder IncentiveGenesisBuilder) WithSimpleBorrowRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) IncentiveGenesisBuilder {
+	return builder.WithInitializedBorrowRewardPeriod(types.NewMultiRewardPeriod(
 		true,
 		ctype,
 		builder.genesisTime,
@@ -257,7 +257,7 @@ func (builder incentiveGenesisBuilder) withSimpleBorrowRewardPeriod(ctype string
 		rewardsPerSecond,
 	))
 }
-func (builder incentiveGenesisBuilder) withInitializedSupplyRewardPeriod(period types.MultiRewardPeriod) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithInitializedSupplyRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
 	// TODO this could set the start/end times on the period according to builder.genesisTime
 	// Then they could be created by a different builder
 
@@ -268,8 +268,8 @@ func (builder incentiveGenesisBuilder) withInitializedSupplyRewardPeriod(period 
 	return builder
 }
 
-func (builder incentiveGenesisBuilder) withSimpleSupplyRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) incentiveGenesisBuilder {
-	return builder.withInitializedSupplyRewardPeriod(types.NewMultiRewardPeriod(
+func (builder IncentiveGenesisBuilder) WithSimpleSupplyRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) IncentiveGenesisBuilder {
+	return builder.WithInitializedSupplyRewardPeriod(types.NewMultiRewardPeriod(
 		true,
 		ctype,
 		builder.genesisTime,
@@ -277,7 +277,7 @@ func (builder incentiveGenesisBuilder) withSimpleSupplyRewardPeriod(ctype string
 		rewardsPerSecond,
 	))
 }
-func (builder incentiveGenesisBuilder) withInitializedDelegatorRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithInitializedDelegatorRewardPeriod(period types.RewardPeriod) IncentiveGenesisBuilder {
 	builder.Params.HardDelegatorRewardPeriods = append(builder.Params.HardDelegatorRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
@@ -285,8 +285,8 @@ func (builder incentiveGenesisBuilder) withInitializedDelegatorRewardPeriod(peri
 	return builder
 }
 
-func (builder incentiveGenesisBuilder) withSimpleDelegatorRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) incentiveGenesisBuilder {
-	return builder.withInitializedDelegatorRewardPeriod(types.NewRewardPeriod(
+func (builder IncentiveGenesisBuilder) WithSimpleDelegatorRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) IncentiveGenesisBuilder {
+	return builder.WithInitializedDelegatorRewardPeriod(types.NewRewardPeriod(
 		true,
 		ctype,
 		builder.genesisTime,
@@ -294,7 +294,7 @@ func (builder incentiveGenesisBuilder) withSimpleDelegatorRewardPeriod(ctype str
 		rewardsPerSecond,
 	))
 }
-func (builder incentiveGenesisBuilder) withInitializedUSDXRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithInitializedUSDXRewardPeriod(period types.RewardPeriod) IncentiveGenesisBuilder {
 	builder.Params.USDXMintingRewardPeriods = append(builder.Params.USDXMintingRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
@@ -302,8 +302,8 @@ func (builder incentiveGenesisBuilder) withInitializedUSDXRewardPeriod(period ty
 	return builder
 }
 
-func (builder incentiveGenesisBuilder) withSimpleUSDXRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) incentiveGenesisBuilder {
-	return builder.withInitializedUSDXRewardPeriod(types.NewRewardPeriod(
+func (builder IncentiveGenesisBuilder) WithSimpleUSDXRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) IncentiveGenesisBuilder {
+	return builder.WithInitializedUSDXRewardPeriod(types.NewRewardPeriod(
 		true,
 		ctype,
 		builder.genesisTime,
@@ -312,7 +312,7 @@ func (builder incentiveGenesisBuilder) withSimpleUSDXRewardPeriod(ctype string, 
 	))
 }
 
-func (builder incentiveGenesisBuilder) withMultipliers(multipliers types.Multipliers) incentiveGenesisBuilder {
+func (builder IncentiveGenesisBuilder) WithMultipliers(multipliers types.Multipliers) IncentiveGenesisBuilder {
 	builder.Params.ClaimMultipliers = multipliers
 	return builder
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -199,19 +199,19 @@ func NewHardGenStateMulti(genTime time.Time) HardGenesisBuilder {
 //     genesisState := builder.Build()
 //
 type AuthGenesisBuilder struct {
-	genesis auth.GenesisState
+	auth.GenesisState
 }
 
 // NewAuthGenesisBuilder creates a AuthGenesisBuilder containing a default genesis state.
 func NewAuthGenesisBuilder() AuthGenesisBuilder {
 	return AuthGenesisBuilder{
-		genesis: auth.DefaultGenesisState(),
+		GenesisState: auth.DefaultGenesisState(),
 	}
 }
 
 // Build assembles and returns the final GenesisState
 func (builder AuthGenesisBuilder) Build() auth.GenesisState {
-	return builder.genesis
+	return builder.GenesisState
 }
 
 // BuildMarshalled assembles the final GenesisState and json encodes it into a universal genesis type.
@@ -221,14 +221,9 @@ func (builder AuthGenesisBuilder) BuildMarshalled() app.GenesisState {
 	}
 }
 
-func (builder AuthGenesisBuilder) WithParams(params auth.Params) AuthGenesisBuilder {
-	builder.genesis.Params = params
-	return builder
-}
-
 // WithAccounts adds accounts of any type to the genesis state.
 func (builder AuthGenesisBuilder) WithAccounts(account ...authexported.GenesisAccount) AuthGenesisBuilder {
-	builder.genesis.Accounts = append(builder.genesis.Accounts, account...)
+	builder.Accounts = append(builder.Accounts, account...)
 	return builder
 }
 
@@ -237,12 +232,14 @@ func (builder AuthGenesisBuilder) WithSimpleAccount(address sdk.AccAddress, bala
 	return builder.WithAccounts(auth.NewBaseAccount(address, balance, nil, 0, 0))
 }
 
+// WithSimpleAccount adds a module account to the genesis state.
 func (builder AuthGenesisBuilder) WithSimpleModuleAccount(moduleName string, balance sdk.Coins, permissions ...string) AuthGenesisBuilder {
 	account := supply.NewEmptyModuleAccount(moduleName, permissions...)
 	account.SetCoins(balance)
 	return builder.WithAccounts(account)
 }
 
+// WithSimpleAccount adds a periodic veesting account to the genesis state.
 func (builder AuthGenesisBuilder) WithSimplePeriodicVestingAccount(address sdk.AccAddress, balance sdk.Coins, periods vesting.Periods, firstPeriodStartTimestamp int64) AuthGenesisBuilder {
 	baseAccount := auth.NewBaseAccount(address, balance, nil, 0, 0)
 
@@ -266,6 +263,7 @@ func (builder AuthGenesisBuilder) WithSimplePeriodicVestingAccount(address sdk.A
 	return builder.WithAccounts(periodicVestingAccount)
 }
 
+// WithSimpleAccount adds a stub validator vesting account to the genesis state.
 func (builder AuthGenesisBuilder) WithEmptyValidatorVestingAccount(address sdk.AccAddress) AuthGenesisBuilder {
 	// TODO create a validator vesting account builder and remove this method
 	bacc := auth.NewBaseAccount(address, nil, nil, 0, 0)
@@ -306,19 +304,19 @@ func NewCommitteeGenesisState(members []sdk.AccAddress) app.GenesisState {
 // Helper methods add values onto a default genesis state.
 // All methods are immutable and return updated copies of the builder.
 type incentiveGenesisBuilder struct {
-	genesis     types.GenesisState
+	types.GenesisState
 	genesisTime time.Time
 }
 
 func newIncentiveGenesisBuilder() incentiveGenesisBuilder {
 	return incentiveGenesisBuilder{
-		genesis:     types.DefaultGenesisState(),
-		genesisTime: time.Time{},
+		GenesisState: types.DefaultGenesisState(),
+		genesisTime:  time.Time{},
 	}
 }
 
 func (builder incentiveGenesisBuilder) build() types.GenesisState {
-	return builder.genesis
+	return builder.GenesisState
 }
 
 func (builder incentiveGenesisBuilder) buildMarshalled() app.GenesisState {
@@ -329,15 +327,15 @@ func (builder incentiveGenesisBuilder) buildMarshalled() app.GenesisState {
 
 func (builder incentiveGenesisBuilder) withGenesisTime(time time.Time) incentiveGenesisBuilder {
 	builder.genesisTime = time
-	builder.genesis.Params.ClaimEnd = time.Add(5 * oneYear)
+	builder.Params.ClaimEnd = time.Add(5 * oneYear)
 	return builder
 }
 
 func (builder incentiveGenesisBuilder) withInitializedBorrowRewardPeriod(period types.MultiRewardPeriod) incentiveGenesisBuilder {
-	builder.genesis.Params.HardBorrowRewardPeriods = append(builder.genesis.Params.HardBorrowRewardPeriods, period)
+	builder.Params.HardBorrowRewardPeriods = append(builder.Params.HardBorrowRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
-	builder.genesis.HardBorrowAccumulationTimes = append(builder.genesis.HardBorrowAccumulationTimes, accumulationTimeForPeriod)
+	builder.HardBorrowAccumulationTimes = append(builder.HardBorrowAccumulationTimes, accumulationTimeForPeriod)
 	return builder
 }
 
@@ -354,10 +352,10 @@ func (builder incentiveGenesisBuilder) withInitializedSupplyRewardPeriod(period 
 	// TODO this could set the start/end times on the period according to builder.genesisTime
 	// Then they could be created by a different builder
 
-	builder.genesis.Params.HardSupplyRewardPeriods = append(builder.genesis.Params.HardSupplyRewardPeriods, period)
+	builder.Params.HardSupplyRewardPeriods = append(builder.Params.HardSupplyRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
-	builder.genesis.HardSupplyAccumulationTimes = append(builder.genesis.HardSupplyAccumulationTimes, accumulationTimeForPeriod)
+	builder.HardSupplyAccumulationTimes = append(builder.HardSupplyAccumulationTimes, accumulationTimeForPeriod)
 	return builder
 }
 
@@ -371,10 +369,10 @@ func (builder incentiveGenesisBuilder) withSimpleSupplyRewardPeriod(ctype string
 	))
 }
 func (builder incentiveGenesisBuilder) withInitializedDelegatorRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
-	builder.genesis.Params.HardDelegatorRewardPeriods = append(builder.genesis.Params.HardDelegatorRewardPeriods, period)
+	builder.Params.HardDelegatorRewardPeriods = append(builder.Params.HardDelegatorRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
-	builder.genesis.HardDelegatorAccumulationTimes = append(builder.genesis.HardDelegatorAccumulationTimes, accumulationTimeForPeriod)
+	builder.HardDelegatorAccumulationTimes = append(builder.HardDelegatorAccumulationTimes, accumulationTimeForPeriod)
 	return builder
 }
 
@@ -388,10 +386,10 @@ func (builder incentiveGenesisBuilder) withSimpleDelegatorRewardPeriod(ctype str
 	))
 }
 func (builder incentiveGenesisBuilder) withInitializedUSDXRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
-	builder.genesis.Params.USDXMintingRewardPeriods = append(builder.genesis.Params.USDXMintingRewardPeriods, period)
+	builder.Params.USDXMintingRewardPeriods = append(builder.Params.USDXMintingRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
-	builder.genesis.USDXAccumulationTimes = append(builder.genesis.USDXAccumulationTimes, accumulationTimeForPeriod)
+	builder.USDXAccumulationTimes = append(builder.USDXAccumulationTimes, accumulationTimeForPeriod)
 	return builder
 }
 
@@ -406,7 +404,7 @@ func (builder incentiveGenesisBuilder) withSimpleUSDXRewardPeriod(ctype string, 
 }
 
 func (builder incentiveGenesisBuilder) withMultipliers(multipliers types.Multipliers) incentiveGenesisBuilder {
-	builder.genesis.Params.ClaimMultipliers = multipliers
+	builder.Params.ClaimMultipliers = multipliers
 	return builder
 }
 

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -370,4 +370,44 @@ func (builder incentiveGenesisBuilder) withSimpleSupplyRewardPeriod(ctype string
 		rewardsPerSecond,
 	))
 }
+func (builder incentiveGenesisBuilder) withInitializedDelegatorRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
+	builder.genesis.Params.HardDelegatorRewardPeriods = append(builder.genesis.Params.HardDelegatorRewardPeriods, period)
+
+	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
+	builder.genesis.HardDelegatorAccumulationTimes = append(builder.genesis.HardDelegatorAccumulationTimes, accumulationTimeForPeriod)
+	return builder
+}
+
+func (builder incentiveGenesisBuilder) withSimpleDelegatorRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) incentiveGenesisBuilder {
+	return builder.withInitializedDelegatorRewardPeriod(types.NewRewardPeriod(
+		true,
+		ctype,
+		builder.genesisTime,
+		builder.genesisTime.Add(4*oneYear),
+		rewardsPerSecond,
+	))
+}
+func (builder incentiveGenesisBuilder) withInitializedUSDXRewardPeriod(period types.RewardPeriod) incentiveGenesisBuilder {
+	builder.genesis.Params.USDXMintingRewardPeriods = append(builder.genesis.Params.USDXMintingRewardPeriods, period)
+
+	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)
+	builder.genesis.USDXAccumulationTimes = append(builder.genesis.USDXAccumulationTimes, accumulationTimeForPeriod)
+	return builder
+}
+
+func (builder incentiveGenesisBuilder) withSimpleUSDXRewardPeriod(ctype string, rewardsPerSecond sdk.Coin) incentiveGenesisBuilder {
+	return builder.withInitializedUSDXRewardPeriod(types.NewRewardPeriod(
+		true,
+		ctype,
+		builder.genesisTime,
+		builder.genesisTime.Add(4*oneYear),
+		rewardsPerSecond,
+	))
+}
+
+func (builder incentiveGenesisBuilder) withMultipliers(multipliers types.Multipliers) incentiveGenesisBuilder {
+	builder.genesis.Params.ClaimMultipliers = multipliers
+	return builder
+}
+
 

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -4,11 +4,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
-	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	"github.com/cosmos/cosmos-sdk/x/staking"
-	"github.com/cosmos/cosmos-sdk/x/supply"
 
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/cdp"
@@ -17,7 +13,6 @@ import (
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 	"github.com/kava-labs/kava/x/incentive/types"
 	"github.com/kava-labs/kava/x/pricefeed"
-	validatorvesting "github.com/kava-labs/kava/x/validator-vesting"
 )
 
 const (
@@ -191,92 +186,6 @@ func NewHardGenStateMulti(genTime time.Time) HardGenesisBuilder {
 		WithInitializedMoneyMarket(NewStandardMoneyMarket("xrp")).
 		WithInitializedMoneyMarket(NewStandardMoneyMarket("zzz"))
 	return builder
-}
-
-// AuthGenesisBuilder is a tool for creating an auth genesis state.
-// Helper methods create basic accounts types and add them to a default genesis state.
-// All methods are immutable and return updated copies of the builder.
-//
-// Example:
-//     // create a single account genesis state
-//     builder := NewAuthGenesisBuilder().WithSimpleAccount(testUserAddress, testCoins)
-//     genesisState := builder.Build()
-//
-type AuthGenesisBuilder struct {
-	auth.GenesisState
-}
-
-// NewAuthGenesisBuilder creates a AuthGenesisBuilder containing a default genesis state.
-func NewAuthGenesisBuilder() AuthGenesisBuilder {
-	return AuthGenesisBuilder{
-		GenesisState: auth.DefaultGenesisState(),
-	}
-}
-
-// Build assembles and returns the final GenesisState
-func (builder AuthGenesisBuilder) Build() auth.GenesisState {
-	return builder.GenesisState
-}
-
-// BuildMarshalled assembles the final GenesisState and json encodes it into a universal genesis type.
-func (builder AuthGenesisBuilder) BuildMarshalled() app.GenesisState {
-	return app.GenesisState{
-		auth.ModuleName: auth.ModuleCdc.MustMarshalJSON(builder.Build()),
-	}
-}
-
-// WithAccounts adds accounts of any type to the genesis state.
-func (builder AuthGenesisBuilder) WithAccounts(account ...authexported.GenesisAccount) AuthGenesisBuilder {
-	builder.Accounts = append(builder.Accounts, account...)
-	return builder
-}
-
-// WithSimpleAccount adds a standard account to the genesis state.
-func (builder AuthGenesisBuilder) WithSimpleAccount(address sdk.AccAddress, balance sdk.Coins) AuthGenesisBuilder {
-	return builder.WithAccounts(auth.NewBaseAccount(address, balance, nil, 0, 0))
-}
-
-// WithSimpleAccount adds a module account to the genesis state.
-func (builder AuthGenesisBuilder) WithSimpleModuleAccount(moduleName string, balance sdk.Coins, permissions ...string) AuthGenesisBuilder {
-	account := supply.NewEmptyModuleAccount(moduleName, permissions...)
-	account.SetCoins(balance)
-	return builder.WithAccounts(account)
-}
-
-// WithSimpleAccount adds a periodic veesting account to the genesis state.
-func (builder AuthGenesisBuilder) WithSimplePeriodicVestingAccount(address sdk.AccAddress, balance sdk.Coins, periods vesting.Periods, firstPeriodStartTimestamp int64) AuthGenesisBuilder {
-	baseAccount := auth.NewBaseAccount(address, balance, nil, 0, 0)
-
-	originalVesting := sdk.NewCoins()
-	for _, p := range periods {
-		originalVesting = originalVesting.Add(p.Amount...)
-	}
-
-	var totalPeriods int64
-	for _, p := range periods {
-		totalPeriods += p.Length
-	}
-	endTime := firstPeriodStartTimestamp + totalPeriods
-
-	baseVestingAccount, err := vesting.NewBaseVestingAccount(baseAccount, originalVesting, endTime)
-	if err != nil {
-		panic(err.Error())
-	}
-	periodicVestingAccount := vesting.NewPeriodicVestingAccountRaw(baseVestingAccount, firstPeriodStartTimestamp, periods)
-
-	return builder.WithAccounts(periodicVestingAccount)
-}
-
-// WithSimpleAccount adds a stub validator vesting account to the genesis state.
-func (builder AuthGenesisBuilder) WithEmptyValidatorVestingAccount(address sdk.AccAddress) AuthGenesisBuilder {
-	// TODO create a validator vesting account builder and remove this method
-	bacc := auth.NewBaseAccount(address, nil, nil, 0, 0)
-	bva, err := vesting.NewBaseVestingAccount(bacc, nil, 1)
-	if err != nil {
-		panic(err.Error())
-	}
-	account := validatorvesting.NewValidatorVestingAccountRaw(bva, 0, nil, sdk.ConsAddress{}, nil, 90)
-	return builder.WithAccounts(account)
 }
 
 func NewStakingGenesisState() app.GenesisState {
@@ -465,4 +374,3 @@ func NewStandardMoneyMarket(denom string) hardtypes.MoneyMarket {
 		sdk.ZeroDec(),
 	)
 }
-

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -258,9 +258,6 @@ func (builder IncentiveGenesisBuilder) WithSimpleBorrowRewardPeriod(ctype string
 	))
 }
 func (builder IncentiveGenesisBuilder) WithInitializedSupplyRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
-	// TODO this could set the start/end times on the period according to builder.genesisTime
-	// Then they could be created by a different builder
-
 	builder.Params.HardSupplyRewardPeriods = append(builder.Params.HardSupplyRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -120,6 +120,10 @@ func NewCDPGenStateMulti() app.GenesisState {
 }
 
 func NewPricefeedGenStateMulti() app.GenesisState {
+	return NewPricefeedGenStateMultiFromTime(time.Now())
+}
+
+func NewPricefeedGenStateMultiFromTime(t time.Time) app.GenesisState {
 	pfGenesis := pricefeed.GenesisState{
 		Params: pricefeed.Params{
 			Markets: []pricefeed.Market{
@@ -136,37 +140,37 @@ func NewPricefeedGenStateMulti() app.GenesisState {
 				MarketID:      "kava:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("2.00"),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 			{
 				MarketID:      "btc:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("8000.00"),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 			{
 				MarketID:      "xrp:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("0.25"),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 			{
 				MarketID:      "bnb:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("17.25"),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 			{
 				MarketID:      "busd:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.OneDec(),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 			{
 				MarketID:      "zzz:usd",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("2.00"),
-				Expiry:        time.Now().Add(1 * time.Hour),
+				Expiry:        t.Add(1 * time.Hour),
 			},
 		},
 	}

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -6,9 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 
-	abci "github.com/tendermint/tendermint/abci/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
-
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/cdp"
 	committeetypes "github.com/kava-labs/kava/x/committee/types"
@@ -223,29 +220,4 @@ func NewCommitteeGenesisState(members []sdk.AccAddress) app.GenesisState {
 	return app.GenesisState{
 		committeetypes.ModuleName: committeetypes.ModuleCdc.MustMarshalJSON(genState),
 	}
-}
-
-func (suite *KeeperTestSuite) SetupApp() {
-	suite.app = app.NewTestApp()
-
-	suite.keeper = suite.app.GetIncentiveKeeper()
-	suite.hardKeeper = suite.app.GetHardKeeper()
-	suite.stakingKeeper = suite.app.GetStakingKeeper()
-	suite.committeeKeeper = suite.app.GetCommitteeKeeper()
-
-	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
-}
-
-func (suite *KeeperTestSuite) SetupWithGenState() {
-	suite.SetupApp()
-
-	suite.app.InitializeFromGenesisStates(
-		NewAuthGenState(suite.getAllAddrs(), cs(c("ukava", 1_000_000_000))),
-		NewStakingGenesisState(),
-		NewPricefeedGenStateMulti(),
-		NewCDPGenStateMulti(),
-		NewHardGenStateMulti(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
-	)
-
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -225,23 +225,27 @@ func NewCommitteeGenesisState(members []sdk.AccAddress) app.GenesisState {
 	}
 }
 
-func (suite *KeeperTestSuite) SetupWithGenState() {
-	tApp := app.NewTestApp()
-	ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+func (suite *KeeperTestSuite) SetupApp() {
+	suite.app = app.NewTestApp()
 
-	tApp.InitializeFromGenesisStates(
+	suite.keeper = suite.app.GetIncentiveKeeper()
+	suite.hardKeeper = suite.app.GetHardKeeper()
+	suite.stakingKeeper = suite.app.GetStakingKeeper()
+	suite.committeeKeeper = suite.app.GetCommitteeKeeper()
+
+	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+}
+
+func (suite *KeeperTestSuite) SetupWithGenState() {
+	suite.SetupApp()
+
+	suite.app.InitializeFromGenesisStates(
 		NewAuthGenState(suite.getAllAddrs(), cs(c("ukava", 1_000_000_000))),
 		NewStakingGenesisState(),
 		NewPricefeedGenStateMulti(),
 		NewCDPGenStateMulti(),
 		NewHardGenStateMulti(),
-		NewCommitteeGenesisState(suite.addrs[:2]),
+		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
 	)
 
-	suite.app = tApp
-	suite.ctx = ctx
-	suite.keeper = tApp.GetIncentiveKeeper()
-	suite.hardKeeper = tApp.GetHardKeeper()
-	suite.stakingKeeper = tApp.GetStakingKeeper()
-	suite.committeeKeeper = tApp.GetCommitteeKeeper()
 }

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/kava-labs/kava/x/pricefeed"
 )
 
+const (
+	oneYear time.Duration = time.Hour * 24 * 365
+)
+
 // Avoid cluttering test cases with long function names
 func i(in int64) sdk.Int                    { return sdk.NewInt(in) }
 func d(str string) sdk.Dec                  { return sdk.MustNewDecFromStr(str) }

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/params/subspace"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -18,16 +17,20 @@ type Keeper struct {
 	cdpKeeper     types.CdpKeeper
 	hardKeeper    types.HardKeeper
 	key           sdk.StoreKey
-	paramSubspace subspace.Subspace
+	paramSubspace types.ParamSubspace
 	supplyKeeper  types.SupplyKeeper
 	stakingKeeper types.StakingKeeper
 }
 
 // NewKeeper creates a new keeper
 func NewKeeper(
-	cdc *codec.Codec, key sdk.StoreKey, paramstore subspace.Subspace, sk types.SupplyKeeper,
+	cdc *codec.Codec, key sdk.StoreKey, paramstore types.ParamSubspace, sk types.SupplyKeeper,
 	cdpk types.CdpKeeper, hk types.HardKeeper, ak types.AccountKeeper, stk types.StakingKeeper,
 ) Keeper {
+
+	if !paramstore.HasKeyTable() {
+		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
+	}
 
 	return Keeper{
 		accountKeeper: ak,
@@ -35,7 +38,7 @@ func NewKeeper(
 		cdpKeeper:     cdpk,
 		hardKeeper:    hk,
 		key:           key,
-		paramSubspace: paramstore.WithKeyTable(types.ParamKeyTable()),
+		paramSubspace: paramstore,
 		supplyKeeper:  sk,
 		stakingKeeper: stk,
 	}

--- a/x/incentive/keeper/keeper_test.go
+++ b/x/incentive/keeper/keeper_test.go
@@ -2,10 +2,10 @@ package keeper_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -19,9 +19,12 @@ type KeeperTestSuite struct {
 	suite.Suite
 
 	keeper keeper.Keeper
-	app    app.TestApp
-	ctx    sdk.Context
-	addrs  []sdk.AccAddress
+
+	app app.TestApp
+	ctx sdk.Context
+
+	genesisTime time.Time
+	addrs       []sdk.AccAddress
 }
 
 // SetupTest is run automatically before each suite test
@@ -30,6 +33,8 @@ func (suite *KeeperTestSuite) SetupTest() {
 	app.SetBech32AddressPrefixes(config)
 
 	_, suite.addrs = app.GeneratePrivKeyAddressPairs(5)
+
+	suite.genesisTime = time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
 }
 
 func (suite *KeeperTestSuite) SetupApp() {
@@ -37,7 +42,7 @@ func (suite *KeeperTestSuite) SetupApp() {
 
 	suite.keeper = suite.app.GetIncentiveKeeper()
 
-	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
 func (suite *KeeperTestSuite) TestGetSetDeleteUSDXMintingClaim() {

--- a/x/incentive/keeper/keeper_test.go
+++ b/x/incentive/keeper/keeper_test.go
@@ -8,13 +8,8 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 
 	"github.com/kava-labs/kava/app"
-	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
-	hardkeeper "github.com/kava-labs/kava/x/hard/keeper"
 	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -23,14 +18,10 @@ import (
 type KeeperTestSuite struct {
 	suite.Suite
 
-	keeper          keeper.Keeper
-	hardKeeper      hardkeeper.Keeper
-	stakingKeeper   stakingkeeper.Keeper
-	committeeKeeper committeekeeper.Keeper
-	app             app.TestApp
-	ctx             sdk.Context
-	addrs           []sdk.AccAddress
-	validatorAddrs  []sdk.ValAddress
+	keeper keeper.Keeper
+	app    app.TestApp
+	ctx    sdk.Context
+	addrs  []sdk.AccAddress
 }
 
 // SetupTest is run automatically before each suite test
@@ -38,47 +29,17 @@ func (suite *KeeperTestSuite) SetupTest() {
 	config := sdk.GetConfig()
 	app.SetBech32AddressPrefixes(config)
 
-	_, allAddrs := app.GeneratePrivKeyAddressPairs(10)
-	suite.addrs = allAddrs[:5]
-	for _, a := range allAddrs[5:] {
-		suite.validatorAddrs = append(suite.validatorAddrs, sdk.ValAddress(a))
-	}
+	_, suite.addrs = app.GeneratePrivKeyAddressPairs(5)
 }
 
 func (suite *KeeperTestSuite) SetupApp() {
 	suite.app = app.NewTestApp()
 
 	suite.keeper = suite.app.GetIncentiveKeeper()
-	suite.hardKeeper = suite.app.GetHardKeeper()
-	suite.stakingKeeper = suite.app.GetStakingKeeper()
-	suite.committeeKeeper = suite.app.GetCommitteeKeeper()
 
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 }
 
-// getAllAddrs returns all user and validator addresses in the suite
-func (suite *KeeperTestSuite) getAllAddrs() []sdk.AccAddress {
-	accAddrs := []sdk.AccAddress{} // initialize new slice to avoid accidental modifications to underlying
-	accAddrs = append(accAddrs, suite.addrs...)
-	for _, a := range suite.validatorAddrs {
-		accAddrs = append(accAddrs, sdk.AccAddress(a))
-	}
-	return accAddrs
-}
-
-func (suite *KeeperTestSuite) SetupWithGenState() {
-	suite.SetupApp()
-
-	suite.app.InitializeFromGenesisStates(
-		NewAuthGenState(suite.getAllAddrs(), cs(c("ukava", 1_000_000_000))),
-		NewStakingGenesisState(),
-		NewPricefeedGenStateMulti(),
-		NewCDPGenStateMulti(),
-		NewHardGenStateMulti(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
-	)
-
-}
 func (suite *KeeperTestSuite) TestGetSetDeleteUSDXMintingClaim() {
 	suite.SetupApp()
 	c := types.NewUSDXMintingClaim(suite.addrs[0], c("ukava", 1000000), types.RewardIndexes{types.NewRewardIndex("bnb-a", sdk.ZeroDec())})
@@ -115,28 +76,6 @@ func (suite *KeeperTestSuite) TestIterateUSDXMintingClaims() {
 	claims = suite.keeper.GetAllUSDXMintingClaims(suite.ctx)
 	suite.Require().Equal(len(suite.addrs), len(claims))
 }
-
-func createPeriodicVestingAccount(origVesting sdk.Coins, periods vesting.Periods, startTime, endTime int64) (*vesting.PeriodicVestingAccount, error) {
-	_, addr := app.GeneratePrivKeyAddressPairs(1)
-	bacc := auth.NewBaseAccountWithAddress(addr[0])
-	bacc.Coins = origVesting
-	bva, err := vesting.NewBaseVestingAccount(&bacc, origVesting, endTime)
-	if err != nil {
-		return &vesting.PeriodicVestingAccount{}, err
-	}
-	pva := vesting.NewPeriodicVestingAccountRaw(bva, startTime, periods)
-	err = pva.Validate()
-	if err != nil {
-		return &vesting.PeriodicVestingAccount{}, err
-	}
-	return pva, nil
-}
-
-// Avoid cluttering test cases with long function names
-func i(in int64) sdk.Int                    { return sdk.NewInt(in) }
-func d(str string) sdk.Dec                  { return sdk.MustNewDecFromStr(str) }
-func c(denom string, amount int64) sdk.Coin { return sdk.NewInt64Coin(denom, amount) }
-func cs(coins ...sdk.Coin) sdk.Coins        { return sdk.NewCoins(coins...) }
 
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))

--- a/x/incentive/keeper/keeper_test.go
+++ b/x/incentive/keeper/keeper_test.go
@@ -12,9 +12,6 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 
-	abci "github.com/tendermint/tendermint/abci/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
-
 	"github.com/kava-labs/kava/app"
 	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
 	hardkeeper "github.com/kava-labs/kava/x/hard/keeper"
@@ -36,7 +33,7 @@ type KeeperTestSuite struct {
 	validatorAddrs  []sdk.ValAddress
 }
 
-// The default state used by each test
+// SetupTest is run automatically before each suite test
 func (suite *KeeperTestSuite) SetupTest() {
 	config := sdk.GetConfig()
 	app.SetBech32AddressPrefixes(config)
@@ -46,15 +43,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 	for _, a := range allAddrs[5:] {
 		suite.validatorAddrs = append(suite.validatorAddrs, sdk.ValAddress(a))
 	}
-
-	tApp := app.NewTestApp()
-	ctx := tApp.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
-
-	tApp.InitializeFromGenesisStates()
-
-	suite.keeper = tApp.GetIncentiveKeeper()
-	suite.app = tApp
-	suite.ctx = ctx
 }
 
 // getAllAddrs returns all user and validator addresses in the suite

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -58,7 +58,7 @@ func (suite *PayoutTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *PayoutTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *PayoutTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder IncentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -67,7 +67,7 @@ func (suite *PayoutTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuild
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		NewCDPGenStateMulti(),
 		hardBuilder.BuildMarshalled(),
-		incentBuilder.buildMarshalled(),
+		incentBuilder.BuildMarshalled(),
 	)
 }
 
@@ -150,10 +150,10 @@ func (suite *PayoutTestSuite) TestPayoutUSDXMintingClaim() {
 				WithSimpleAccount(userAddr, cs(tc.args.initialCollateral)).
 				WithSimpleModuleAccount(kavadist.ModuleName, cs(c("ukava", 1000000000000)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond).
-				withMultipliers(tc.args.multipliers)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond).
+				WithMultipliers(tc.args.multipliers)
 
 			suite.SetupWithGenState(authBulder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -336,14 +336,14 @@ func (suite *PayoutTestSuite) TestPayoutHardLiquidityProviderClaim() {
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15))).
 				WithSimpleModuleAccount(kavadist.ModuleName, cs(c("hard", 1000000000000000000), c("ukava", 1000000000000000000)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withMultipliers(tc.args.multipliers)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithMultipliers(tc.args.multipliers)
 			for _, c := range tc.args.deposit {
-				incentBuilder = incentBuilder.withSimpleSupplyRewardPeriod(c.Denom, tc.args.rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleSupplyRewardPeriod(c.Denom, tc.args.rewardsPerSecond)
 			}
 			for _, c := range tc.args.borrow {
-				incentBuilder = incentBuilder.withSimpleBorrowRewardPeriod(c.Denom, tc.args.rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleBorrowRewardPeriod(c.Denom, tc.args.rewardsPerSecond)
 			}
 
 			suite.SetupWithGenState(authBulder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
 
 	"github.com/cosmos/cosmos-sdk/x/auth"
 
@@ -671,6 +672,8 @@ func (suite *KeeperTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 	}
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
+			suite.SetupApp()
+			suite.app.InitializeFromGenesisStates()
 			// create the periodic vesting account
 			pva, err := createPeriodicVestingAccount(tc.args.accArgs.origVestingCoins, tc.args.accArgs.periods, tc.args.accArgs.startTime, tc.args.accArgs.endTime)
 			suite.Require().NoError(err)
@@ -908,6 +911,7 @@ func (suite *KeeperTestSuite) TestGetPeriodLength() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
+			suite.SetupApp()
 			ctx := suite.ctx.WithBlockTime(tc.args.blockTime)
 			length, err := suite.keeper.GetPeriodLength(ctx, tc.args.multiplier)
 			if tc.errArgs.expectPass {
@@ -918,4 +922,10 @@ func (suite *KeeperTestSuite) TestGetPeriodLength() {
 			}
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) SetupApp() {
+	suite.app = app.NewTestApp()
+	suite.keeper = suite.app.GetIncentiveKeeper()
+	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
 }

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -58,7 +58,7 @@ func (suite *PayoutTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *PayoutTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *PayoutTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -146,7 +146,7 @@ func (suite *PayoutTestSuite) TestPayoutUSDXMintingClaim() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[0]
-			authBulder := NewAuthGenesisBuilder().
+			authBulder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(userAddr, cs(tc.args.initialCollateral)).
 				WithSimpleModuleAccount(kavadist.ModuleName, cs(c("ukava", 1000000000000)))
 
@@ -332,7 +332,7 @@ func (suite *PayoutTestSuite) TestPayoutHardLiquidityProviderClaim() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBulder := NewAuthGenesisBuilder().
+			authBulder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15))).
 				WithSimpleModuleAccount(kavadist.ModuleName, cs(c("hard", 1000000000000000000), c("ukava", 1000000000000000000)))
 
@@ -663,7 +663,7 @@ func (suite *PayoutTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 	}
 	for _, tc := range tests {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().WithSimplePeriodicVestingAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimplePeriodicVestingAccount(
 				suite.addrs[0],
 				tc.args.accArgs.origVestingCoins,
 				tc.args.accArgs.periods,
@@ -699,7 +699,7 @@ func (suite *PayoutTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 }
 
 func (suite *PayoutTestSuite) TestSendCoinsToBaseAccount() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleAccount(suite.addrs[1], cs(c("ukava", 400))).
 		WithSimpleModuleAccount(kavadist.ModuleName, cs(c("ukava", 600)))
 
@@ -727,7 +727,7 @@ func (suite *PayoutTestSuite) TestSendCoinsToBaseAccount() {
 }
 
 func (suite *PayoutTestSuite) TestSendCoinsToInvalidAccount() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleModuleAccount(kavadist.ModuleName, cs(c("ukava", 600))).
 		WithEmptyValidatorVestingAccount(suite.addrs[2])
 

--- a/x/incentive/keeper/payout_test.go
+++ b/x/incentive/keeper/payout_test.go
@@ -785,6 +785,22 @@ func (suite *PayoutTestSuite) TestSendCoinsToPeriodicVestingAccount() {
 	}
 }
 
+func createPeriodicVestingAccount(origVesting sdk.Coins, periods vesting.Periods, startTime, endTime int64) (*vesting.PeriodicVestingAccount, error) {
+	_, addr := app.GeneratePrivKeyAddressPairs(1)
+	bacc := auth.NewBaseAccountWithAddress(addr[0])
+	bacc.Coins = origVesting
+	bva, err := vesting.NewBaseVestingAccount(&bacc, origVesting, endTime)
+	if err != nil {
+		return &vesting.PeriodicVestingAccount{}, err
+	}
+	pva := vesting.NewPeriodicVestingAccountRaw(bva, startTime, periods)
+	err = pva.Validate()
+	if err != nil {
+		return &vesting.PeriodicVestingAccount{}, err
+	}
+	return pva, nil
+}
+
 func (suite *PayoutTestSuite) TestSendCoinsToBaseAccount() {
 	suite.SetupWithAccountState()
 	// send coins to base account

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -173,7 +173,7 @@ func (k Keeper) CalculateRewards(oldIndexes, newIndexes types.RewardIndexes, rew
 			return nil, sdkerrors.Wrapf(types.ErrDecreasingRewardFactor, "old: %v, new: %v", oldIndex, newIndex)
 		}
 	}
-	reward := sdk.NewCoins()
+	var reward sdk.Coins
 	for _, newIndex := range newIndexes {
 		factor, found := oldIndexes.Get(newIndex.CollateralType)
 		if !found {

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -118,10 +118,11 @@ func (k Keeper) SynchronizeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bo
 
 		newRewards, err := k.CalculateRewards(userRewardIndexes, globalRewardIndexes, coin.Amount)
 		if err != nil {
-			// Global reward indexes should never decrease or be deleted.
-			// So old values stored in a claim should always be ≤ the current global values.
+			// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
+			// This panics if a global reward factor decreases or disappears between the old and new indexes.
 			panic(fmt.Sprintf("corrupted global reward indexes found: %v", err))
 		}
+
 		claim.Reward = claim.Reward.Add(newRewards...)
 		claim.BorrowRewardIndexes = claim.BorrowRewardIndexes.With(coin.Denom, globalRewardIndexes)
 	}

--- a/x/incentive/keeper/rewards_borrow_init_test.go
+++ b/x/incentive/keeper/rewards_borrow_init_test.go
@@ -39,7 +39,7 @@ func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimExi
 	suite.storeClaim(claim)
 
 	globalIndexes := nonEmptyMultiRewardIndexes
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -53,7 +53,7 @@ func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimExi
 }
 func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimDoesNotExist() {
 	globalIndexes := nonEmptyMultiRewardIndexes
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	owner := arbitraryAddress()
 	borrow := hardtypes.Borrow{
@@ -70,7 +70,7 @@ func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimDoe
 func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetEmptyForMissingIndexes() {
 
 	globalIndexes := nonEmptyMultiRewardIndexes
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	owner := arbitraryAddress()
 	// Borrow a denom that is not in the global indexes.

--- a/x/incentive/keeper/rewards_borrow_init_test.go
+++ b/x/incentive/keeper/rewards_borrow_init_test.go
@@ -1,0 +1,162 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	db "github.com/tendermint/tm-db"
+
+	"github.com/kava-labs/kava/app"
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive"
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// NewTestContext sets up a basic context with an in-memory db
+func NewTestContext(requiredStoreKeys ...sdk.StoreKey) sdk.Context {
+	memDB := db.NewMemDB()
+	cms := store.NewCommitMultiStore(memDB)
+
+	for _, key := range requiredStoreKeys {
+		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
+	}
+
+	cms.LoadLatestVersion()
+
+	return sdk.NewContext(cms, abci.Header{}, false, log.NewNopLogger())
+}
+
+type unitTester struct {
+	suite.Suite
+	keeper keeper.Keeper
+	ctx    sdk.Context
+}
+
+func (suite *unitTester) SetupTest() {
+	incentiveStoreKey := sdk.NewKVStoreKey(types.StoreKey)
+	suite.keeper = suite.setupKeeper(incentiveStoreKey)
+	suite.ctx = NewTestContext(incentiveStoreKey)
+}
+
+func (suite *unitTester) TearDownTest() {
+	suite.keeper = keeper.Keeper{}
+	suite.ctx = sdk.Context{}
+}
+
+func (suite *unitTester) setupKeeper(incentiveStoreKey sdk.StoreKey) keeper.Keeper {
+	cdc := app.MakeCodec()
+	// TODO The param store key needs to be initialized in the multistore for the subspace to function.
+	paramSubspace := params.NewKeeper(
+		cdc,
+		sdk.NewKVStoreKey(params.StoreKey),
+		sdk.NewTransientStoreKey(params.StoreKey),
+	).Subspace(incentive.DefaultParamspace)
+
+	return keeper.NewKeeper(cdc, incentiveStoreKey, paramSubspace, nil, nil, nil, nil, nil)
+}
+
+func (suite *unitTester) storeGlobalIndexes(indexes types.MultiRewardIndexes) {
+	for _, i := range indexes {
+		suite.keeper.SetHardBorrowRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
+	}
+}
+
+func (suite *unitTester) storeClaim(claim types.HardLiquidityProviderClaim) {
+	suite.keeper.SetHardLiquidityProviderClaim(suite.ctx, claim)
+}
+
+// InitializeHardBorrowRewardTests runs unit tests for the keeper.InitializeHardBorrowReward method
+//
+// inputs
+// - claim in store if it exists (only claim.BorrowRewardIndexes)
+// - global indexes in store
+// - borrow function arg (only borrow.Amount)
+//
+// outputs
+// - sets or creates a claim
+type InitializeHardBorrowRewardTests struct {
+	unitTester
+}
+
+func TestInitializeHardBorrowReward(t *testing.T) {
+	suite.Run(t, new(InitializeHardBorrowRewardTests))
+}
+
+func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimExists() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		// Indexes should always be empty when initialize is called.
+		// If initialize is called then the user must have repaid their borrow positions,
+		// which means UpdateHardBorrowIndexDenoms was called and should have remove indexes.
+		BorrowRewardIndexes: types.MultiRewardIndexes{},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalIndexes(globalIndexes)
+
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.InitializeHardBorrowReward(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.BorrowRewardIndexes)
+}
+func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetWhenClaimDoesNotExist() {
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalIndexes(globalIndexes)
+
+	owner := arbitraryAddress()
+	borrow := hardtypes.Borrow{
+		Borrower: owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.InitializeHardBorrowReward(suite.ctx, borrow)
+
+	syncedClaim, found := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, owner)
+	suite.True(found)
+	suite.Equal(globalIndexes, syncedClaim.BorrowRewardIndexes)
+}
+func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetEmptyForMissingIndexes() {
+
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalIndexes(globalIndexes)
+
+	owner := arbitraryAddress()
+	// Borrow a denom that is not in the global indexes.
+	// This happens when a borrow denom has no rewards associated with it.
+	expectedIndexes := appendUniqueEmptyMultiRewardIndex(globalIndexes)
+	borrowedDenoms := extractCollateralTypes(expectedIndexes)
+	borrow := hardtypes.Borrow{
+		Borrower: owner,
+		Amount:   arbitraryCoinsWithDenoms(borrowedDenoms...),
+	}
+
+	suite.keeper.InitializeHardBorrowReward(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, owner)
+	suite.Equal(expectedIndexes, syncedClaim.BorrowRewardIndexes)
+}
+
+func addUniqueDenom(denoms []string) []string {
+	uniqueDenom := "uniquedenom"
+	for _, d := range denoms {
+		if d == uniqueDenom {
+			panic(fmt.Sprintf("tried to add unique denom '%s', but denom already existed", uniqueDenom))
+		}
+	}
+	return append(denoms, uniqueDenom)
+}

--- a/x/incentive/keeper/rewards_borrow_init_test.go
+++ b/x/incentive/keeper/rewards_borrow_init_test.go
@@ -151,7 +151,7 @@ func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetEmptyForMiss
 	suite.Equal(expectedIndexes, syncedClaim.BorrowRewardIndexes)
 }
 
-func addUniqueDenom(denoms []string) []string {
+func appendUniqueDenom(denoms []string) []string {
 	uniqueDenom := "uniquedenom"
 	for _, d := range denoms {
 		if d == uniqueDenom {

--- a/x/incentive/keeper/rewards_borrow_init_test.go
+++ b/x/incentive/keeper/rewards_borrow_init_test.go
@@ -1,76 +1,13 @@
 package keeper_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/store"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/stretchr/testify/suite"
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/libs/log"
-	db "github.com/tendermint/tm-db"
 
-	"github.com/kava-labs/kava/app"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
-	"github.com/kava-labs/kava/x/incentive"
-	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
-
-// NewTestContext sets up a basic context with an in-memory db
-func NewTestContext(requiredStoreKeys ...sdk.StoreKey) sdk.Context {
-	memDB := db.NewMemDB()
-	cms := store.NewCommitMultiStore(memDB)
-
-	for _, key := range requiredStoreKeys {
-		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
-	}
-
-	cms.LoadLatestVersion()
-
-	return sdk.NewContext(cms, abci.Header{}, false, log.NewNopLogger())
-}
-
-type unitTester struct {
-	suite.Suite
-	keeper keeper.Keeper
-	ctx    sdk.Context
-}
-
-func (suite *unitTester) SetupTest() {
-	incentiveStoreKey := sdk.NewKVStoreKey(types.StoreKey)
-	suite.keeper = suite.setupKeeper(incentiveStoreKey)
-	suite.ctx = NewTestContext(incentiveStoreKey)
-}
-
-func (suite *unitTester) TearDownTest() {
-	suite.keeper = keeper.Keeper{}
-	suite.ctx = sdk.Context{}
-}
-
-func (suite *unitTester) setupKeeper(incentiveStoreKey sdk.StoreKey) keeper.Keeper {
-	cdc := app.MakeCodec()
-	// TODO The param store key needs to be initialized in the multistore for the subspace to function.
-	paramSubspace := params.NewKeeper(
-		cdc,
-		sdk.NewKVStoreKey(params.StoreKey),
-		sdk.NewTransientStoreKey(params.StoreKey),
-	).Subspace(incentive.DefaultParamspace)
-
-	return keeper.NewKeeper(cdc, incentiveStoreKey, paramSubspace, nil, nil, nil, nil, nil)
-}
-
-func (suite *unitTester) storeGlobalIndexes(indexes types.MultiRewardIndexes) {
-	for _, i := range indexes {
-		suite.keeper.SetHardBorrowRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
-	}
-}
-
-func (suite *unitTester) storeClaim(claim types.HardLiquidityProviderClaim) {
-	suite.keeper.SetHardLiquidityProviderClaim(suite.ctx, claim)
-}
 
 // InitializeHardBorrowRewardTests runs unit tests for the keeper.InitializeHardBorrowReward method
 //
@@ -149,14 +86,4 @@ func (suite *InitializeHardBorrowRewardTests) TestClaimIndexesAreSetEmptyForMiss
 
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, owner)
 	suite.Equal(expectedIndexes, syncedClaim.BorrowRewardIndexes)
-}
-
-func appendUniqueDenom(denoms []string) []string {
-	uniqueDenom := "uniquedenom"
-	for _, d := range denoms {
-		if d == uniqueDenom {
-			panic(fmt.Sprintf("tried to add unique denom '%s', but denom already existed", uniqueDenom))
-		}
-	}
-	return append(denoms, uniqueDenom)
 }

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -314,7 +314,7 @@ func TestCalculateRewards(t *testing.T) {
 	}
 	type args struct {
 		oldIndexes, newIndexes types.RewardIndexes
-		sourceAmount           sdk.Int
+		sourceAmount           sdk.Dec
 	}
 	testcases := []struct {
 		name     string
@@ -344,7 +344,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.100000001"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				// for each denom: (new - old) * sourceAmount
@@ -370,7 +370,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.100000001"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				// for each denom: (new - old) * sourceAmount
@@ -392,7 +392,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.1"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				err: types.ErrDecreasingRewardFactor,
@@ -417,7 +417,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.2"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				err: types.ErrDecreasingRewardFactor,

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -184,7 +184,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenGlobal
 	)
 }
 
-func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNewRewardAdded() {
+func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard borrow denom the user has already borrowed, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
 	suite.T().Skip("TODO fix this bug")
@@ -248,7 +248,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNe
 		syncedClaim.Reward,
 	)
 }
-func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNewRewardDenomAdded() {
+func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded borrow denom (that the user has already borrowed), and the claim is synced;
 	// Then the user earns rewards for the time since the reward was added
 

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -2,14 +2,12 @@ package keeper_test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/kava-labs/kava/app"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
@@ -436,139 +434,4 @@ func TestCalculateRewards(t *testing.T) {
 			}
 		})
 	}
-}
-
-func arbitraryCoins() sdk.Coins {
-	return cs(c("btcb", 1))
-}
-
-func arbitraryCoinsWithDenoms(denom ...string) sdk.Coins {
-	const arbitraryAmount = 1 // must be > 0 as sdk.Coins type only stores positive amounts
-	coins := sdk.NewCoins()
-	for _, d := range denom {
-		coins = coins.Add(sdk.NewInt64Coin(d, arbitraryAmount))
-	}
-	return coins
-}
-
-func arbitraryAddress() sdk.AccAddress {
-	_, addresses := app.GeneratePrivKeyAddressPairs(1)
-	return addresses[0]
-}
-
-var nonEmptyMultiRewardIndexes = types.MultiRewardIndexes{
-	{
-		CollateralType: "bnb",
-		RewardIndexes: types.RewardIndexes{
-			{
-				CollateralType: "hard",
-				RewardFactor:   d("0.02"),
-			},
-			{
-				CollateralType: "ukava",
-				RewardFactor:   d("0.04"),
-			},
-		},
-	},
-	{
-		CollateralType: "btcb",
-		RewardIndexes: types.RewardIndexes{
-			{
-				CollateralType: "hard",
-				RewardFactor:   d("0.2"),
-			},
-			{
-				CollateralType: "ukava",
-				RewardFactor:   d("0.4"),
-			},
-		},
-	},
-}
-
-func extractCollateralTypes(indexes types.MultiRewardIndexes) []string {
-	var denoms []string
-	for _, ri := range indexes {
-		denoms = append(denoms, ri.CollateralType)
-	}
-	return denoms
-}
-
-func increaseAllRewardFactors(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
-	increasedIndexes := make(types.MultiRewardIndexes, len(indexes))
-	copy(increasedIndexes, indexes)
-
-	for i := range increasedIndexes {
-		increasedIndexes[i].RewardIndexes = increaseRewardFactors(increasedIndexes[i].RewardIndexes)
-	}
-	return increasedIndexes
-}
-
-func increaseRewardFactors(indexes types.RewardIndexes) types.RewardIndexes {
-	increasedIndexes := make(types.RewardIndexes, len(indexes))
-	copy(increasedIndexes, indexes)
-
-	for i := range increasedIndexes {
-		increasedIndexes[i].RewardFactor = increasedIndexes[i].RewardFactor.MulInt64(2)
-	}
-	return increasedIndexes
-}
-
-func appendUniqueMultiRewardIndex(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
-	const uniqueDenom = "uniquedenom"
-
-	for _, mri := range indexes {
-		if mri.CollateralType == uniqueDenom {
-			panic(fmt.Sprintf("tried to add unique multi reward index with denom '%s', but denom already existed", uniqueDenom))
-		}
-	}
-
-	return append(indexes, types.NewMultiRewardIndex(
-		uniqueDenom,
-		types.RewardIndexes{
-			{
-				CollateralType: "hard",
-				RewardFactor:   d("0.02"),
-			},
-			{
-				CollateralType: "ukava",
-				RewardFactor:   d("0.04"),
-			},
-		},
-	),
-	)
-}
-
-func appendUniqueEmptyMultiRewardIndex(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
-	const uniqueDenom = "uniquedenom"
-
-	for _, mri := range indexes {
-		if mri.CollateralType == uniqueDenom {
-			panic(fmt.Sprintf("tried to add unique multi reward index with denom '%s', but denom already existed", uniqueDenom))
-		}
-	}
-
-	return append(indexes, types.NewMultiRewardIndex(uniqueDenom, nil))
-}
-
-func appendUniqueRewardIndexToFirstItem(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
-	newIndexes := make(types.MultiRewardIndexes, len(indexes))
-	copy(newIndexes, indexes)
-
-	newIndexes[0].RewardIndexes = appendUniqueRewardIndex(newIndexes[0].RewardIndexes)
-	return newIndexes
-}
-
-func appendUniqueRewardIndex(indexes types.RewardIndexes) types.RewardIndexes {
-	const uniqueDenom = "uniquereward"
-
-	for _, mri := range indexes {
-		if mri.CollateralType == uniqueDenom {
-			panic(fmt.Sprintf("tried to add unique reward index with denom '%s', but denom already existed", uniqueDenom))
-		}
-	}
-
-	return append(
-		indexes,
-		types.NewRewardIndex(uniqueDenom, d("0.02")),
-	)
 }

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -42,7 +42,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenGlo
 	suite.storeClaim(claim)
 
 	globalIndexes := increaseAllRewardFactors(nonEmptyMultiRewardIndexes)
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
 		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(claim.BorrowRewardIndexes)...),
@@ -66,7 +66,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUnchangedWhenG
 	}
 	suite.storeClaim(claim)
 
-	suite.storeGlobalIndexes(unchangingIndexes)
+	suite.storeGlobalBorrowIndexes(unchangingIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -92,7 +92,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	suite.storeClaim(claim)
 
 	globalIndexes := appendUniqueMultiRewardIndex(nonEmptyMultiRewardIndexes)
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -117,7 +117,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	suite.storeClaim(claim)
 
 	globalIndexes := appendUniqueRewardIndexToFirstItem(nonEmptyMultiRewardIndexes)
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -157,7 +157,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenGlobal
 	}
 	suite.storeClaim(claim)
 
-	suite.storeGlobalIndexes(types.MultiRewardIndexes{
+	suite.storeGlobalBorrowIndexes(types.MultiRewardIndexes{
 		{
 			CollateralType: "borrowdenom",
 			RewardIndexes: types.RewardIndexes{
@@ -231,7 +231,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNe
 			},
 		},
 	}
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -289,7 +289,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNe
 			},
 		},
 	}
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -436,25 +436,6 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				expectedRewards: cs(c("hard", 12235400), c("ukava", 55555500)),
 			},
 		},
-		// {
-		// 	"denom is in incentive's hard borrow reward params but it has no rewards; add reward",
-		// 	args{
-		// 		incentiveBorrowRewardDenom: "bnb",
-		// 		borrow:                     c("bnb", 10000000000),
-		// 		rewardsPerSecond:           sdk.Coins{},
-		// 		blockTimes:                 []int{100},
-		// 		expectedRewardIndexes:      types.RewardIndexes{},
-		// 		expectedRewards:            sdk.Coins{},
-		// 		updateRewardsViaCommmittee: true,
-		// 		updatedBaseDenom:           "bnb",
-		// 		updatedRewardsPerSecond:    cs(c("hard", 100000)),
-		// 		updatedExpectedRewards:     cs(c("hard", 8640000000)),
-		// 		updatedExpectedRewardIndexes: types.RewardIndexes{
-		// 			types.NewRewardIndex("hard", d("0.864000000049803065")),
-		// 		},
-		// 		updatedTimeDuration: 86400,
-		// 	},
-		// },
 		{
 			"denom is in incentive's hard borrow reward params and has rewards; add new reward type",
 			args{
@@ -496,27 +477,6 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// {
-		// 	"denom incentive's hard borrow reward params but it has no rewards; add multiple reward types",
-		// 	args{
-		// 		incentiveBorrowRewardDenom: "bnb",
-		// 		borrow:                     c("bnb", 10000000000),
-		// 		rewardsPerSecond:           sdk.Coins{},
-		// 		blockTimes:                 []int{100},
-		// 		expectedRewardIndexes:      types.RewardIndexes{},
-		// 		expectedRewards:            sdk.Coins{},
-		// 		updateRewardsViaCommmittee: true,
-		// 		updatedBaseDenom:           "bnb",
-		// 		updatedRewardsPerSecond:    cs(c("hard", 100000), c("ukava", 100500), c("swap", 500)),
-		// 		updatedExpectedRewards:     cs(c("hard", 8640000000), c("ukava", 8683200001), c("swap", 43200000)),
-		// 		updatedExpectedRewardIndexes: types.RewardIndexes{
-		// 			types.NewRewardIndex("hard", d("0.864000000049803065")),
-		// 			types.NewRewardIndex("ukava", d("0.868320000050052081")),
-		// 			types.NewRewardIndex("swap", d("0.004320000000249015")),
-		// 		},
-		// 		updatedTimeDuration: 86400,
-		// 	},
-		// },
 		{
 			"denom is in hard's money market params but not in incentive's hard supply reward params; add multiple reward types",
 			args{
@@ -538,6 +498,7 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
+		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -53,7 +53,7 @@ func (suite *BorrowRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder IncentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -62,7 +62,7 @@ func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
 		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite,
-		incentBuilder.buildMarshalled(),
+		incentBuilder.BuildMarshalled(),
 	)
 }
 
@@ -162,9 +162,9 @@ func (suite *BorrowRewardsTestSuite) TestAccumulateHardBorrowRewards() {
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleBorrowRewardPeriod(tc.args.borrow.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleBorrowRewardPeriod(tc.args.borrow.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -317,9 +317,9 @@ func (suite *BorrowRewardsTestSuite) TestInitializeHardBorrowRewards() {
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
 
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime)
 			for moneyMarketDenom, rewardsPerSecond := range tc.args.moneyMarketRewardDenoms {
-				incentBuilder = incentBuilder.withSimpleBorrowRewardPeriod(moneyMarketDenom, rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleBorrowRewardPeriod(moneyMarketDenom, rewardsPerSecond)
 			}
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
@@ -546,9 +546,9 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime)
 			if tc.args.rewardsPerSecond != nil {
-				incentBuilder = incentBuilder.withSimpleBorrowRewardPeriod(tc.args.incentiveBorrowRewardDenom, tc.args.rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleBorrowRewardPeriod(tc.args.incentiveBorrowRewardDenom, tc.args.rewardsPerSecond)
 			}
 			// Set the minimum borrow to 0 to allow testing small borrows
 			hardBuilder := NewHardGenStateMulti(suite.genesisTime).WithMinBorrow(sdk.ZeroDec())
@@ -871,12 +871,12 @@ func (suite *BorrowRewardsTestSuite) TestUpdateHardBorrowIndexDenoms() {
 					cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 				)
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleBorrowRewardPeriod("bnb", tc.args.rewardsPerSecond).
-				withSimpleBorrowRewardPeriod("ukava", tc.args.rewardsPerSecond).
-				withSimpleBorrowRewardPeriod("btcb", tc.args.rewardsPerSecond).
-				withSimpleBorrowRewardPeriod("xrp", tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleBorrowRewardPeriod("bnb", tc.args.rewardsPerSecond).
+				WithSimpleBorrowRewardPeriod("ukava", tc.args.rewardsPerSecond).
+				WithSimpleBorrowRewardPeriod("btcb", tc.args.rewardsPerSecond).
+				WithSimpleBorrowRewardPeriod("xrp", tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -973,9 +973,9 @@ func (suite *BorrowRewardsTestSuite) TestSimulateHardBorrowRewardSynchronization
 			userAddr := suite.addrs[3]
 			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleBorrowRewardPeriod(tc.args.borrow.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleBorrowRewardPeriod(tc.args.borrow.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -53,7 +53,7 @@ func (suite *BorrowRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -157,7 +157,7 @@ func (suite *BorrowRewardsTestSuite) TestAccumulateHardBorrowRewards() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
@@ -312,7 +312,7 @@ func (suite *BorrowRewardsTestSuite) TestInitializeHardBorrowRewards() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
@@ -542,7 +542,7 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
@@ -861,7 +861,7 @@ func (suite *BorrowRewardsTestSuite) TestUpdateHardBorrowIndexDenoms() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(
 					userAddr,
 					cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
@@ -971,7 +971,7 @@ func (suite *BorrowRewardsTestSuite) TestSimulateHardBorrowRewardSynchronization
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
 			incentBuilder := newIncentiveGenesisBuilder().
 				withGenesisTime(suite.genesisTime).

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -25,10 +25,12 @@ type BorrowRewardsTestSuite struct {
 	keeper          keeper.Keeper
 	hardKeeper      hardkeeper.Keeper
 	committeeKeeper committeekeeper.Keeper
-	app             app.TestApp
-	ctx             sdk.Context
-	addrs           []sdk.AccAddress
-	genesisTime     time.Time
+
+	app app.TestApp
+	ctx sdk.Context
+
+	genesisTime time.Time
+	addrs       []sdk.AccAddress
 }
 
 // SetupTest is run automatically before each suite test

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -742,7 +742,9 @@ func (suite *KeeperTestSuite) TestSynchronizeHardBorrowReward() {
 
 			// 5. Committee votes and passes proposal
 			err = suite.committeeKeeper.AddVote(suite.ctx, proposalID, committeeMemberOne)
+			suite.Require().NoError(err)
 			err = suite.committeeKeeper.AddVote(suite.ctx, proposalID, committeeMemberTwo)
+			suite.Require().NoError(err)
 
 			// 6. Check proposal passed
 			proposalPasses, err := suite.committeeKeeper.GetProposalResult(suite.ctx, proposalID)

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -61,7 +61,7 @@ func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite,
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_borrow_unit_test.go
+++ b/x/incentive/keeper/rewards_borrow_unit_test.go
@@ -1,0 +1,232 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	db "github.com/tendermint/tm-db"
+
+	"github.com/kava-labs/kava/app"
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive"
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// NewTestContext sets up a basic context with an in-memory db
+func NewTestContext(requiredStoreKeys ...sdk.StoreKey) sdk.Context {
+	memDB := db.NewMemDB()
+	cms := store.NewCommitMultiStore(memDB)
+
+	for _, key := range requiredStoreKeys {
+		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
+	}
+
+	cms.LoadLatestVersion()
+
+	return sdk.NewContext(cms, abci.Header{}, false, log.NewNopLogger())
+}
+
+// SynchronizeHardBorrowRewardTests runs unit tests for the keeper.SynchronizeHardBorrowReward method
+//
+// inputs
+// - claim in store (only claim.BorrowRewardIndexes, claim.Reward)
+// - global indexes in store
+// - borrow function arg (only borrow.Amount)
+//
+// outputs
+// - sets a claim
+type SynchronizeHardBorrowRewardTests struct {
+	suite.Suite
+	keeper keeper.Keeper
+	ctx    sdk.Context
+}
+
+func TestSynchronizeHardBorrowReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeHardBorrowRewardTests))
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) SetupTest() {
+	incentveStoreKey := sdk.NewKVStoreKey(types.StoreKey)
+	suite.keeper = suite.setupKeeper(incentveStoreKey)
+	suite.ctx = NewTestContext(incentveStoreKey)
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) TearDownTest() {
+	suite.keeper = keeper.Keeper{}
+	suite.ctx = sdk.Context{}
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) setupKeeper(incentiveStoreKey sdk.StoreKey) keeper.Keeper {
+	cdc := app.MakeCodec()
+	paramSubspace := params.NewKeeper(
+		cdc,
+		sdk.NewKVStoreKey(params.StoreKey),
+		sdk.NewTransientStoreKey(params.StoreKey), // TODO param subspace isn't used in the tests, replace with interface and use nil instead
+	).Subspace(incentive.DefaultParamspace)
+
+	return keeper.NewKeeper(cdc, incentiveStoreKey, paramSubspace, nil, nil, nil, nil, nil)
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) storeGlobalIndexes(indexes types.MultiRewardIndexes) {
+	for _, i := range indexes {
+		suite.keeper.SetHardBorrowRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
+	}
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) storeClaim(claim types.HardLiquidityProviderClaim) {
+	suite.keeper.SetHardLiquidityProviderClaim(suite.ctx, claim)
+}
+
+func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenGlobalIndexesAmountsIncreased() {
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalIndexes(
+		increaseAllRewardFactors(nonEmptyMultiRewardIndexes),
+	)
+
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(claim.BorrowRewardIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardBorrowReward(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.BorrowRewardIndexes, syncedClaim.BorrowRewardIndexes)
+}
+func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenGlobalIndexesHaveIncreased() {
+	originalReward := arbitraryCoins()
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  arbitraryAddress(),
+			Reward: originalReward,
+		},
+		BorrowRewardIndexes: types.MultiRewardIndexes{
+			{
+				CollateralType: "borrowdenom",
+				RewardIndexes: types.RewardIndexes{
+					{
+						CollateralType: "rewarddenom",
+						RewardFactor:   d("1000.001"),
+					},
+				},
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalIndexes(types.MultiRewardIndexes{
+		{
+			CollateralType: "borrowdenom",
+			RewardIndexes: types.RewardIndexes{
+				{
+					CollateralType: "rewarddenom",
+					RewardFactor:   d("2000.002"),
+				},
+			},
+		},
+	})
+
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   cs(c("borrowdenom", 1e9)),
+	}
+
+	suite.keeper.SynchronizeHardBorrowReward(suite.ctx, borrow)
+
+	// new reward is (new index - old index) * borrow amount
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(
+		cs(c("rewarddenom", 1_000_001_000_000)).Add(originalReward...),
+		syncedClaim.Reward,
+	)
+}
+
+func arbitraryCoins() sdk.Coins {
+	return cs(c("btcb", 1))
+}
+
+func arbitraryCoinsWithDenoms(denom ...string) sdk.Coins {
+	const arbitraryAmount = 1 // must be > 0 as sdk.Coins type only stores positive amounts
+	coins := sdk.NewCoins()
+	for _, d := range denom {
+		coins.Add(sdk.NewInt64Coin(d, arbitraryAmount))
+	}
+	return coins
+}
+
+func arbitraryAddress() sdk.AccAddress {
+	_, addresses := app.GeneratePrivKeyAddressPairs(1)
+	return addresses[0]
+}
+
+var nonEmptyMultiRewardIndexes = types.MultiRewardIndexes{
+	{
+		CollateralType: "btcb",
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: "hard",
+				RewardFactor:   d("0.2"),
+			},
+			{
+				CollateralType: "ukava",
+				RewardFactor:   d("0.4"),
+			},
+		},
+	},
+	{
+		CollateralType: "bnb",
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: "hard",
+				RewardFactor:   d("0.02"),
+			},
+			{
+				CollateralType: "ukava",
+				RewardFactor:   d("0.04"),
+			},
+		},
+	},
+}
+
+func extractCollateralTypes(indexes types.MultiRewardIndexes) []string {
+	var denoms []string
+	for _, ri := range indexes {
+		denoms = append(denoms, ri.CollateralType)
+	}
+	return denoms
+}
+
+func increaseAllRewardFactors(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
+	increasedIndexes := make(types.MultiRewardIndexes, len(indexes))
+	copy(increasedIndexes, indexes)
+
+	for i := range increasedIndexes {
+		increasedIndexes[i].RewardIndexes = increaseRewardFactors(increasedIndexes[i].RewardIndexes)
+	}
+	return increasedIndexes
+}
+
+func increaseRewardFactors(indexes types.RewardIndexes) types.RewardIndexes {
+	increasedIndexes := make(types.RewardIndexes, len(indexes))
+	copy(increasedIndexes, indexes)
+
+	for i := range increasedIndexes {
+		increasedIndexes[i].RewardFactor = increasedIndexes[i].RewardFactor.MulInt64(2)
+	}
+	return increasedIndexes
+}

--- a/x/incentive/keeper/rewards_borrow_update_test.go
+++ b/x/incentive/keeper/rewards_borrow_update_test.go
@@ -1,0 +1,119 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// UpdateHardBorrowIndexDenomsTests runs unit tests for the keeper.UpdateHardBorrowIndexDenoms method
+//
+// inputs
+// - claim in store if it exists (only claim.BorrowRewardIndexes)
+// - global indexes in store
+// - borrow function arg (only borrow.Amount)
+//
+// outputs
+// - sets a claim
+type UpdateHardBorrowIndexDenomsTests struct {
+	unitTester
+}
+
+func TestUpdateHardBorrowIndexDenoms(t *testing.T) {
+	suite.Run(t, new(UpdateHardBorrowIndexDenomsTests))
+}
+
+func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreRemovedForDenomsNoLongerBorrowed() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	suite.storeGlobalIndexes(claim.BorrowRewardIndexes)
+
+	// remove one denom from the indexes already in the borrow
+	expectedIndexes := claim.BorrowRewardIndexes[1:]
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(expectedIndexes)...),
+	}
+
+	suite.keeper.UpdateHardBorrowIndexDenoms(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(expectedIndexes, syncedClaim.BorrowRewardIndexes)
+}
+
+func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreAddedForNewlyBorrowedDenoms() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	globalIndexes := appendUniqueMultiRewardIndex(claim.BorrowRewardIndexes)
+	suite.storeGlobalIndexes(globalIndexes)
+
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.UpdateHardBorrowIndexDenoms(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.BorrowRewardIndexes)
+}
+
+func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreUnchangedWhenBorrowedDenomsUnchanged() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	// Set global indexes with same denoms but different values.
+	// UpdateHardBorrowIndexDenoms should ignore the new values.
+	suite.storeGlobalIndexes(increaseAllRewardFactors(claim.BorrowRewardIndexes))
+
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(claim.BorrowRewardIndexes)...),
+	}
+
+	suite.keeper.UpdateHardBorrowIndexDenoms(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.BorrowRewardIndexes, syncedClaim.BorrowRewardIndexes)
+}
+
+func (suite *UpdateHardBorrowIndexDenomsTests) TestEmptyClaimIndexesAreAddedForNewlyBorrowedButNotRewardedDenoms() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	suite.storeGlobalIndexes(claim.BorrowRewardIndexes)
+
+	// add a denom to the borrowed amount that is not in the global or claim's indexes
+	expectedIndexes := appendUniqueEmptyMultiRewardIndex(claim.BorrowRewardIndexes)
+	borrowedDenoms := extractCollateralTypes(expectedIndexes)
+	borrow := hardtypes.Borrow{
+		Borrower: claim.Owner,
+		Amount:   arbitraryCoinsWithDenoms(borrowedDenoms...),
+	}
+
+	suite.keeper.UpdateHardBorrowIndexDenoms(suite.ctx, borrow)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(expectedIndexes, syncedClaim.BorrowRewardIndexes)
+}

--- a/x/incentive/keeper/rewards_borrow_update_test.go
+++ b/x/incentive/keeper/rewards_borrow_update_test.go
@@ -34,7 +34,7 @@ func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreRemovedForDeno
 		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
 	}
 	suite.storeClaim(claim)
-	suite.storeGlobalIndexes(claim.BorrowRewardIndexes)
+	suite.storeGlobalBorrowIndexes(claim.BorrowRewardIndexes)
 
 	// remove one denom from the indexes already in the borrow
 	expectedIndexes := claim.BorrowRewardIndexes[1:]
@@ -58,7 +58,7 @@ func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreAddedForNewlyB
 	}
 	suite.storeClaim(claim)
 	globalIndexes := appendUniqueMultiRewardIndex(claim.BorrowRewardIndexes)
-	suite.storeGlobalIndexes(globalIndexes)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -81,7 +81,7 @@ func (suite *UpdateHardBorrowIndexDenomsTests) TestClaimIndexesAreUnchangedWhenB
 	suite.storeClaim(claim)
 	// Set global indexes with same denoms but different values.
 	// UpdateHardBorrowIndexDenoms should ignore the new values.
-	suite.storeGlobalIndexes(increaseAllRewardFactors(claim.BorrowRewardIndexes))
+	suite.storeGlobalBorrowIndexes(increaseAllRewardFactors(claim.BorrowRewardIndexes))
 
 	borrow := hardtypes.Borrow{
 		Borrower: claim.Owner,
@@ -102,7 +102,7 @@ func (suite *UpdateHardBorrowIndexDenomsTests) TestEmptyClaimIndexesAreAddedForN
 		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
 	}
 	suite.storeClaim(claim)
-	suite.storeGlobalIndexes(claim.BorrowRewardIndexes)
+	suite.storeGlobalBorrowIndexes(claim.BorrowRewardIndexes)
 
 	// add a denom to the borrowed amount that is not in the global or claim's indexes
 	expectedIndexes := appendUniqueEmptyMultiRewardIndex(claim.BorrowRewardIndexes)

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -81,7 +81,7 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 
 	totalDelegated := k.GetTotalDelegated(ctx, delegator, valAddr, shouldIncludeValidator)
 
-	rewardsEarned := k.calculateSingleReward(userRewardFactor, delegatorFactor, totalDelegated.RoundInt()) // TODO fix rounding
+	rewardsEarned := k.calculateSingleReward(userRewardFactor, delegatorFactor, totalDelegated)
 	newRewardsCoin := sdk.NewCoin(types.HardLiquidityRewardDenom, rewardsEarned)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -65,6 +65,8 @@ func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.Acc
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }
 
+var TestHelper_TotalDelegated sdk.Dec
+
 // SynchronizeHardDelegatorRewards updates the claim object by adding any accumulated rewards, and setting the reward indexes to the global values.
 // valAddr and shouldIncludeValidator are used to ignore or include delegations to a particular validator when summing up the total delegation.
 // Normally only delegations to Bonded validators are included in the total. This is needed as staking hooks are sometimes called on the wrong side of a validator's state update (from this module's perspective).
@@ -122,6 +124,7 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 		}
 		totalDelegated = totalDelegated.Add(delegatedTokens)
 	}
+	TestHelper_TotalDelegated = totalDelegated
 	rewardsEarned := rewardsAccumulatedFactor.Mul(totalDelegated).RoundInt()
 
 	// Add rewards to delegator's hard claim

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -45,23 +45,20 @@ func (k Keeper) AccumulateHardDelegatorRewards(ctx sdk.Context, rewardPeriod typ
 
 // InitializeHardDelegatorReward initializes the delegator reward index of a hard claim
 func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.AccAddress) {
-	delegatorFactor, foundDelegatorFactor := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
-	if !foundDelegatorFactor { // Should always be found...
-		delegatorFactor = sdk.ZeroDec()
-	}
-
-	delegatorRewardIndexes := types.NewRewardIndex(types.BondDenom, delegatorFactor)
-
 	claim, found := k.GetHardLiquidityProviderClaim(ctx, delegator)
 	if !found {
-		// Instantiate claim object
 		claim = types.NewHardLiquidityProviderClaim(delegator, sdk.Coins{}, nil, nil, nil)
 	} else {
 		k.SynchronizeHardDelegatorRewards(ctx, delegator, nil, false)
 		claim, _ = k.GetHardLiquidityProviderClaim(ctx, delegator)
 	}
 
-	claim.DelegatorRewardIndexes = types.RewardIndexes{delegatorRewardIndexes}
+	delegatorFactor, foundDelegatorFactor := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
+	if !foundDelegatorFactor { // Should always be found...
+		delegatorFactor = sdk.ZeroDec()
+	}
+
+	claim.DelegatorRewardIndexes = types.RewardIndexes{types.NewRewardIndex(types.BondDenom, delegatorFactor)}
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }
 

--- a/x/incentive/keeper/rewards_delegator_init_test.go
+++ b/x/incentive/keeper/rewards_delegator_init_test.go
@@ -1,0 +1,115 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// InitializeHardDelegatorRewardTests runs unit tests for the keeper.InitializeHardDelegatorReward method
+//
+// inputs
+// - claim in store if it exists (only claim.DelegatorRewardIndexes)
+// - global indexes in store
+// - delegator function arg
+//
+// outputs
+// - sets or creates a claim
+type InitializeHardDelegatorRewardTests struct {
+	unitTester
+}
+
+func TestInitializeHardDelegatorReward(t *testing.T) {
+	suite.Run(t, new(InitializeHardDelegatorRewardTests))
+}
+
+func (suite *InitializeHardDelegatorRewardTests) storeGlobalDelegatorFactor(rewardIndexes types.RewardIndexes) {
+	factor := rewardIndexes[0]
+	suite.keeper.SetHardDelegatorRewardFactor(suite.ctx, factor.CollateralType, factor.RewardFactor)
+}
+
+func (suite *InitializeHardDelegatorRewardTests) TestClaimIndexesAreSetWhenClaimDoesNotExist() {
+	globalIndex := arbitraryDelegatorRewardIndexes
+	suite.storeGlobalDelegatorFactor(globalIndex)
+
+	delegator := arbitraryAddress()
+	suite.keeper.InitializeHardDelegatorReward(suite.ctx, delegator)
+
+	syncedClaim, f := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, delegator)
+	suite.True(f)
+	suite.Equal(globalIndex, syncedClaim.DelegatorRewardIndexes)
+}
+
+func (suite *InitializeHardDelegatorRewardTests) TestClaimIsSyncedAndIndexesAreSetWhenClaimDoesExist() {
+	validatorAddress := arbitraryValidatorAddress()
+	sk := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{{
+			ValidatorAddress: validatorAddress,
+			Shares:           d("1000"),
+		}},
+		validators: stakingtypes.Validators{{
+			OperatorAddress: validatorAddress,
+			Status:          sdk.Bonded,
+			Tokens:          i(1000),
+			DelegatorShares: d("1000"),
+		}},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, sk)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	// Set the global factor to a value different to one in claim so
+	// we can detect if it is overwritten.
+	globalIndex := increaseRewardFactors(claim.DelegatorRewardIndexes)
+	suite.storeGlobalDelegatorFactor(globalIndex)
+
+	suite.keeper.InitializeHardDelegatorReward(suite.ctx, claim.Owner)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndex, syncedClaim.DelegatorRewardIndexes)
+	suite.Truef(syncedClaim.Reward.IsAllGT(claim.Reward), "'%s' not greater than '%s'", syncedClaim.Reward, claim.Reward)
+}
+
+// arbitraryDelegatorRewardIndexes contains only one reward index as there is only every one bond denom
+var arbitraryDelegatorRewardIndexes = types.RewardIndexes{
+	types.NewRewardIndex(types.BondDenom, d("0.2")),
+}
+
+type fakeStakingKeeper struct {
+	delegations stakingtypes.Delegations
+	validators  stakingtypes.Validators
+}
+
+func (k fakeStakingKeeper) TotalBondedTokens(ctx sdk.Context) sdk.Int {
+	panic("unimplemented")
+}
+func (k fakeStakingKeeper) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress, maxRetrieve uint16) []stakingtypes.Delegation {
+	return k.delegations
+}
+func (k fakeStakingKeeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (stakingtypes.Validator, bool) {
+	for _, val := range k.validators {
+		if val.GetOperator().Equals(addr) {
+			return val, true
+		}
+	}
+	return stakingtypes.Validator{}, false
+}
+func (k fakeStakingKeeper) GetValidatorDelegations(ctx sdk.Context, valAddr sdk.ValAddress) []stakingtypes.Delegation {
+	var delegations stakingtypes.Delegations
+	for _, d := range k.delegations {
+		if d.ValidatorAddress.Equals(valAddr) {
+			delegations = append(delegations, d)
+		}
+	}
+	return delegations
+}

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -1,0 +1,356 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// SynchronizeHardDelegatorRewardTests runs unit tests for the keeper.SynchronizeHardDelegatorReward method
+//
+// inputs
+// - claim in store if it exists (only claim.DelegatorRewardIndexes and claim.Reward)
+// - global index in store
+// - function args: delegator address, validator address, shouldIncludeValidator flag
+// - delegator's delegations and the corresponding validators
+//
+// outputs
+// - sets or creates a claim
+type SynchronizeHardDelegatorRewardTests struct {
+	unitTester
+}
+
+func TestSynchronizeHardDelegatorReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeHardDelegatorRewardTests))
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) storeGlobalDelegatorFactor(rewardIndexes types.RewardIndexes) {
+	factor := rewardIndexes[0]
+	suite.keeper.SetHardDelegatorRewardFactor(suite.ctx, factor.CollateralType, factor.RewardFactor)
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestClaimIndexesAreUnchangedWhenGlobalFactorUnchanged() {
+	delegator := arbitraryAddress()
+
+	stakingKeeper := fakeStakingKeeper{} // use an empty staking keeper that returns no delegations
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: delegator,
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.DelegatorRewardIndexes, syncedClaim.DelegatorRewardIndexes)
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestClaimIndexesAreUpdatedWhenGlobalFactorIncreased() {
+	delegator := arbitraryAddress()
+
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, fakeStakingKeeper{})
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: delegator,
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claim.DelegatorRewardIndexes)
+	suite.storeGlobalDelegatorFactor(globalIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.DelegatorRewardIndexes)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsUnchangedWhenGlobalFactorUnchanged() {
+	delegator := arbitraryAddress()
+	validatorAddress := arbitraryValidatorAddress()
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddress,
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddress),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: types.RewardIndexes{{
+			CollateralType: types.BondDenom,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+
+	suite.Equal(claim.Reward, syncedClaim.Reward)
+}
+
+// No test for TestRewardIsIncrementedWhenNewRewardAdded as we can currently only have one reward denom for our one bond denom.
+// So new rewards cannot be added.
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsIncreasedWhenGlobalFactorIncreased() {
+	delegator := arbitraryAddress()
+	validatorAddress := arbitraryValidatorAddress()
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddress,
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddress),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: types.RewardIndexes{{
+			CollateralType: types.BondDenom,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(
+		types.RewardIndexes{
+			types.NewRewardIndex(types.BondDenom, d("0.2")),
+		},
+	)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+
+	suite.Equal(
+		cs(c(types.HardLiquidityRewardDenom, 100)).Add(claim.Reward...),
+		syncedClaim.Reward,
+	)
+}
+
+func unslashedBondedValidator(address sdk.ValAddress) stakingtypes.Validator {
+	return stakingtypes.Validator{
+		OperatorAddress: address,
+		Status:          sdk.Bonded,
+
+		// Set the tokens and shares equal so then
+		// a _delegator's_ token amount is equal to their shares amount
+		Tokens:          i(1e12),
+		DelegatorShares: i(1e12).ToDec(),
+	}
+}
+func unslashedNotBondedValidator(address sdk.ValAddress) stakingtypes.Validator {
+	return stakingtypes.Validator{
+		OperatorAddress: address,
+		Status:          sdk.Unbonding,
+
+		// Set the tokens and shares equal so then
+		// a _delegator's_ token amount is equal to their shares amount
+		Tokens:          i(1e12),
+		DelegatorShares: i(1e12).ToDec(),
+	}
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenValAddrIsNil() {
+	// when valAddr is nil, get total delegated to bonded validators
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	suite.Equal(
+		d("11"), // delegation to bonded validators
+		keeper.TestHelper_TotalDelegated,
+	)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingAValidator() {
+	// when valAddr is x, get total delegated to bonded validators excluding those to x
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[0], false)
+
+	suite.Equal(
+		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
+		keeper.TestHelper_TotalDelegated,
+	)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingAValidator() {
+	// when valAddr is x, get total delegated to bonded validators including those to x
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[2], true)
+
+	suite.Equal(
+		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
+		keeper.TestHelper_TotalDelegated,
+	)
+}

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -7,7 +7,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
@@ -224,22 +223,9 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenValAddrIsN
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
-
 	suite.Equal(
 		d("11"), // delegation to bonded validators
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, nil, false),
 	)
 }
 func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingAValidator() {
@@ -280,22 +266,9 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingA
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[0], false)
-
 	suite.Equal(
 		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[0], false),
 	)
 }
 func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingAValidator() {
@@ -336,21 +309,8 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingA
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[2], true)
-
 	suite.Equal(
 		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[2], true),
 	)
 }

--- a/x/incentive/keeper/rewards_delegator_test.go
+++ b/x/incentive/keeper/rewards_delegator_test.go
@@ -53,7 +53,7 @@ func (suite *DelegatorRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *DelegatorRewardsTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
+func (suite *DelegatorRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -106,7 +106,7 @@ func (suite *DelegatorRewardsTestSuite) TestAccumulateHardDelegatorRewards() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
@@ -185,7 +185,7 @@ func (suite *DelegatorRewardsTestSuite) TestSynchronizeHardDelegatorReward() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
@@ -290,7 +290,7 @@ func (suite *DelegatorRewardsTestSuite) TestSimulateHardDelegatorRewardSynchroni
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
@@ -388,7 +388,7 @@ func (suite *DelegatorRewardsTestSuite) deliverMsgRedelegate(ctx sdk.Context, de
 
 // given a user has a delegation to a bonded validator, when the validator starts unbonding, the user does not accumulate rewards
 func (suite *DelegatorRewardsTestSuite) TestUnbondingValidatorSyncsClaim() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 		WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
@@ -478,7 +478,7 @@ func (suite *DelegatorRewardsTestSuite) TestUnbondingValidatorSyncsClaim() {
 
 // given a user has a delegation to an unbonded validator, when the validator becomes bonded, the user starts accumulating rewards
 func (suite *DelegatorRewardsTestSuite) TestBondingValidatorSyncsClaim() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 		WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
@@ -568,7 +568,7 @@ func (suite *DelegatorRewardsTestSuite) TestBondingValidatorSyncsClaim() {
 
 // If a validator is slashed delegators should have their claims synced
 func (suite *DelegatorRewardsTestSuite) TestSlashingValidatorSyncsClaim() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9)))
@@ -649,7 +649,7 @@ func (suite *DelegatorRewardsTestSuite) TestSlashingValidatorSyncsClaim() {
 
 // Given a delegation to a bonded validator, when a user redelegates everything to another (bonded) validator, the user's claim is synced
 func (suite *DelegatorRewardsTestSuite) TestRedelegationSyncsClaim() {
-	authBuilder := NewAuthGenesisBuilder().
+	authBuilder := app.NewAuthGenesisBuilder().
 		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
 		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9)))

--- a/x/incentive/keeper/rewards_delegator_test.go
+++ b/x/incentive/keeper/rewards_delegator_test.go
@@ -60,11 +60,11 @@ func (suite *DelegatorRewardsTestSuite) getAllAddrs() []sdk.AccAddress {
 	return accAddrs
 }
 
-func (suite *DelegatorRewardsTestSuite) SetupWithGenState() {
+func (suite *DelegatorRewardsTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStates(
-		NewAuthGenState(suite.getAllAddrs(), cs(c("ukava", 1_000_000_000))),
+		authBuilder.BuildMarshalled(),
 		NewStakingGenesisState(),
 	)
 }
@@ -115,7 +115,10 @@ func (suite *DelegatorRewardsTestSuite) TestAccumulateHardDelegatorRewards() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			suite.SetupWithGenState()
+			authBuilder := NewAuthGenesisBuilder().
+				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
+			suite.SetupWithGenState(authBuilder)
 			suite.ctx = suite.ctx.WithBlockTime(tc.args.initialTime)
 
 			// Set up incentive state
@@ -204,7 +207,10 @@ func (suite *DelegatorRewardsTestSuite) TestSynchronizeHardDelegatorReward() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			suite.SetupWithGenState()
+			authBuilder := NewAuthGenesisBuilder().
+				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
+			suite.SetupWithGenState(authBuilder)
 			suite.ctx = suite.ctx.WithBlockTime(tc.args.initialTime)
 
 			// setup incentive state
@@ -318,7 +324,10 @@ func (suite *DelegatorRewardsTestSuite) TestSimulateHardDelegatorRewardSynchroni
 
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			suite.SetupWithGenState()
+			authBuilder := NewAuthGenesisBuilder().
+				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
+			suite.SetupWithGenState(authBuilder)
 			suite.ctx = suite.ctx.WithBlockTime(tc.args.initialTime)
 
 			// setup incentive state
@@ -422,7 +431,13 @@ func (suite *DelegatorRewardsTestSuite) deliverMsgRedelegate(ctx sdk.Context, de
 
 // given a user has a delegation to a bonded validator, when the validator starts unbonding, the user does not accumulate rewards
 func (suite *DelegatorRewardsTestSuite) TestUnbondingValidatorSyncsClaim() {
-	suite.SetupWithGenState()
+	authBuilder := NewAuthGenesisBuilder().
+		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+		WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[2]), cs(c("ukava", 1e9)))
+	suite.SetupWithGenState(authBuilder)
 	initialTime := time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
 	suite.ctx = suite.ctx.WithBlockTime(initialTime)
 	blockDuration := 10 * time.Second
@@ -516,7 +531,13 @@ func (suite *DelegatorRewardsTestSuite) TestUnbondingValidatorSyncsClaim() {
 
 // given a user has a delegation to an unbonded validator, when the validator becomes bonded, the user starts accumulating rewards
 func (suite *DelegatorRewardsTestSuite) TestBondingValidatorSyncsClaim() {
-	suite.SetupWithGenState()
+	authBuilder := NewAuthGenesisBuilder().
+		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+		WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[2]), cs(c("ukava", 1e9)))
+	suite.SetupWithGenState(authBuilder)
 	initialTime := time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
 	suite.ctx = suite.ctx.WithBlockTime(initialTime)
 	blockDuration := 10 * time.Second
@@ -610,7 +631,11 @@ func (suite *DelegatorRewardsTestSuite) TestBondingValidatorSyncsClaim() {
 
 // If a validator is slashed delegators should have their claims synced
 func (suite *DelegatorRewardsTestSuite) TestSlashingValidatorSyncsClaim() {
-	suite.SetupWithGenState()
+	authBuilder := NewAuthGenesisBuilder().
+		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9)))
+	suite.SetupWithGenState(authBuilder)
 	initialTime := time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
 	suite.ctx = suite.ctx.WithBlockTime(initialTime)
 	blockDuration := 10 * time.Second
@@ -697,7 +722,11 @@ func (suite *DelegatorRewardsTestSuite) TestSlashingValidatorSyncsClaim() {
 
 // Given a delegation to a bonded validator, when a user redelegates everything to another (bonded) validator, the user's claim is synced
 func (suite *DelegatorRewardsTestSuite) TestRedelegationSyncsClaim() {
-	suite.SetupWithGenState()
+	authBuilder := NewAuthGenesisBuilder().
+		WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9))).
+		WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[1]), cs(c("ukava", 1e9)))
+	suite.SetupWithGenState(authBuilder)
 	initialTime := time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
 	suite.ctx = suite.ctx.WithBlockTime(initialTime)
 	blockDuration := 10 * time.Second

--- a/x/incentive/keeper/rewards_delegator_test.go
+++ b/x/incentive/keeper/rewards_delegator_test.go
@@ -53,14 +53,14 @@ func (suite *DelegatorRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *DelegatorRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
+func (suite *DelegatorRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder IncentiveGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
 		suite.genesisTime,
 		authBuilder.BuildMarshalled(),
 		NewStakingGenesisState(),
-		incentBuilder.buildMarshalled(),
+		incentBuilder.BuildMarshalled(),
 	)
 }
 
@@ -110,9 +110,9 @@ func (suite *DelegatorRewardsTestSuite) TestAccumulateHardDelegatorRewards() {
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -189,9 +189,9 @@ func (suite *DelegatorRewardsTestSuite) TestSynchronizeHardDelegatorReward() {
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -294,9 +294,9 @@ func (suite *DelegatorRewardsTestSuite) TestSimulateHardDelegatorRewardSynchroni
 				WithSimpleAccount(suite.addrs[0], cs(c("ukava", 1e9))).
 				WithSimpleAccount(sdk.AccAddress(suite.validatorAddrs[0]), cs(c("ukava", 1e9)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleDelegatorRewardPeriod(tc.args.delegation.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -398,9 +398,9 @@ func (suite *DelegatorRewardsTestSuite) TestUnbondingValidatorSyncsClaim() {
 	rewardsPerSecond := c("hard", 122354)
 	bondDenom := "ukava"
 
-	incentBuilder := newIncentiveGenesisBuilder().
-		withGenesisTime(suite.genesisTime).
-		withSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
+	incentBuilder := NewIncentiveGenesisBuilder().
+		WithGenesisTime(suite.genesisTime).
+		WithSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
 
 	suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -488,9 +488,9 @@ func (suite *DelegatorRewardsTestSuite) TestBondingValidatorSyncsClaim() {
 	rewardsPerSecond := c("hard", 122354)
 	bondDenom := "ukava"
 
-	incentBuilder := newIncentiveGenesisBuilder().
-		withGenesisTime(suite.genesisTime).
-		withSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
+	incentBuilder := NewIncentiveGenesisBuilder().
+		WithGenesisTime(suite.genesisTime).
+		WithSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
 
 	suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -576,9 +576,9 @@ func (suite *DelegatorRewardsTestSuite) TestSlashingValidatorSyncsClaim() {
 	rewardsPerSecond := c("hard", 122354)
 	bondDenom := "ukava"
 
-	incentBuilder := newIncentiveGenesisBuilder().
-		withGenesisTime(suite.genesisTime).
-		withSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
+	incentBuilder := NewIncentiveGenesisBuilder().
+		WithGenesisTime(suite.genesisTime).
+		WithSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
 
 	suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -657,9 +657,9 @@ func (suite *DelegatorRewardsTestSuite) TestRedelegationSyncsClaim() {
 	rewardsPerSecond := c("hard", 122354)
 	bondDenom := "ukava"
 
-	incentBuilder := newIncentiveGenesisBuilder().
-		withGenesisTime(suite.genesisTime).
-		withSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
+	incentBuilder := NewIncentiveGenesisBuilder().
+		WithGenesisTime(suite.genesisTime).
+		WithSimpleDelegatorRewardPeriod(bondDenom, rewardsPerSecond)
 
 	suite.SetupWithGenState(authBuilder, incentBuilder)
 

--- a/x/incentive/keeper/rewards_delegator_test.go
+++ b/x/incentive/keeper/rewards_delegator_test.go
@@ -102,7 +102,7 @@ func (suite *KeeperTestSuite) TestAccumulateHardDelegatorRewards() {
 			err = suite.keeper.AccumulateHardDelegatorRewards(runCtx, rewardPeriod)
 			suite.Require().NoError(err)
 
-			rewardFactor, found := suite.keeper.GetHardDelegatorRewardFactor(runCtx, tc.args.delegation.Denom)
+			rewardFactor, _ := suite.keeper.GetHardDelegatorRewardFactor(runCtx, tc.args.delegation.Denom)
 			suite.Require().Equal(tc.args.expectedRewardFactor, rewardFactor)
 		})
 	}
@@ -232,7 +232,7 @@ func (suite *KeeperTestSuite) TestSynchronizeHardDelegatorReward() {
 			})
 
 			// Check that reward factor and claim have been updated as expected
-			rewardFactor, found := suite.keeper.GetHardDelegatorRewardFactor(suite.ctx, tc.args.delegation.Denom)
+			rewardFactor, _ := suite.keeper.GetHardDelegatorRewardFactor(suite.ctx, tc.args.delegation.Denom)
 			suite.Require().Equal(tc.args.expectedRewardFactor, rewardFactor)
 
 			claim, found = suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, suite.addrs[0])

--- a/x/incentive/keeper/rewards_supply.go
+++ b/x/incentive/keeper/rewards_supply.go
@@ -117,7 +117,7 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 			continue
 		}
 
-		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount)
+		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())
 		if err != nil {
 			// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
 			// This panics if a global reward factor decreases or disappears between the old and new indexes.

--- a/x/incentive/keeper/rewards_supply_init_test.go
+++ b/x/incentive/keeper/rewards_supply_init_test.go
@@ -1,0 +1,89 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// InitializeHardSupplyRewardTests runs unit tests for the keeper.InitializeHardSupplyReward method
+//
+// inputs
+// - claim in store if it exists (only claim.SupplyRewardIndexes)
+// - global indexes in store
+// - deposit function arg (only deposit.Amount)
+//
+// outputs
+// - sets or creates a claim
+type InitializeHardSupplyRewardTests struct {
+	unitTester
+}
+
+func TestInitializeHardSupplyReward(t *testing.T) {
+	suite.Run(t, new(InitializeHardSupplyRewardTests))
+}
+
+func (suite *InitializeHardSupplyRewardTests) TestClaimIndexesAreSetWhenClaimExists() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		// Indexes should always be empty when initialize is called.
+		// If initialize is called then the user must have repaid their deposit positions,
+		// which means UpdateHardSupplyIndexDenoms was called and should have remove indexes.
+		SupplyRewardIndexes: types.MultiRewardIndexes{},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.InitializeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+func (suite *InitializeHardSupplyRewardTests) TestClaimIndexesAreSetWhenClaimDoesNotExist() {
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	owner := arbitraryAddress()
+	deposit := hardtypes.Deposit{
+		Depositor: owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.InitializeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, found := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, owner)
+	suite.True(found)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+func (suite *InitializeHardSupplyRewardTests) TestClaimIndexesAreSetEmptyForMissingIndexes() {
+
+	globalIndexes := nonEmptyMultiRewardIndexes
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	owner := arbitraryAddress()
+	// Supply a denom that is not in the global indexes.
+	// This happens when a deposit denom has no rewards associated with it.
+	expectedIndexes := appendUniqueEmptyMultiRewardIndex(globalIndexes)
+	depositedDenoms := extractCollateralTypes(expectedIndexes)
+	deposit := hardtypes.Deposit{
+		Depositor: owner,
+		Amount:    arbitraryCoinsWithDenoms(depositedDenoms...),
+	}
+
+	suite.keeper.InitializeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, owner)
+	suite.Equal(expectedIndexes, syncedClaim.SupplyRewardIndexes)
+}

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -100,6 +100,32 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
 	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
 }
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAddedWithZeroRewardsPerSecond() {
+	// When a new reward (with zero rewards per second) is added (via gov) for a hard deposited denom the user has already deposited, and the claim is synced;
+	// Then the new reward's index should be added to the claim.
+	suite.T().Skip("TODO fix this bug")
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := nonEmptyMultiRewardIndexes.With("uniquezerorps", nil)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the new reward coin's index should be added to the claim.

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -180,7 +180,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenGlobal
 	)
 }
 
-func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardAdded() {
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
 	suite.T().Skip("TODO fix this bug")
@@ -244,7 +244,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNe
 		syncedClaim.Reward,
 	)
 }
-func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardDenomAdded() {
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the user earns rewards for the time since the reward was added
 

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -1,0 +1,304 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// SynchronizeHardSupplyRewardTests runs unit tests for the keeper.SynchronizeHardSupplyReward method
+//
+// inputs
+// - claim in store (only claim.SupplyRewardIndexes, claim.Reward)
+// - global indexes in store
+// - deposit function arg (only deposit.Amount)
+//
+// outputs
+// - sets a claim
+type SynchronizeHardSupplyRewardTests struct {
+	unitTester
+}
+
+func TestSynchronizeHardSupplyReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeHardSupplyRewardTests))
+}
+
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenGlobalIndexesHaveIncreased() {
+	// This is the normal case
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseAllRewardFactors(nonEmptyMultiRewardIndexes)
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(claim.SupplyRewardIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUnchangedWhenGlobalIndexesUnchanged() {
+	// It should be safe to call SynchronizeHardSupplyReward multiple times
+
+	unchangingIndexes := nonEmptyMultiRewardIndexes
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: unchangingIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalSupplyIndexes(unchangingIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(unchangingIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(unchangingIndexes, syncedClaim.SupplyRewardIndexes)
+}
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAdded() {
+	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced;
+	// Then the new reward's index should be added to the claim.
+	suite.T().Skip("TODO fix this bug")
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := appendUniqueMultiRewardIndex(nonEmptyMultiRewardIndexes)
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
+	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
+	// Then the new reward coin's index should be added to the claim.
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := appendUniqueRewardIndexToFirstItem(nonEmptyMultiRewardIndexes)
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenGlobalIndexesHaveIncreased() {
+	// This is the normal case
+	// Given some time has passed (meaning the global indexes have increased)
+	// When the claim is synced
+	// The user earns rewards for the time passed
+
+	originalReward := arbitraryCoins()
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  arbitraryAddress(),
+			Reward: originalReward,
+		},
+		SupplyRewardIndexes: types.MultiRewardIndexes{
+			{
+				CollateralType: "depositdenom",
+				RewardIndexes: types.RewardIndexes{
+					{
+						CollateralType: "rewarddenom",
+						RewardFactor:   d("1000.001"),
+					},
+				},
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalSupplyIndexes(types.MultiRewardIndexes{
+		{
+			CollateralType: "depositdenom",
+			RewardIndexes: types.RewardIndexes{
+				{
+					CollateralType: "rewarddenom",
+					RewardFactor:   d("2000.002"),
+				},
+			},
+		},
+	})
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    cs(c("depositdenom", 1e9)),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	// new reward is (new index - old index) * deposit amount
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(
+		cs(c("rewarddenom", 1_000_001_000_000)).Add(originalReward...),
+		syncedClaim.Reward,
+	)
+}
+
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardAdded() {
+	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced
+	// Then the user earns rewards for the time since the reward was added
+	suite.T().Skip("TODO fix this bug")
+
+	originalReward := arbitraryCoins()
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  arbitraryAddress(),
+			Reward: originalReward,
+		},
+		SupplyRewardIndexes: types.MultiRewardIndexes{
+			{
+				CollateralType: "rewarded",
+				RewardIndexes: types.RewardIndexes{
+					{
+						CollateralType: "reward",
+						RewardFactor:   d("1000.001"),
+					},
+				},
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.MultiRewardIndexes{
+		{
+			CollateralType: "rewarded",
+			RewardIndexes: types.RewardIndexes{
+				{
+					CollateralType: "reward",
+					RewardFactor:   d("2000.002"),
+				},
+			},
+		},
+		{
+			CollateralType: "newlyrewarded",
+			RewardIndexes: types.RewardIndexes{
+				{
+					CollateralType: "otherreward",
+					// Indexes start at 0 when the reward is added by gov,
+					// so this represents the syncing happening some time later.
+					RewardFactor: d("1000.001"),
+				},
+			},
+		},
+	}
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    cs(c("rewarded", 1e9), c("newlyrewarded", 1e9)),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	// new reward is (new index - old index) * deposit amount for each deposited denom
+	// The old index for `newlyrewarded` isn't in the claim, so it's added starting at 0 for calculating the reward.
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(
+		cs(c("otherreward", 1_000_001_000_000), c("reward", 1_000_001_000_000)).Add(originalReward...),
+		syncedClaim.Reward,
+	)
+}
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardDenomAdded() {
+	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
+	// Then the user earns rewards for the time since the reward was added
+
+	originalReward := arbitraryCoins()
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  arbitraryAddress(),
+			Reward: originalReward,
+		},
+		SupplyRewardIndexes: types.MultiRewardIndexes{
+			{
+				CollateralType: "deposited",
+				RewardIndexes: types.RewardIndexes{
+					{
+						CollateralType: "reward",
+						RewardFactor:   d("1000.001"),
+					},
+				},
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.MultiRewardIndexes{
+		{
+			CollateralType: "deposited",
+			RewardIndexes: types.RewardIndexes{
+				{
+					CollateralType: "reward",
+					RewardFactor:   d("2000.002"),
+				},
+				{
+					CollateralType: "otherreward",
+					// Indexes start at 0 when the reward is added by gov,
+					// so this represents the syncing happening some time later.
+					RewardFactor: d("1000.001"),
+				},
+			},
+		},
+	}
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    cs(c("deposited", 1e9)),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	// new reward is (new index - old index) * deposit amount for each deposited denom
+	// The old index for `otherreward` isn't in the claim, so it's added starting at 0 for calculating the reward.
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(
+		cs(c("reward", 1_000_001_000_000), c("otherreward", 1_000_001_000_000)).Add(originalReward...),
+		syncedClaim.Reward,
+	)
+}

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -742,7 +742,9 @@ func (suite *KeeperTestSuite) TestSynchronizeHardSupplyReward() {
 
 			// 5. Committee votes and passes proposal
 			err = suite.committeeKeeper.AddVote(suite.ctx, proposalID, committeeMemberOne)
+			suite.Require().NoError(err)
 			err = suite.committeeKeeper.AddVote(suite.ctx, proposalID, committeeMemberTwo)
+			suite.Require().NoError(err)
 
 			// 6. Check proposal passed
 			proposalPasses, err := suite.committeeKeeper.GetProposalResult(suite.ctx, proposalID)

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -53,7 +53,7 @@ func (suite *SupplyRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -166,7 +166,7 @@ func (suite *SupplyRewardsTestSuite) TestAccumulateHardSupplyRewards() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
@@ -320,7 +320,7 @@ func (suite *SupplyRewardsTestSuite) TestInitializeHardSupplyRewards() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
@@ -550,7 +550,7 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().
+			authBuilder := app.NewAuthGenesisBuilder().
 				WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
@@ -852,7 +852,7 @@ func (suite *SupplyRewardsTestSuite) TestUpdateHardSupplyIndexDenoms() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
@@ -936,7 +936,7 @@ func (suite *SupplyRewardsTestSuite) TestSimulateHardSupplyRewardSynchronization
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			userAddr := suite.addrs[3]
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -153,15 +153,7 @@ func (suite *SupplyRewardsTestSuite) TestAccumulateHardSupplyRewards() {
 				},
 			},
 		},
-		// {
-		// 	"single reward denom, no rewards",
-		// 	args{
-		// 		deposit:               c("bnb", 1000000000000),
-		// 		rewardsPerSecond:      nil,
-		// 		timeElapsed:           7,
-		// 		expectedRewardIndexes: types.RewardIndexes{},
-		// 	},
-		// },
+		// TODO test accumulate when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
@@ -444,25 +436,6 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updateRewardsViaCommmittee: false,
 			},
 		},
-		// {
-		// 	"denom is in incentive's hard supply reward params but it has no rewards; add reward",
-		// 	args{
-		// 		incentiveSupplyRewardDenom: "bnb",
-		// 		deposit:                    c("bnb", 10000000000),
-		// 		rewardsPerSecond:           sdk.Coins{},
-		// 		blockTimes:                 []int{100},
-		// 		expectedRewardIndexes:      types.RewardIndexes{},
-		// 		expectedRewards:            sdk.Coins{},
-		// 		updateRewardsViaCommmittee: true,
-		// 		updatedBaseDenom:           "bnb",
-		// 		updatedRewardsPerSecond:    cs(c("hard", 100000)),
-		// 		updatedExpectedRewards:     cs(c("hard", 8640000000)),
-		// 		updatedExpectedRewardIndexes: types.RewardIndexes{
-		// 			types.NewRewardIndex("hard", d("0.864")),
-		// 		},
-		// 		updatedTimeDuration: 86400,
-		// 	},
-		// },
 		{
 			"denom is in incentive's hard supply reward params and has rewards; add new reward type",
 			args{
@@ -504,27 +477,6 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// {
-		// 	"denom incentive's hard supply reward params but it has no rewards; add multiple reward types",
-		// 	args{
-		// 		incentiveSupplyRewardDenom: "bnb",
-		// 		deposit:                    c("bnb", 10000000000),
-		// 		rewardsPerSecond:           sdk.Coins{},
-		// 		blockTimes:                 []int{100},
-		// 		expectedRewardIndexes:      types.RewardIndexes{},
-		// 		expectedRewards:            sdk.Coins{},
-		// 		updateRewardsViaCommmittee: true,
-		// 		updatedBaseDenom:           "bnb",
-		// 		updatedRewardsPerSecond:    cs(c("hard", 100000), c("ukava", 100500), c("swap", 500)),
-		// 		updatedExpectedRewards:     cs(c("hard", 8640000000), c("ukava", 8683200000), c("swap", 43200000)),
-		// 		updatedExpectedRewardIndexes: types.RewardIndexes{
-		// 			types.NewRewardIndex("hard", d("0.864")),
-		// 			types.NewRewardIndex("ukava", d("0.86832")),
-		// 			types.NewRewardIndex("swap", d("0.00432")),
-		// 		},
-		// 		updatedTimeDuration: 86400,
-		// 	},
-		// },
 		{
 			"denom is in hard's money market params but not in incentive's hard supply reward params; add multiple reward types",
 			args{
@@ -546,6 +498,7 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
+		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -53,7 +53,7 @@ func (suite *SupplyRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
+func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder IncentiveGenesisBuilder, hardBuilder HardGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -62,7 +62,7 @@ func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
 		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
-		incentBuilder.buildMarshalled(),
+		incentBuilder.BuildMarshalled(),
 	)
 }
 
@@ -171,10 +171,10 @@ func (suite *SupplyRewardsTestSuite) TestAccumulateHardSupplyRewards() {
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
 			// suite.SetupWithGenState(authBuilder)
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime)
 			if tc.args.rewardsPerSecond != nil {
-				incentBuilder = incentBuilder.withSimpleSupplyRewardPeriod(tc.args.deposit.Denom, tc.args.rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleSupplyRewardPeriod(tc.args.deposit.Denom, tc.args.rewardsPerSecond)
 			}
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
@@ -325,9 +325,9 @@ func (suite *SupplyRewardsTestSuite) TestInitializeHardSupplyRewards() {
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
 
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime)
 			for moneyMarketDenom, rewardsPerSecond := range tc.args.moneyMarketRewardDenoms {
-				incentBuilder = incentBuilder.withSimpleSupplyRewardPeriod(moneyMarketDenom, rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleSupplyRewardPeriod(moneyMarketDenom, rewardsPerSecond)
 			}
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -554,10 +554,10 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				WithSimpleAccount(suite.addrs[2], cs(c("ukava", 1e9))).
 				WithSimpleAccount(userAddr, cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)))
 
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime)
 			if tc.args.rewardsPerSecond != nil {
-				incentBuilder = incentBuilder.withSimpleSupplyRewardPeriod(tc.args.incentiveSupplyRewardDenom, tc.args.rewardsPerSecond)
+				incentBuilder = incentBuilder.WithSimpleSupplyRewardPeriod(tc.args.incentiveSupplyRewardDenom, tc.args.rewardsPerSecond)
 			}
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -856,12 +856,12 @@ func (suite *SupplyRewardsTestSuite) TestUpdateHardSupplyIndexDenoms() {
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleSupplyRewardPeriod("bnb", tc.args.rewardsPerSecond).
-				withSimpleSupplyRewardPeriod("ukava", tc.args.rewardsPerSecond).
-				withSimpleSupplyRewardPeriod("btcb", tc.args.rewardsPerSecond).
-				withSimpleSupplyRewardPeriod("xrp", tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleSupplyRewardPeriod("bnb", tc.args.rewardsPerSecond).
+				WithSimpleSupplyRewardPeriod("ukava", tc.args.rewardsPerSecond).
+				WithSimpleSupplyRewardPeriod("btcb", tc.args.rewardsPerSecond).
+				WithSimpleSupplyRewardPeriod("xrp", tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 
@@ -940,9 +940,9 @@ func (suite *SupplyRewardsTestSuite) TestSimulateHardSupplyRewardSynchronization
 				userAddr,
 				cs(c("bnb", 1e15), c("ukava", 1e15), c("btcb", 1e15), c("xrp", 1e15), c("zzz", 1e15)),
 			)
-			incentBuilder := newIncentiveGenesisBuilder().
-				withGenesisTime(suite.genesisTime).
-				withSimpleSupplyRewardPeriod(tc.args.deposit.Denom, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().
+				WithGenesisTime(suite.genesisTime).
+				WithSimpleSupplyRewardPeriod(tc.args.deposit.Denom, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder, NewHardGenStateMulti(suite.genesisTime))
 

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -61,7 +61,7 @@ func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_supply_update_test.go
+++ b/x/incentive/keeper/rewards_supply_update_test.go
@@ -1,0 +1,119 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// UpdateHardSupplyIndexDenomsTests runs unit tests for the keeper.UpdateHardSupplyIndexDenoms method
+//
+// inputs
+// - claim in store if it exists (only claim.SupplyRewardIndexes)
+// - global indexes in store
+// - deposit function arg (only deposit.Amount)
+//
+// outputs
+// - sets a claim
+type UpdateHardSupplyIndexDenomsTests struct {
+	unitTester
+}
+
+func TestUpdateHardSupplyIndexDenoms(t *testing.T) {
+	suite.Run(t, new(UpdateHardSupplyIndexDenomsTests))
+}
+
+func (suite *UpdateHardSupplyIndexDenomsTests) TestClaimIndexesAreRemovedForDenomsNoLongerSupplied() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	suite.storeGlobalSupplyIndexes(claim.SupplyRewardIndexes)
+
+	// remove one denom from the indexes already in the deposit
+	expectedIndexes := claim.SupplyRewardIndexes[1:]
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(expectedIndexes)...),
+	}
+
+	suite.keeper.UpdateHardSupplyIndexDenoms(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(expectedIndexes, syncedClaim.SupplyRewardIndexes)
+}
+
+func (suite *UpdateHardSupplyIndexDenomsTests) TestClaimIndexesAreAddedForNewlySuppliedDenoms() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	globalIndexes := appendUniqueMultiRewardIndex(claim.SupplyRewardIndexes)
+	suite.storeGlobalSupplyIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.UpdateHardSupplyIndexDenoms(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
+
+func (suite *UpdateHardSupplyIndexDenomsTests) TestClaimIndexesAreUnchangedWhenSuppliedDenomsUnchanged() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	// Set global indexes with same denoms but different values.
+	// UpdateHardSupplyIndexDenoms should ignore the new values.
+	suite.storeGlobalSupplyIndexes(increaseAllRewardFactors(claim.SupplyRewardIndexes))
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(claim.SupplyRewardIndexes)...),
+	}
+
+	suite.keeper.UpdateHardSupplyIndexDenoms(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.SupplyRewardIndexes, syncedClaim.SupplyRewardIndexes)
+}
+
+func (suite *UpdateHardSupplyIndexDenomsTests) TestEmptyClaimIndexesAreAddedForNewlySuppliedButNotRewardedDenoms() {
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+	suite.storeGlobalSupplyIndexes(claim.SupplyRewardIndexes)
+
+	// add a denom to the deposited amount that is not in the global or claim's indexes
+	expectedIndexes := appendUniqueEmptyMultiRewardIndex(claim.SupplyRewardIndexes)
+	depositedDenoms := extractCollateralTypes(expectedIndexes)
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(depositedDenoms...),
+	}
+
+	suite.keeper.UpdateHardSupplyIndexDenoms(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(expectedIndexes, syncedClaim.SupplyRewardIndexes)
+}

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -86,13 +86,13 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		claim = types.NewUSDXMintingClaim(
 			cdp.Owner,
 			sdk.NewCoin(types.USDXMintingRewardDenom, sdk.ZeroInt()),
-			types.RewardIndexes{types.NewRewardIndex(cdp.Type, globalRewardFactor)}, // FIXME factor should be 0.0
+			types.RewardIndexes{},
 		)
 	}
 
 	userRewardFactor, hasRewardIndex := claim.RewardIndexes.Get(cdp.Type)
 	if !hasRewardIndex { // this is the owner's first usdx minting reward for this collateral type
-		userRewardFactor = globalRewardFactor // FIXME should be 0.0
+		userRewardFactor = globalRewardFactor
 	}
 
 	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount)

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -95,7 +95,7 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		userRewardFactor = globalRewardFactor
 	}
 
-	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount)
+	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount.ToDec())
 	newRewardsCoin := sdk.NewCoin(types.USDXMintingRewardDenom, newRewardsAmount)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)

--- a/x/incentive/keeper/rewards_usdx_test.go
+++ b/x/incentive/keeper/rewards_usdx_test.go
@@ -47,7 +47,7 @@ func (suite *USDXRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *USDXRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
+func (suite *USDXRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder IncentiveGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -55,7 +55,7 @@ func (suite *USDXRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesis
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		NewCDPGenStateMulti(),
-		incentBuilder.buildMarshalled(),
+		incentBuilder.BuildMarshalled(),
 	)
 }
 
@@ -105,7 +105,7 @@ func (suite *USDXRewardsTestSuite) TestAccumulateUSDXMintingRewards() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime).WithSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(app.NewAuthGenesisBuilder(), incentBuilder)
 
@@ -169,7 +169,7 @@ func (suite *USDXRewardsTestSuite) TestSynchronizeUSDXMintingReward() {
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime).WithSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
 
@@ -256,7 +256,7 @@ func (suite *USDXRewardsTestSuite) TestSimulateUSDXMintingRewardSynchronization(
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
 			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
-			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
+			incentBuilder := NewIncentiveGenesisBuilder().WithGenesisTime(suite.genesisTime).WithSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
 

--- a/x/incentive/keeper/rewards_usdx_test.go
+++ b/x/incentive/keeper/rewards_usdx_test.go
@@ -47,7 +47,7 @@ func (suite *USDXRewardsTestSuite) SetupApp() {
 	suite.ctx = suite.app.NewContext(true, abci.Header{Height: 1, Time: suite.genesisTime})
 }
 
-func (suite *USDXRewardsTestSuite) SetupWithGenState(authBuilder AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
+func (suite *USDXRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenesisBuilder, incentBuilder incentiveGenesisBuilder) {
 	suite.SetupApp()
 
 	suite.app.InitializeFromGenesisStatesWithTime(
@@ -107,7 +107,7 @@ func (suite *USDXRewardsTestSuite) TestAccumulateUSDXMintingRewards() {
 		suite.Run(tc.name, func() {
 			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
-			suite.SetupWithGenState(NewAuthGenesisBuilder(), incentBuilder)
+			suite.SetupWithGenState(app.NewAuthGenesisBuilder(), incentBuilder)
 
 			// setup cdp state
 			suite.cdpKeeper.SetTotalPrincipal(suite.ctx, tc.args.ctype, cdptypes.DefaultStableDenom, tc.args.initialTotalPrincipal.Amount)
@@ -168,7 +168,7 @@ func (suite *USDXRewardsTestSuite) TestSynchronizeUSDXMintingReward() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
 			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)
@@ -255,7 +255,7 @@ func (suite *USDXRewardsTestSuite) TestSimulateUSDXMintingRewardSynchronization(
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			authBuilder := NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
+			authBuilder := app.NewAuthGenesisBuilder().WithSimpleAccount(suite.addrs[0], cs(tc.args.initialCollateral))
 			incentBuilder := newIncentiveGenesisBuilder().withGenesisTime(suite.genesisTime).withSimpleUSDXRewardPeriod(tc.args.ctype, tc.args.rewardsPerSecond)
 
 			suite.SetupWithGenState(authBuilder, incentBuilder)

--- a/x/incentive/keeper/rewards_usdx_test.go
+++ b/x/incentive/keeper/rewards_usdx_test.go
@@ -90,7 +90,7 @@ func (suite *KeeperTestSuite) TestAccumulateUSDXMintingRewards() {
 			err := suite.keeper.AccumulateUSDXMintingRewards(suite.ctx, rewardPeriod)
 			suite.Require().NoError(err)
 
-			rewardFactor, found := suite.keeper.GetUSDXMintingRewardFactor(suite.ctx, tc.args.ctype)
+			rewardFactor, _ := suite.keeper.GetUSDXMintingRewardFactor(suite.ctx, tc.args.ctype)
 			suite.Require().Equal(tc.args.expectedRewardFactor, rewardFactor)
 		})
 	}
@@ -192,7 +192,7 @@ func (suite *KeeperTestSuite) TestSynchronizeUSDXMintingReward() {
 				suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
 			})
 
-			rewardFactor, found := suite.keeper.GetUSDXMintingRewardFactor(suite.ctx, tc.args.ctype)
+			rewardFactor, _ := suite.keeper.GetUSDXMintingRewardFactor(suite.ctx, tc.args.ctype)
 			suite.Require().Equal(tc.args.expectedRewardFactor, rewardFactor)
 
 			claim, found = suite.keeper.GetUSDXMintingClaim(suite.ctx, suite.addrs[0])

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -101,7 +101,7 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardUnchangedWhenGlobalInd
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
 			Owner:  arbitraryAddress(),
-			Reward: arbitraryCoin(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: unchangingRewardIndexes,
 	}
@@ -163,7 +163,8 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenGloba
 
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
-			Owner: arbitraryAddress(),
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: claimsRewardIndexes,
 	}
@@ -202,7 +203,8 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenNewRe
 
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
-			Owner: arbitraryAddress(),
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: claimsRewardIndexes,
 	}

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -1,0 +1,298 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	cdptypes "github.com/kava-labs/kava/x/cdp/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// usdxRewardsUnitTester contains common methods for running unit tests for keeper methods related to the USDX minting rewards
+type usdxRewardsUnitTester struct {
+	unitTester
+}
+
+func (suite *usdxRewardsUnitTester) storeGlobalUSDXIndexes(indexes types.RewardIndexes) {
+	for _, ri := range indexes {
+		suite.keeper.SetUSDXMintingRewardFactor(suite.ctx, ri.CollateralType, ri.RewardFactor)
+	}
+}
+func (suite *usdxRewardsUnitTester) storeClaim(claim types.USDXMintingClaim) {
+	suite.keeper.SetUSDXMintingClaim(suite.ctx, claim)
+}
+
+type InitializeUSDXMintingClaimTests struct {
+	usdxRewardsUnitTester
+}
+
+func TestInitializeUSDXMintingClaims(t *testing.T) {
+	suite.Run(t, new(InitializeUSDXMintingClaimTests))
+}
+
+func (suite *InitializeUSDXMintingClaimTests) TestClaimIndexIsSetWhenClaimDoesNotExist() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	cdp := NewCDPBuilder(arbitraryAddress(), collateralType).Build()
+
+	globalIndexes := types.RewardIndexes{{
+		CollateralType: collateralType,
+		RewardFactor:   d("0.2"),
+	}}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	suite.keeper.InitializeUSDXMintingClaim(suite.ctx, cdp)
+
+	syncedClaim, f := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
+	suite.True(f)
+	suite.Equal(globalIndexes, syncedClaim.RewardIndexes)
+}
+
+func (suite *InitializeUSDXMintingClaimTests) TestClaimIndexIsSetWhenClaimExists() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: types.RewardIndexes{{
+			CollateralType: collateralType,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.RewardIndexes{{
+		CollateralType: collateralType,
+		RewardFactor:   d("0.2"),
+	}}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.InitializeUSDXMintingClaim(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
+	suite.Equal(globalIndexes, syncedClaim.RewardIndexes)
+}
+
+type SynchronizeUSDXMintingRewardTests struct {
+	usdxRewardsUnitTester
+}
+
+func TestSynchronizeUSDXMintingReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeUSDXMintingRewardTests))
+}
+func (suite *SynchronizeUSDXMintingRewardTests) TestRewardUnchangedWhenGlobalIndexesUnchanged() {
+	unchangingRewardIndexes := nonEmptyRewardIndexes
+	collateralType := extractFirstCollateralType(unchangingRewardIndexes)
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner:  arbitraryAddress(),
+			Reward: arbitraryCoin(),
+		},
+		RewardIndexes: unchangingRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalUSDXIndexes(unchangingRewardIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.Reward, syncedClaim.Reward)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenGlobalIndexesHaveIncreased() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
+		},
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: collateralType,
+				RewardFactor:   d("0.1"),
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.RewardIndexes{
+		{
+			CollateralType: collateralType,
+			RewardFactor:   d("0.2"),
+		},
+	}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).WithPrincipal(i(1e12)).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+	// reward is ( new index - old index ) * cdp.TotalPrincipal
+	suite.Equal(c(types.USDXMintingRewardDenom, 1e11), syncedClaim.Reward)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenGlobalIndexIncreased() {
+	claimsRewardIndexes := nonEmptyRewardIndexes
+	collateralType := extractFirstCollateralType(claimsRewardIndexes)
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: claimsRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claimsRewardIndexes)
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+
+	// Only the claim's index for `collateralType` should have been changed
+	i, _ := globalIndexes.Get(collateralType)
+	expectedIndexes := claimsRewardIndexes.With(collateralType, i)
+	suite.Equal(expectedIndexes, syncedClaim.RewardIndexes)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenNewRewardAddedAndClaimAlreadyExists() {
+	claimsRewardIndexes := types.RewardIndexes{
+		{
+			CollateralType: "bnb-a",
+			RewardFactor:   d("0.1"),
+		},
+		{
+			CollateralType: "busd-b",
+			RewardFactor:   d("0.4"),
+		},
+	}
+	newRewardIndex := types.NewRewardIndex("xrp-a", d("0.0001"))
+
+	subspace := paramsWithSingleUSDXRewardPeriod(newRewardIndex.CollateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: claimsRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claimsRewardIndexes)
+	globalIndexes = append(globalIndexes, newRewardIndex)
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, newRewardIndex.CollateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+
+	// Only the claim's index for `collateralType` should have been changed
+	expectedIndexes := claimsRewardIndexes.With(newRewardIndex.CollateralType, newRewardIndex.RewardFactor)
+	suite.Equal(expectedIndexes, syncedClaim.RewardIndexes)
+}
+
+type cdpBuilder struct {
+	cdptypes.CDP
+}
+
+func NewCDPBuilder(owner sdk.AccAddress, collateralType string) cdpBuilder {
+	return cdpBuilder{
+		CDP: cdptypes.CDP{
+			Owner: owner,
+			Type:  collateralType,
+			// The zero value of Principal and AccumulatedFees (type sdk.Coin) is invalid as the denom is ""
+			// Set them to the default denom, but with 0 amount.
+			Principal:       c(cdptypes.DefaultStableDenom, 0),
+			AccumulatedFees: c(cdptypes.DefaultStableDenom, 0),
+		}}
+}
+
+func (builder cdpBuilder) Build() cdptypes.CDP { return builder.CDP }
+
+func (builder cdpBuilder) WithPrincipal(principal sdk.Int) cdpBuilder {
+	builder.Principal = sdk.NewCoin(cdptypes.DefaultStableDenom, principal)
+	return builder
+}
+
+var nonEmptyRewardIndexes = types.RewardIndexes{
+	{
+		CollateralType: "bnb-a",
+		RewardFactor:   d("0.1"),
+	},
+	{
+		CollateralType: "busd-b",
+		RewardFactor:   d("0.4"),
+	},
+}
+
+func paramsWithSingleUSDXRewardPeriod(collateralType string) types.ParamSubspace {
+	return &fakeParamSubspace{
+		params: types.Params{
+			USDXMintingRewardPeriods: types.RewardPeriods{
+				{
+					CollateralType: collateralType,
+				},
+			},
+		},
+	}
+}
+
+func extractFirstCollateralType(indexes types.RewardIndexes) string {
+	if len(indexes) == 0 {
+		panic("cannot extract a collateral type from 0 length RewardIndexes")
+	}
+	return indexes[0].CollateralType
+}
+
+/*
+Init
+given a claim doesn't exist, when sync is called, a claim is created with the current global index for cdp.Type
+given a claim does exist, when sync is called, the claim's indexes are updated with the current global index for cdp.Type
+same as above but with new cdp.Type, rather than existing one
+
+other
+given a reward period doesn't exist, do nothing
+given the global index doesn't exist, update index with 0
+
+
+Sync
+given increase in global indexes, new rewards are added
+given unchanged global indexes, no new rewards
+given new global index added, new rewards starting from zero
+
+other
+given no reward period, do nothing
+given no claim, create one with 0 global index
+*/

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -175,7 +175,7 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenNewRe
 
 	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
 	// The global index was not around when this cdp was created as it was not stored in a claim.
-	// Therefor it must have been added via params after.
+	// Therefore it must have been added via params after.
 	// To include rewards since the params were updated, the old index should be assumed to be 0.
 	// reward is ( new index - old index ) * cdp.TotalPrincipal
 	suite.Equal(c(types.USDXMintingRewardDenom, 2e11), syncedClaim.Reward)

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -1,0 +1,208 @@
+package keeper_test
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	db "github.com/tendermint/tm-db"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/x/incentive"
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// NewTestContext sets up a basic context with an in-memory db
+func NewTestContext(requiredStoreKeys ...sdk.StoreKey) sdk.Context {
+	memDB := db.NewMemDB()
+	cms := store.NewCommitMultiStore(memDB)
+
+	for _, key := range requiredStoreKeys {
+		cms.MountStoreWithDB(key, sdk.StoreTypeIAVL, nil)
+	}
+
+	cms.LoadLatestVersion()
+
+	return sdk.NewContext(cms, abci.Header{}, false, log.NewNopLogger())
+}
+
+// unitTester is a wrapper around suite.Suite, with common functionality for keeper unit tests.
+// It can be embedded in structs the same way as suite.Suite.
+type unitTester struct {
+	suite.Suite
+	keeper keeper.Keeper
+	ctx    sdk.Context
+}
+
+func (suite *unitTester) SetupTest() {
+	incentiveStoreKey := sdk.NewKVStoreKey(types.StoreKey)
+	suite.keeper = suite.setupKeeper(incentiveStoreKey)
+	suite.ctx = NewTestContext(incentiveStoreKey)
+}
+
+func (suite *unitTester) TearDownTest() {
+	suite.keeper = keeper.Keeper{}
+	suite.ctx = sdk.Context{}
+}
+
+func (suite *unitTester) setupKeeper(incentiveStoreKey sdk.StoreKey) keeper.Keeper {
+	cdc := app.MakeCodec()
+	// TODO The param store key needs to be initialized in the multistore if params are to be Get/Set.
+	paramSubspace := params.NewKeeper(
+		cdc,
+		sdk.NewKVStoreKey(params.StoreKey),
+		sdk.NewTransientStoreKey(params.StoreKey),
+	).Subspace(incentive.DefaultParamspace)
+
+	return keeper.NewKeeper(cdc, incentiveStoreKey, paramSubspace, nil, nil, nil, nil, nil)
+}
+
+func (suite *unitTester) storeGlobalIndexes(indexes types.MultiRewardIndexes) {
+	for _, i := range indexes {
+		suite.keeper.SetHardBorrowRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
+	}
+}
+
+func (suite *unitTester) storeClaim(claim types.HardLiquidityProviderClaim) {
+	suite.keeper.SetHardLiquidityProviderClaim(suite.ctx, claim)
+}
+
+func arbitraryCoins() sdk.Coins {
+	return cs(c("btcb", 1))
+}
+
+func arbitraryCoinsWithDenoms(denom ...string) sdk.Coins {
+	const arbitraryAmount = 1 // must be > 0 as sdk.Coins type only stores positive amounts
+	coins := sdk.NewCoins()
+	for _, d := range denom {
+		coins = coins.Add(sdk.NewInt64Coin(d, arbitraryAmount))
+	}
+	return coins
+}
+
+func arbitraryAddress() sdk.AccAddress {
+	_, addresses := app.GeneratePrivKeyAddressPairs(1)
+	return addresses[0]
+}
+
+var nonEmptyMultiRewardIndexes = types.MultiRewardIndexes{
+	{
+		CollateralType: "bnb",
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: "hard",
+				RewardFactor:   d("0.02"),
+			},
+			{
+				CollateralType: "ukava",
+				RewardFactor:   d("0.04"),
+			},
+		},
+	},
+	{
+		CollateralType: "btcb",
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: "hard",
+				RewardFactor:   d("0.2"),
+			},
+			{
+				CollateralType: "ukava",
+				RewardFactor:   d("0.4"),
+			},
+		},
+	},
+}
+
+func extractCollateralTypes(indexes types.MultiRewardIndexes) []string {
+	var denoms []string
+	for _, ri := range indexes {
+		denoms = append(denoms, ri.CollateralType)
+	}
+	return denoms
+}
+
+func increaseAllRewardFactors(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
+	increasedIndexes := make(types.MultiRewardIndexes, len(indexes))
+	copy(increasedIndexes, indexes)
+
+	for i := range increasedIndexes {
+		increasedIndexes[i].RewardIndexes = increaseRewardFactors(increasedIndexes[i].RewardIndexes)
+	}
+	return increasedIndexes
+}
+
+func increaseRewardFactors(indexes types.RewardIndexes) types.RewardIndexes {
+	increasedIndexes := make(types.RewardIndexes, len(indexes))
+	copy(increasedIndexes, indexes)
+
+	for i := range increasedIndexes {
+		increasedIndexes[i].RewardFactor = increasedIndexes[i].RewardFactor.MulInt64(2)
+	}
+	return increasedIndexes
+}
+
+func appendUniqueMultiRewardIndex(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
+	const uniqueDenom = "uniquedenom"
+
+	for _, mri := range indexes {
+		if mri.CollateralType == uniqueDenom {
+			panic(fmt.Sprintf("tried to add unique multi reward index with denom '%s', but denom already existed", uniqueDenom))
+		}
+	}
+
+	return append(indexes, types.NewMultiRewardIndex(
+		uniqueDenom,
+		types.RewardIndexes{
+			{
+				CollateralType: "hard",
+				RewardFactor:   d("0.02"),
+			},
+			{
+				CollateralType: "ukava",
+				RewardFactor:   d("0.04"),
+			},
+		},
+	),
+	)
+}
+
+func appendUniqueEmptyMultiRewardIndex(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
+	const uniqueDenom = "uniquedenom"
+
+	for _, mri := range indexes {
+		if mri.CollateralType == uniqueDenom {
+			panic(fmt.Sprintf("tried to add unique multi reward index with denom '%s', but denom already existed", uniqueDenom))
+		}
+	}
+
+	return append(indexes, types.NewMultiRewardIndex(uniqueDenom, nil))
+}
+
+func appendUniqueRewardIndexToFirstItem(indexes types.MultiRewardIndexes) types.MultiRewardIndexes {
+	newIndexes := make(types.MultiRewardIndexes, len(indexes))
+	copy(newIndexes, indexes)
+
+	newIndexes[0].RewardIndexes = appendUniqueRewardIndex(newIndexes[0].RewardIndexes)
+	return newIndexes
+}
+
+func appendUniqueRewardIndex(indexes types.RewardIndexes) types.RewardIndexes {
+	const uniqueDenom = "uniquereward"
+
+	for _, mri := range indexes {
+		if mri.CollateralType == uniqueDenom {
+			panic(fmt.Sprintf("tried to add unique reward index with denom '%s', but denom already existed", uniqueDenom))
+		}
+	}
+
+	return append(
+		indexes,
+		types.NewRewardIndex(uniqueDenom, d("0.02")),
+	)
+}

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -62,9 +62,14 @@ func (suite *unitTester) setupKeeper(incentiveStoreKey sdk.StoreKey) keeper.Keep
 	return keeper.NewKeeper(cdc, incentiveStoreKey, paramSubspace, nil, nil, nil, nil, nil)
 }
 
-func (suite *unitTester) storeGlobalIndexes(indexes types.MultiRewardIndexes) {
+func (suite *unitTester) storeGlobalBorrowIndexes(indexes types.MultiRewardIndexes) {
 	for _, i := range indexes {
 		suite.keeper.SetHardBorrowRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
+	}
+}
+func (suite *unitTester) storeGlobalSupplyIndexes(indexes types.MultiRewardIndexes) {
+	for _, i := range indexes {
+		suite.keeper.SetHardSupplyRewardIndexes(suite.ctx, i.CollateralType, i.RewardIndexes)
 	}
 }
 

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -118,6 +118,17 @@ func arbitraryAddress() sdk.AccAddress {
 	_, addresses := app.GeneratePrivKeyAddressPairs(1)
 	return addresses[0]
 }
+func arbitraryValidatorAddress() sdk.ValAddress {
+	return generateValidatorAddresses(1)[0]
+}
+func generateValidatorAddresses(n int) []sdk.ValAddress {
+	_, addresses := app.GeneratePrivKeyAddressPairs(n)
+	var valAddresses []sdk.ValAddress
+	for _, a := range addresses {
+		valAddresses = append(valAddresses, sdk.ValAddress(a))
+	}
+	return valAddresses
+}
 
 var nonEmptyMultiRewardIndexes = types.MultiRewardIndexes{
 	{

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -402,6 +402,20 @@ func (ris RewardIndexes) GetRewardIndex(denom string) (RewardIndex, bool) {
 	return RewardIndex{}, false
 }
 
+// With returns a copy of the indexes with a new reward index added
+func (ris RewardIndexes) With(denom string, factor sdk.Dec) RewardIndexes {
+	newIndexes := make(RewardIndexes, len(ris))
+	copy(newIndexes, ris)
+
+	for i, ri := range newIndexes {
+		if ri.CollateralType == denom {
+			newIndexes[i].RewardFactor = factor
+			return newIndexes
+		}
+	}
+	return append(newIndexes, NewRewardIndex(denom, factor))
+}
+
 // GetFactorIndex gets the index of a specific reward index inside the array by its index
 func (ris RewardIndexes) GetFactorIndex(denom string) (int, bool) {
 	for i, ri := range ris {
@@ -496,7 +510,7 @@ func (mris MultiRewardIndexes) GetCollateralTypes() []string {
 }
 
 // RemoveRewardIndex removes a denom's reward interest factor value
-func (mris MultiRewardIndexes) RemoveRewardIndex(denom string) MultiRewardIndexes {
+func (mris MultiRewardIndexes) RemoveRewardIndex(denom string) MultiRewardIndexes { // TODO modifies original dangerously
 	for i, ri := range mris {
 		if ri.CollateralType == denom {
 			return append(mris[:i], mris[i+1:]...)

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -522,8 +522,7 @@ func (mris MultiRewardIndexes) GetRewardIndexIndex(denom string) (int, bool) {
 
 // With returns a copy of the indexes with a new RewardIndexes added
 func (mris MultiRewardIndexes) With(denom string, indexes RewardIndexes) MultiRewardIndexes {
-	newIndexes := make(MultiRewardIndexes, len(mris))
-	copy(newIndexes, mris)
+	newIndexes := mris.copy()
 
 	for i, mri := range newIndexes {
 		if mri.CollateralType == denom {
@@ -544,10 +543,12 @@ func (mris MultiRewardIndexes) GetCollateralTypes() []string {
 }
 
 // RemoveRewardIndex removes a denom's reward interest factor value
-func (mris MultiRewardIndexes) RemoveRewardIndex(denom string) MultiRewardIndexes { // TODO modifies original dangerously
+func (mris MultiRewardIndexes) RemoveRewardIndex(denom string) MultiRewardIndexes {
 	for i, ri := range mris {
 		if ri.CollateralType == denom {
-			return append(mris[:i], mris[i+1:]...)
+			// copy the slice and underlying array to avoid altering the original
+			copy := mris.copy()
+			return append(copy[:i], copy[i+1:]...)
 		}
 	}
 	return mris
@@ -561,4 +562,11 @@ func (mris MultiRewardIndexes) Validate() error {
 		}
 	}
 	return nil
+}
+
+// copy returns a copy the slice and underlying array
+func (mris MultiRewardIndexes) copy() MultiRewardIndexes {
+	newIndexes := make(MultiRewardIndexes, len(mris))
+	copy(newIndexes, mris)
+	return newIndexes
 }

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -402,6 +402,16 @@ func (ris RewardIndexes) GetRewardIndex(denom string) (RewardIndex, bool) {
 	return RewardIndex{}, false
 }
 
+// Get fetches a RewardFactor from the indexes by it's denom
+func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
+	for _, ri := range ris {
+		if ri.CollateralType == denom {
+			return ri.RewardFactor, true
+		}
+	}
+	return sdk.Dec{}, false
+}
+
 // With returns a copy of the indexes with a new reward index added
 func (ris RewardIndexes) With(denom string, factor sdk.Dec) RewardIndexes {
 	newIndexes := make(RewardIndexes, len(ris))
@@ -490,6 +500,16 @@ func (mris MultiRewardIndexes) GetRewardIndex(denom string) (MultiRewardIndex, b
 	return MultiRewardIndex{}, false
 }
 
+// Get fetches a RewardFactor from the indexes by it's denom
+func (mris MultiRewardIndexes) Get(denom string) (RewardIndexes, bool) {
+	for _, mri := range mris {
+		if mri.CollateralType == denom {
+			return mri.RewardIndexes, true
+		}
+	}
+	return nil, false
+}
+
 // GetRewardIndexIndex fetches a specific reward index inside the array by its denom
 func (mris MultiRewardIndexes) GetRewardIndexIndex(denom string) (int, bool) {
 	for i, ri := range mris {
@@ -498,6 +518,20 @@ func (mris MultiRewardIndexes) GetRewardIndexIndex(denom string) (int, bool) {
 		}
 	}
 	return -1, false
+}
+
+// With returns a copy of the indexes with a new RewardIndexes added
+func (mris MultiRewardIndexes) With(denom string, indexes RewardIndexes) MultiRewardIndexes {
+	newIndexes := make(MultiRewardIndexes, len(mris))
+	copy(newIndexes, mris)
+
+	for i, mri := range newIndexes {
+		if mri.CollateralType == denom {
+			newIndexes[i].RewardIndexes = indexes
+			return newIndexes
+		}
+	}
+	return append(newIndexes, NewMultiRewardIndex(denom, indexes))
 }
 
 // GetCollateralTypes returns a slice of containing all collateral types

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -402,7 +402,7 @@ func (ris RewardIndexes) GetRewardIndex(denom string) (RewardIndex, bool) {
 	return RewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardFactor by it's denom
 func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	for _, ri := range ris {
 		if ri.CollateralType == denom {
@@ -412,7 +412,7 @@ func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	return sdk.Dec{}, false
 }
 
-// With returns a copy of the indexes with a new reward index added
+// With returns a copy of the indexes with a new reward factor added
 func (ris RewardIndexes) With(denom string, factor sdk.Dec) RewardIndexes {
 	newIndexes := make(RewardIndexes, len(ris))
 	copy(newIndexes, ris)
@@ -500,7 +500,7 @@ func (mris MultiRewardIndexes) GetRewardIndex(denom string) (MultiRewardIndex, b
 	return MultiRewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardIndexes by it's denom
 func (mris MultiRewardIndexes) Get(denom string) (RewardIndexes, bool) {
 	for _, mri := range mris {
 		if mri.CollateralType == denom {
@@ -564,7 +564,7 @@ func (mris MultiRewardIndexes) Validate() error {
 	return nil
 }
 
-// copy returns a copy the slice and underlying array
+// copy returns a copy of the slice and underlying array
 func (mris MultiRewardIndexes) copy() MultiRewardIndexes {
 	newIndexes := make(MultiRewardIndexes, len(mris))
 	copy(newIndexes, mris)

--- a/x/incentive/types/claims_test.go
+++ b/x/incentive/types/claims_test.go
@@ -349,7 +349,6 @@ func TestMultiRewardIndexes(t *testing.T) {
 	})
 }
 
-// TODO dedupe with copy in keeper
 func appendUniqueRewardIndex(indexes RewardIndexes) RewardIndexes {
 	const uniqueDenom = "uniquereward"
 

--- a/x/incentive/types/claims_test.go
+++ b/x/incentive/types/claims_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -123,4 +124,191 @@ func TestRewardIndexes(t *testing.T) {
 			})
 		}
 	})
+	t.Run("Get", func(t *testing.T) {
+		var arbitraryDec = sdk.MustNewDecFromStr("0.1")
+
+		type expected struct {
+			factor sdk.Dec
+			found  bool
+		}
+		testcases := []struct {
+			name          string
+			rewardIndexes RewardIndexes
+			arg_denom     string
+			expected      expected
+		}{
+			{
+				name: "when index is present, it is found and returned",
+				rewardIndexes: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec),
+				},
+				arg_denom: "denom",
+				expected: expected{
+					factor: arbitraryDec,
+					found:  true,
+				},
+			},
+			{
+				name: "when index is not present, it is not found",
+				rewardIndexes: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec),
+				},
+				arg_denom: "notpresent",
+				expected: expected{
+					found: false,
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				factor, found := tc.rewardIndexes.Get(tc.arg_denom)
+
+				require.Equal(t, tc.expected.found, found)
+				require.Equal(t, tc.expected.factor, factor)
+			})
+		}
+	})
+}
+
+func TestMultiRewardIndexes(t *testing.T) {
+	t.Run("Get", func(t *testing.T) {
+		arbitraryRewardIndexes := RewardIndexes{
+			{
+				CollateralType: "reward",
+				RewardFactor:   sdk.MustNewDecFromStr("0.1"),
+			},
+		}
+		type expected struct {
+			rewardIndexes RewardIndexes
+			found         bool
+		}
+		testcases := []struct {
+			name               string
+			multiRewardIndexes MultiRewardIndexes
+			arg_denom          string
+			expected           expected
+		}{
+			{
+				name: "when indexes are present, they are found and returned",
+				multiRewardIndexes: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+				},
+				arg_denom: "denom",
+				expected: expected{
+					found:         true,
+					rewardIndexes: arbitraryRewardIndexes,
+				},
+			},
+			{
+				name: "when indexes are not present, they are not found",
+				multiRewardIndexes: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+				},
+				arg_denom: "notpresent",
+				expected: expected{
+					found: false,
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				rewardIndexes, found := tc.multiRewardIndexes.Get(tc.arg_denom)
+
+				require.Equal(t, tc.expected.found, found)
+				require.Equal(t, tc.expected.rewardIndexes, rewardIndexes)
+			})
+		}
+	})
+	t.Run("With", func(t *testing.T) {
+		arbitraryRewardIndexes := RewardIndexes{
+			{
+				CollateralType: "reward",
+				RewardFactor:   sdk.MustNewDecFromStr("0.1"),
+			},
+		}
+		type args struct {
+			denom         string
+			rewardIndexes RewardIndexes
+		}
+		testcases := []struct {
+			name               string
+			multiRewardIndexes MultiRewardIndexes
+			args               args
+			expected           MultiRewardIndexes
+		}{
+			{
+				name: "when indexes are not present, add them and do not update original",
+				multiRewardIndexes: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+				},
+				args: args{
+					denom:         "otherdenom",
+					rewardIndexes: arbitraryRewardIndexes,
+				},
+				expected: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+					{
+						CollateralType: "otherdenom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+				},
+			},
+			{
+				name: "when indexes are present, update them and do not update original",
+				multiRewardIndexes: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  arbitraryRewardIndexes,
+					},
+				},
+				args: args{
+					denom:         "denom",
+					rewardIndexes: appendUniqueRewardIndex(arbitraryRewardIndexes),
+				},
+				expected: MultiRewardIndexes{
+					{
+						CollateralType: "denom",
+						RewardIndexes:  appendUniqueRewardIndex(arbitraryRewardIndexes),
+					},
+				},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				newIndexes := tc.multiRewardIndexes.With(tc.args.denom, tc.args.rewardIndexes)
+
+				require.Equal(t, tc.expected, newIndexes)
+				require.NotEqual(t, tc.multiRewardIndexes, newIndexes)
+			})
+		}
+	})
+}
+
+// TODO dedupe with copy in keeper
+func appendUniqueRewardIndex(indexes RewardIndexes) RewardIndexes {
+	const uniqueDenom = "uniquereward"
+
+	for _, mri := range indexes {
+		if mri.CollateralType == uniqueDenom {
+			panic(fmt.Sprintf("tried to add unique reward index with denom '%s', but denom already existed", uniqueDenom))
+		}
+	}
+
+	return append(
+		indexes,
+		NewRewardIndex(uniqueDenom, sdk.MustNewDecFromStr("0.02")),
+	)
 }

--- a/x/incentive/types/claims_test.go
+++ b/x/incentive/types/claims_test.go
@@ -3,11 +3,9 @@ package types
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/tendermint/tendermint/crypto"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/crypto"
 )
 
 func TestClaimsValidate(t *testing.T) {
@@ -71,4 +69,58 @@ func TestClaimsValidate(t *testing.T) {
 			require.Error(t, err, tc.msg)
 		}
 	}
+}
+
+func TestRewardIndexes(t *testing.T) {
+	t.Run("With", func(t *testing.T) {
+		var arbitraryDec = sdk.MustNewDecFromStr("0.1")
+
+		type args struct {
+			denom  string
+			factor sdk.Dec
+		}
+		testcases := []struct {
+			name          string
+			rewardIndexes RewardIndexes
+			args          args
+			expected      RewardIndexes
+		}{
+			{
+				name: "when index is not present, it's added and original isn't overwritten",
+				rewardIndexes: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec),
+				},
+				args: args{
+					denom:  "otherdenom",
+					factor: arbitraryDec,
+				},
+				expected: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec),
+					NewRewardIndex("otherdenom", arbitraryDec),
+				},
+			},
+			{
+				name: "when index is present, it's updated and original isn't overwritten",
+				rewardIndexes: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec),
+				},
+				args: args{
+					denom:  "denom",
+					factor: arbitraryDec.MulInt64(2),
+				},
+				expected: RewardIndexes{
+					NewRewardIndex("denom", arbitraryDec.MulInt64(2)),
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				newIndexes := tc.rewardIndexes.With(tc.args.denom, tc.args.factor)
+
+				require.Equal(t, tc.expected, newIndexes)
+				require.NotEqual(t, tc.rewardIndexes, newIndexes) // check original slice not modified
+			})
+		}
+	})
 }

--- a/x/incentive/types/errors.go
+++ b/x/incentive/types/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrClaimExpired                  = sdkerrors.Register(ModuleName, 10, "claim has expired")
 	ErrInvalidClaimType              = sdkerrors.Register(ModuleName, 11, "invalid claim type")
 	ErrInvalidClaimOwner             = sdkerrors.Register(ModuleName, 12, "invalid claim owner")
+	ErrDecreasingRewardFactor        = sdkerrors.Register(ModuleName, 13, "found new reward factor less than an old reward factor")
 )

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -3,12 +3,21 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/params"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 )
+
+// ParamSubspace defines the expected Subspace interfacace
+type ParamSubspace interface {
+	GetParamSet(sdk.Context, params.ParamSet)
+	SetParamSet(sdk.Context, params.ParamSet)
+	WithKeyTable(params.KeyTable) params.Subspace
+	HasKeyTable() bool
+}
 
 // SupplyKeeper defines the expected supply keeper for module accounts
 type SupplyKeeper interface {


### PR DESCRIPTION
Fairly simple refactors of the main reward syncing functions, with accompany tests.
The behaviour of each method is (mostly) unchanged. No migrations needed.

changes
- Add a unit tests for `Initialize...`, `Synchronize...`, `Update...` methods for each of the 4 reward types: Borrow, Supply, Delegator, USDX.
  - aims:
    - ensure I don't break anything by specifing what the method should do
    - try out a structure for unit tests with no dependencies
      - removing dependencies should simplify the test setup
    - notes
      - I changed the way param subspace is setup in the keeper to allow mocking in the unit tests. I copied the way cosmos-sdk/x/staking did it.
      - I used a heirarchy of Suites, but not super sold on it. Might be easier to just use go tests and subtests.
      - 
- Refactor of `Initialize...`, `Synchronize...`, `Update...` methods for each reward type
  - aims:
    - move (Multi)RewardIndex manipulations out of these functions to make them a little easier to read
    - rearrange these functions to look the same, to help with deduplication later
  - changes
    - Added `With` and `Get` methods to `(Multi)RewardIndexes` to encapsulate read/writes
    - In supply and borrow rewards, if a global reward factor ( ie "bnb": "hard": 0.12345) somehow dissapears Sync will now panic. Before there was no panic, and the old factor was left in the user indexes.

bugs
Found a few minor bugs, added to Asana