### PR TITLE
Incentive refactor: bug fixes

### DIFF
--- a/x/incentive/genesis.go
+++ b/x/incentive/genesis.go
@@ -37,7 +37,6 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, supplyKeeper types.SupplyKeep
 			newRewardIndexes = append(newRewardIndexes, ri)
 		}
 		k.SetHardSupplyRewardIndexes(ctx, mrp.CollateralType, newRewardIndexes)
-		// XXX if params removed there'll be claims with missing collat type
 	}
 
 	for _, mrp := range gs.Params.HardBorrowRewardPeriods {

--- a/x/incentive/genesis.go
+++ b/x/incentive/genesis.go
@@ -37,6 +37,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, supplyKeeper types.SupplyKeep
 			newRewardIndexes = append(newRewardIndexes, ri)
 		}
 		k.SetHardSupplyRewardIndexes(ctx, mrp.CollateralType, newRewardIndexes)
+		// XXX if params removed there'll be claims with missing collat type
 	}
 
 	for _, mrp := range gs.Params.HardBorrowRewardPeriods {

--- a/x/incentive/keeper/hooks.go
+++ b/x/incentive/keeper/hooks.go
@@ -81,6 +81,8 @@ When delegated tokens (to bonded validators) are changed:
   - jail: total bonded delegation decreases (tokens no longer bonded (after end blocker runs))
 - validator becomes unbonded (ie when they drop out of the top 100)
   - total bonded delegation decreases (tokens no longer bonded)
+- validator becomes bonded (ie when they're promoted into the top 100)
+  - total bonded delegation increases (tokens become bonded)
 
 */
 

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -262,9 +262,6 @@ func (builder IncentiveGenesisBuilder) WithSimpleBorrowRewardPeriod(ctype string
 	))
 }
 func (builder IncentiveGenesisBuilder) WithInitializedSupplyRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
-	// TODO this could set the start/end times on the period according to builder.genesisTime
-	// Then they could be created by a different builder
-
 	builder.Params.HardSupplyRewardPeriods = append(builder.Params.HardSupplyRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -173,7 +173,7 @@ func (k Keeper) CalculateRewards(oldIndexes, newIndexes types.RewardIndexes, rew
 			return nil, sdkerrors.Wrapf(types.ErrDecreasingRewardFactor, "old: %v, new: %v", oldIndex, newIndex)
 		}
 	}
-	reward := sdk.NewCoins()
+	var reward sdk.Coins
 	for _, newIndex := range newIndexes {
 		factor, found := oldIndexes.Get(newIndex.CollateralType)
 		if !found {

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -113,7 +113,10 @@ func (k Keeper) SynchronizeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bo
 
 		userRewardIndexes, found := claim.BorrowRewardIndexes.Get(coin.Denom)
 		if !found {
-			continue
+			// Normally the reward indexes should always be found.
+			// But if a denom was not rewarded then becomes rewarded (ie a reward period is added to params), then the indexes will be missing from claims for that borrowed denom.
+			// So given the reward period was just added, assume the starting value for any global reward indexes, which is an empty slice.
+			userRewardIndexes = types.RewardIndexes{}
 		}
 
 		newRewards, err := k.CalculateRewards(userRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -108,6 +108,12 @@ func (k Keeper) SynchronizeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bo
 	for _, coin := range borrow.Amount {
 		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
 		if !foundGlobalRewardIndexes {
+			// The global factor is only not found if
+			// - the borrowed denom has not started accumulating rewards yet (either there is no reward specified in params, or the reward start time hasn't been hit)
+			// - OR it was wrongly deleted from state (factors should never be removed while unsynced claims exist)
+			// If not found we could either skip this sync, or assume the global factor is zero.
+			// Skipping will avoid storing unnecessary factors in the claim for non rewarded denoms.
+			// And in the event a global factor is wrongly deleted, it will avoid this function panicking when calculating rewards.
 			continue
 		}
 

--- a/x/incentive/keeper/rewards_borrow.go
+++ b/x/incentive/keeper/rewards_borrow.go
@@ -86,8 +86,8 @@ func (k Keeper) InitializeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bor
 
 	var borrowRewardIndexes types.MultiRewardIndexes
 	for _, coin := range borrow.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
+		if !found {
 			globalRewardIndexes = types.RewardIndexes{}
 		}
 		borrowRewardIndexes = borrowRewardIndexes.With(coin.Denom, globalRewardIndexes)
@@ -106,8 +106,8 @@ func (k Keeper) SynchronizeHardBorrowReward(ctx sdk.Context, borrow hardtypes.Bo
 	}
 
 	for _, coin := range borrow.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardBorrowRewardIndexes(ctx, coin.Denom)
+		if !found {
 			// The global factor is only not found if
 			// - the borrowed denom has not started accumulating rewards yet (either there is no reward specified in params, or the reward start time hasn't been hit)
 			// - OR it was wrongly deleted from state (factors should never be removed while unsynced claims exist)

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -314,7 +314,7 @@ func TestCalculateRewards(t *testing.T) {
 	}
 	type args struct {
 		oldIndexes, newIndexes types.RewardIndexes
-		sourceAmount           sdk.Int
+		sourceAmount           sdk.Dec
 	}
 	testcases := []struct {
 		name     string
@@ -344,7 +344,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.100000001"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				// for each denom: (new - old) * sourceAmount
@@ -370,7 +370,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.100000001"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				// for each denom: (new - old) * sourceAmount
@@ -392,7 +392,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.1"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				err: types.ErrDecreasingRewardFactor,
@@ -417,7 +417,7 @@ func TestCalculateRewards(t *testing.T) {
 						RewardFactor:   d("0.2"),
 					},
 				},
-				sourceAmount: i(1e9),
+				sourceAmount: d("1000000000"),
 			},
 			expected: expected{
 				err: types.ErrDecreasingRewardFactor,

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -81,7 +81,6 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUnchangedWhenG
 func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard borrow denom the user has already borrowed, and the claim is synced;
 	// Then the new reward's index should be added to the claim.
-	suite.T().Skip("TODO fix this bug")
 
 	claim := types.HardLiquidityProviderClaim{
 		BaseMultiClaim: types.BaseMultiClaim{
@@ -104,32 +103,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
 	suite.Equal(globalIndexes, syncedClaim.BorrowRewardIndexes)
 }
-func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAddedWithZeroRewardsPerSecond() {
-	// When a new reward (with zero rewards per second) is added (via gov) for a hard borrow denom the user has already borrowed, and the claim is synced;
-	// Then the new reward's index should be added to the claim.
-	suite.T().Skip("TODO fix this bug")
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner: arbitraryAddress(),
-		},
-		BorrowRewardIndexes: nonEmptyMultiRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	globalIndexes := nonEmptyMultiRewardIndexes.With("uniquezerorps", nil)
-	suite.storeGlobalBorrowIndexes(globalIndexes)
-
-	borrow := hardtypes.Borrow{
-		Borrower: claim.Owner,
-		Amount:   arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
-	}
-
-	suite.keeper.SynchronizeHardBorrowReward(suite.ctx, borrow)
-
-	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
-	suite.Equal(globalIndexes, syncedClaim.BorrowRewardIndexes)
-}
 func (suite *SynchronizeHardBorrowRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded borrow denom (that the user has already borrowed), and the claim is synced;
 	// Then the new reward coin's index should be added to the claim.
@@ -213,7 +187,6 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenGlobal
 func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard borrow denom the user has already borrowed, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
-	suite.T().Skip("TODO fix this bug")
 
 	originalReward := arbitraryCoins()
 	claim := types.HardLiquidityProviderClaim{

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -61,7 +61,7 @@ func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite,
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -81,7 +81,7 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 
 	totalDelegated := k.GetTotalDelegated(ctx, delegator, valAddr, shouldIncludeValidator)
 
-	rewardsEarned := k.calculateSingleReward(userRewardFactor, delegatorFactor, totalDelegated.RoundInt()) // TODO fix rounding
+	rewardsEarned := k.calculateSingleReward(userRewardFactor, delegatorFactor, totalDelegated)
 	newRewardsCoin := sdk.NewCoin(types.HardLiquidityRewardDenom, rewardsEarned)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -51,12 +51,12 @@ func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.Acc
 		claim, _ = k.GetHardLiquidityProviderClaim(ctx, delegator)
 	}
 
-	delegatorFactor, foundDelegatorFactor := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
-	if !foundDelegatorFactor { // Should always be found...
-		delegatorFactor = sdk.ZeroDec()
+	globalRewardFactor, found := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
+	if !found { // Should always be found...
+		globalRewardFactor = sdk.ZeroDec()
 	}
 
-	claim.DelegatorRewardIndexes = types.RewardIndexes{types.NewRewardIndex(types.BondDenom, delegatorFactor)}
+	claim.DelegatorRewardIndexes = types.RewardIndexes{types.NewRewardIndex(types.BondDenom, globalRewardFactor)}
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }
 
@@ -69,7 +69,7 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 		return
 	}
 
-	delegatorFactor, found := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
+	globalRewardFactor, found := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
 	if !found {
 		// The global factor is only not found if
 		// - the bond denom has not started accumulating rewards yet (either there is no reward specified in params, or the reward start time hasn't been hit)
@@ -82,16 +82,19 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 
 	userRewardFactor, found := claim.DelegatorRewardIndexes.Get(types.BondDenom)
 	if !found {
+		// Normally the factor should always be found, as it is added in InitializeHardDelegatorReward when a user delegates.
+		// However if there were no delegator rewards (ie no reward period in params) then a reward period is added, existing claims will not have the factor.
+		// So assume the factor is the starting value for any global factor: 0.
 		userRewardFactor = sdk.ZeroDec()
 	}
 
 	totalDelegated := k.GetTotalDelegated(ctx, delegator, valAddr, shouldIncludeValidator)
 
-	rewardsEarned := k.calculateSingleReward(userRewardFactor, delegatorFactor, totalDelegated)
+	rewardsEarned := k.calculateSingleReward(userRewardFactor, globalRewardFactor, totalDelegated)
 	newRewardsCoin := sdk.NewCoin(types.HardLiquidityRewardDenom, rewardsEarned)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)
-	claim.DelegatorRewardIndexes = claim.DelegatorRewardIndexes.With(types.BondDenom, delegatorFactor)
+	claim.DelegatorRewardIndexes = claim.DelegatorRewardIndexes.With(types.BondDenom, globalRewardFactor)
 
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -54,8 +54,8 @@ func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.Acc
 	}
 
 	globalRewardFactor, found := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
-	if !found { // Should always be found...
-		// if there is no global delegator reward factor, initialize the claim with a delegator factor of zero. This prevents rewards from being lost if delegator rewards are turned on in the future.
+	if !found {
+		// If there's no global delegator reward factor, initialize the claim with a delegator factor of zero.
 		globalRewardFactor = sdk.ZeroDec()
 	}
 

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -100,14 +100,16 @@ func (k Keeper) GetTotalDelegated(ctx sdk.Context, delegator sdk.AccAddress, val
 			continue
 		}
 
-		if valAddr == nil {
-			// Delegators don't accumulate rewards if their validator is unbonded
-			if validator.GetStatus() != sdk.Bonded {
+		if validator.OperatorAddress.Equals(valAddr) {
+			if shouldIncludeValidator {
+				// do nothing, so the validator is included regardless of bonded status
+			} else {
+				// skip this validator
 				continue
 			}
 		} else {
-			if !shouldIncludeValidator && validator.OperatorAddress.Equals(valAddr) {
-				// ignore tokens delegated to the validator
+			// skip any not bonded validator
+			if validator.GetStatus() != sdk.Bonded {
 				continue
 			}
 		}

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -55,6 +55,7 @@ func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.Acc
 
 	globalRewardFactor, found := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
 	if !found { // Should always be found...
+		// if there is no global delegator reward factor, initialize the claim with a delegator factor of zero. This prevents rewards from being lost if delegator rewards are turned on in the future.
 		globalRewardFactor = sdk.ZeroDec()
 	}
 

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -267,7 +267,7 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingA
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
 	suite.Equal(
-		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
+		d("10"),
 		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[0], false),
 	)
 }
@@ -310,7 +310,7 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingA
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
 	suite.Equal(
-		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
+		d("111"),
 		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[2], true),
 	)
 }

--- a/x/incentive/keeper/rewards_supply.go
+++ b/x/incentive/keeper/rewards_supply.go
@@ -117,7 +117,7 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 			continue
 		}
 
-		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount)
+		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())
 		if err != nil {
 			// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
 			// This panics if a global reward factor decreases or disappears between the old and new indexes.

--- a/x/incentive/keeper/rewards_supply.go
+++ b/x/incentive/keeper/rewards_supply.go
@@ -87,8 +87,8 @@ func (k Keeper) InitializeHardSupplyReward(ctx sdk.Context, deposit hardtypes.De
 
 	var supplyRewardIndexes types.MultiRewardIndexes
 	for _, coin := range deposit.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
+		if !found {
 			globalRewardIndexes = types.RewardIndexes{}
 		}
 		supplyRewardIndexes = supplyRewardIndexes.With(coin.Denom, globalRewardIndexes)
@@ -107,8 +107,8 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 	}
 
 	for _, coin := range deposit.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
+		if !found {
 			// The global factor is only not found if
 			// - the supply denom has not started accumulating rewards yet (either there is no reward specified in params, or the reward start time hasn't been hit)
 			// - OR it was wrongly deleted from state (factors should never be removed while unsynced claims exist)
@@ -118,15 +118,15 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 			continue
 		}
 
-		userMultiRewardIndexes, foundUserMultiRewardIndex := claim.SupplyRewardIndexes.Get(coin.Denom)
-		if !foundUserMultiRewardIndex {
+		userRewardIndexes, found := claim.SupplyRewardIndexes.Get(coin.Denom)
+		if !found {
 			// Normally the reward indexes should always be found.
 			// But if a denom was not rewarded then becomes rewarded (ie a reward period is added to params), then the indexes will be missing from claims for that supplied denom.
 			// So given the reward period was just added, assume the starting value for any global reward indexes, which is an empty slice.
-			userMultiRewardIndexes = types.RewardIndexes{}
+			userRewardIndexes = types.RewardIndexes{}
 		}
 
-		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())
+		newRewards, err := k.CalculateRewards(userRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())
 		if err != nil {
 			// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
 			// This panics if a global reward factor decreases or disappears between the old and new indexes.

--- a/x/incentive/keeper/rewards_supply.go
+++ b/x/incentive/keeper/rewards_supply.go
@@ -114,7 +114,10 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 
 		userMultiRewardIndexes, foundUserMultiRewardIndex := claim.SupplyRewardIndexes.Get(coin.Denom)
 		if !foundUserMultiRewardIndex {
-			continue
+			// Normally the reward indexes should always be found.
+			// But if a denom was not rewarded then becomes rewarded (ie a reward period is added to params), then the indexes will be missing from claims for that supplied denom.
+			// So given the reward period was just added, assume the starting value for any global reward indexes, which is an empty slice.
+			userMultiRewardIndexes = types.RewardIndexes{}
 		}
 
 		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -100,6 +100,32 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
 	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
 }
+func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAddedWithZeroRewardsPerSecond() {
+	// When a new reward (with zero rewards per second) is added (via gov) for a hard deposited denom the user has already deposited, and the claim is synced;
+	// Then the new reward's index should be added to the claim.
+	suite.T().Skip("TODO fix this bug")
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := nonEmptyMultiRewardIndexes.With("uniquezerorps", nil)
+	suite.storeGlobalBorrowIndexes(globalIndexes)
+
+	deposit := hardtypes.Deposit{
+		Depositor: claim.Owner,
+		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
+	}
+
+	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
+}
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the new reward coin's index should be added to the claim.

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -77,7 +77,6 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUnchangedWhenG
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced;
 	// Then the new reward's index should be added to the claim.
-	suite.T().Skip("TODO fix this bug")
 
 	claim := types.HardLiquidityProviderClaim{
 		BaseMultiClaim: types.BaseMultiClaim{
@@ -100,32 +99,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
 	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
 }
-func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAddedWithZeroRewardsPerSecond() {
-	// When a new reward (with zero rewards per second) is added (via gov) for a hard deposited denom the user has already deposited, and the claim is synced;
-	// Then the new reward's index should be added to the claim.
-	suite.T().Skip("TODO fix this bug")
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner: arbitraryAddress(),
-		},
-		SupplyRewardIndexes: nonEmptyMultiRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	globalIndexes := nonEmptyMultiRewardIndexes.With("uniquezerorps", nil)
-	suite.storeGlobalBorrowIndexes(globalIndexes)
-
-	deposit := hardtypes.Deposit{
-		Depositor: claim.Owner,
-		Amount:    arbitraryCoinsWithDenoms(extractCollateralTypes(globalIndexes)...),
-	}
-
-	suite.keeper.SynchronizeHardSupplyReward(suite.ctx, deposit)
-
-	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
-	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
-}
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the new reward coin's index should be added to the claim.
@@ -209,7 +183,6 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenGlobal
 func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
-	suite.T().Skip("TODO fix this bug")
 
 	originalReward := arbitraryCoins()
 	claim := types.HardLiquidityProviderClaim{

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -61,7 +61,7 @@ func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -59,11 +59,11 @@ func (k Keeper) InitializeUSDXMintingClaim(ctx sdk.Context, cdp cdptypes.CDP) {
 	if !found { // this is the owner's first usdx minting reward claim
 		claim = types.NewUSDXMintingClaim(cdp.Owner, sdk.NewCoin(types.USDXMintingRewardDenom, sdk.ZeroInt()), types.RewardIndexes{})
 	}
-	rewardFactor, found := k.GetUSDXMintingRewardFactor(ctx, cdp.Type)
+	globalRewardFactor, found := k.GetUSDXMintingRewardFactor(ctx, cdp.Type)
 	if !found {
-		rewardFactor = sdk.ZeroDec()
+		globalRewardFactor = sdk.ZeroDec()
 	}
-	claim.RewardIndexes = claim.RewardIndexes.With(cdp.Type, rewardFactor)
+	claim.RewardIndexes = claim.RewardIndexes.With(cdp.Type, globalRewardFactor)
 
 	k.SetUSDXMintingClaim(ctx, claim)
 }
@@ -91,8 +91,8 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		)
 	}
 
-	userRewardFactor, hasRewardIndex := claim.RewardIndexes.Get(cdp.Type)
-	if !hasRewardIndex {
+	userRewardFactor, found := claim.RewardIndexes.Get(cdp.Type)
+	if !found {
 		// Normally the factor should always be found, as it is added when the cdp is created in InitializeUSDXMintingClaim.
 		// However if a cdp type is not rewarded then becomes rewarded (ie a reward period is added to params), existing cdps will not have the factor in their claims.
 		// So assume the factor is the starting value for any global factor: 0.

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
@@ -99,7 +101,12 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		userRewardFactor = sdk.ZeroDec()
 	}
 
-	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount.ToDec())
+	newRewardsAmount, err := k.CalculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount.ToDec())
+	if err != nil {
+		// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
+		// This panics if a global reward factor decreases or disappears between the old and new indexes.
+		panic(fmt.Sprintf("corrupted global reward indexes found: %v", err))
+	}
 	newRewardsCoin := sdk.NewCoin(types.USDXMintingRewardDenom, newRewardsAmount)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -95,7 +95,7 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		userRewardFactor = globalRewardFactor
 	}
 
-	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount)
+	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount.ToDec())
 	newRewardsCoin := sdk.NewCoin(types.USDXMintingRewardDenom, newRewardsAmount)
 
 	claim.Reward = claim.Reward.Add(newRewardsCoin)

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -71,7 +71,7 @@ func (k Keeper) InitializeUSDXMintingClaim(ctx sdk.Context, cdp cdptypes.CDP) {
 }
 
 // SynchronizeUSDXMintingReward updates the claim object by adding any accumulated rewards and updating the reward index value.
-// this should be called before a cdp is modified, immediately after the 'SynchronizeInterest' method is called in the cdp module
+// this should be called before a cdp is modified.
 func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) {
 
 	globalRewardFactor, found := k.GetUSDXMintingRewardFactor(ctx, cdp.Type)

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -91,8 +91,11 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 	}
 
 	userRewardFactor, hasRewardIndex := claim.RewardIndexes.Get(cdp.Type)
-	if !hasRewardIndex { // this is the owner's first usdx minting reward for this collateral type
-		userRewardFactor = globalRewardFactor
+	if !hasRewardIndex {
+		// Normally the factor should always be found, as it is added when the cdp is created in InitializeUSDXMintingClaim.
+		// However if a cdp type is not rewarded then becomes rewarded (ie a reward period is added to params), existing cdps will not have the factor in their claims.
+		// So assume the factor is the starting value for any global factor: 0.
+		userRewardFactor = sdk.ZeroDec()
 	}
 
 	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount.ToDec())

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -302,24 +302,3 @@ func extractFirstCollateralType(indexes types.RewardIndexes) string {
 	}
 	return indexes[0].CollateralType
 }
-
-/*
-Init
-given a claim doesn't exist, when sync is called, a claim is created with the current global index for cdp.Type
-given a claim does exist, when sync is called, the claim's indexes are updated with the current global index for cdp.Type
-same as above but with new cdp.Type, rather than existing one
-
-other
-given a reward period doesn't exist, do nothing
-given the global index doesn't exist, update index with 0
-
-
-Sync
-given increase in global indexes, new rewards are added
-given unchanged global indexes, no new rewards
-given new global index added, new rewards starting from zero
-
-other
-given no reward period, do nothing
-given no claim, create one with 0 global index
-*/

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -175,7 +175,7 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenNewRe
 
 	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
 	// The global index was not around when this cdp was created as it was not stored in a claim.
-	// Therefor it must have been added via params after.
+	// Therefore it must have been added via params after.
 	// To include rewards since the params were updated, the old index should be assumed to be 0.
 	// reward is ( new index - old index ) * cdp.TotalPrincipal
 	suite.Equal(c(types.USDXMintingRewardDenom, 2e11), syncedClaim.Reward)

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -109,7 +109,7 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardUnchangedWhenGlobalInd
 
 	suite.storeGlobalUSDXIndexes(unchangingRewardIndexes)
 
-	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+	cdp := NewCDPBuilder(claim.Owner, collateralType).WithPrincipal(i(1e12)).Build()
 
 	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
 
@@ -155,7 +155,6 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenGloba
 }
 
 func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenNewRewardAddedAndClaimDoesNotExit() {
-	suite.T().Skip("TODO fix this bug")
 	collateralType := "bnb-a"
 
 	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -402,7 +402,7 @@ func (ris RewardIndexes) GetRewardIndex(denom string) (RewardIndex, bool) {
 	return RewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardFactor by it's denom
 func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	for _, ri := range ris {
 		if ri.CollateralType == denom {
@@ -412,7 +412,7 @@ func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	return sdk.Dec{}, false
 }
 
-// With returns a copy of the indexes with a new reward index added
+// With returns a copy of the indexes with a new reward factor added
 func (ris RewardIndexes) With(denom string, factor sdk.Dec) RewardIndexes {
 	newIndexes := make(RewardIndexes, len(ris))
 	copy(newIndexes, ris)
@@ -500,7 +500,7 @@ func (mris MultiRewardIndexes) GetRewardIndex(denom string) (MultiRewardIndex, b
 	return MultiRewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardIndexes by it's denom
 func (mris MultiRewardIndexes) Get(denom string) (RewardIndexes, bool) {
 	for _, mri := range mris {
 		if mri.CollateralType == denom {
@@ -564,7 +564,7 @@ func (mris MultiRewardIndexes) Validate() error {
 	return nil
 }
 
-// copy returns a copy the slice and underlying array
+// copy returns a copy of the slice and underlying array
 func (mris MultiRewardIndexes) copy() MultiRewardIndexes {
 	newIndexes := make(MultiRewardIndexes, len(mris))
 	copy(newIndexes, mris)

--- a/x/incentive/types/claims_test.go
+++ b/x/incentive/types/claims_test.go
@@ -349,7 +349,6 @@ func TestMultiRewardIndexes(t *testing.T) {
 	})
 }
 
-// TODO dedupe with copy in keeper
 func appendUniqueRewardIndex(indexes RewardIndexes) RewardIndexes {
 	const uniqueDenom = "uniquereward"
 


### PR DESCRIPTION
Third of three PRs (#929, #928, #927) to add tests and simplify the incentive code.

This PR fixes bugs that were found during refactoring, and tidies up various TODOS.

bugs
- total delegation was not calculated correctly
- if new rewards are added, users didn't accrue rewards until they synced