### PR TITLE
Committee gov type registration

### DIFF
--- a/x/committee/types/committee.go
+++ b/x/committee/types/committee.go
@@ -27,6 +27,14 @@ const (
 	BondDenom           = "ukava"
 )
 
+func init() {
+	// CommitteeChange/Delete proposals are registered on gov's ModuleCdc (see proposal.go).
+	// But since these proposals contain Committees, these types also need registering:
+	govtypes.ModuleCdc.RegisterInterface((*Committee)(nil), nil)
+	govtypes.RegisterProposalTypeCodec(MemberCommittee{}, "kava/MemberCommittee")
+	govtypes.RegisterProposalTypeCodec(TokenCommittee{}, "kava/TokenCommittee")
+}
+
 // Committee is an interface for handling common actions on committees
 type Committee interface {
 	GetID() uint64


### PR DESCRIPTION
Gov proposals to create/change/delete committees could not be submitted via the cli, as the new Committee interface type had not been registered on the gov module codec. This PR adds the registration.