### PR TITLE
Incentive refactor: delegator and usdx rewards

### DIFF
--- a/x/incentive/keeper/hooks.go
+++ b/x/incentive/keeper/hooks.go
@@ -81,6 +81,8 @@ When delegated tokens (to bonded validators) are changed:
   - jail: total bonded delegation decreases (tokens no longer bonded (after end blocker runs))
 - validator becomes unbonded (ie when they drop out of the top 100)
   - total bonded delegation decreases (tokens no longer bonded)
+- validator becomes bonded (ie when they're promoted into the top 100)
+  - total bonded delegation increases (tokens become bonded)
 
 */
 

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -262,9 +262,6 @@ func (builder IncentiveGenesisBuilder) WithSimpleBorrowRewardPeriod(ctype string
 	))
 }
 func (builder IncentiveGenesisBuilder) WithInitializedSupplyRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
-	// TODO this could set the start/end times on the period according to builder.genesisTime
-	// Then they could be created by a different builder
-
 	builder.Params.HardSupplyRewardPeriods = append(builder.Params.HardSupplyRewardPeriods, period)
 
 	accumulationTimeForPeriod := types.NewGenesisAccumulationTime(period.CollateralType, builder.genesisTime)

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/params/subspace"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -18,16 +17,20 @@ type Keeper struct {
 	cdpKeeper     types.CdpKeeper
 	hardKeeper    types.HardKeeper
 	key           sdk.StoreKey
-	paramSubspace subspace.Subspace
+	paramSubspace types.ParamSubspace
 	supplyKeeper  types.SupplyKeeper
 	stakingKeeper types.StakingKeeper
 }
 
 // NewKeeper creates a new keeper
 func NewKeeper(
-	cdc *codec.Codec, key sdk.StoreKey, paramstore subspace.Subspace, sk types.SupplyKeeper,
+	cdc *codec.Codec, key sdk.StoreKey, paramstore types.ParamSubspace, sk types.SupplyKeeper,
 	cdpk types.CdpKeeper, hk types.HardKeeper, ak types.AccountKeeper, stk types.StakingKeeper,
 ) Keeper {
+
+	if !paramstore.HasKeyTable() {
+		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
+	}
 
 	return Keeper{
 		accountKeeper: ak,
@@ -35,7 +38,7 @@ func NewKeeper(
 		cdpKeeper:     cdpk,
 		hardKeeper:    hk,
 		key:           key,
-		paramSubspace: paramstore.WithKeyTable(types.ParamKeyTable()),
+		paramSubspace: paramstore,
 		supplyKeeper:  sk,
 		stakingKeeper: stk,
 	}

--- a/x/incentive/keeper/rewards_borrow_sync_test.go
+++ b/x/incentive/keeper/rewards_borrow_sync_test.go
@@ -184,7 +184,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenGlobal
 	)
 }
 
-func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNewRewardAdded() {
+func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard borrow denom the user has already borrowed, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
 	suite.T().Skip("TODO fix this bug")
@@ -248,7 +248,7 @@ func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNe
 		syncedClaim.Reward,
 	)
 }
-func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenWhenNewRewardDenomAdded() {
+func (suite *SynchronizeHardBorrowRewardTests) TestRewardIsIncrementedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded borrow denom (that the user has already borrowed), and the claim is synced;
 	// Then the user earns rewards for the time since the reward was added
 

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -61,7 +61,7 @@ func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite,
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *BorrowRewardsTestSuite) TestSynchronizeHardBorrowReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -65,6 +65,8 @@ func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.Acc
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }
 
+var TestHelper_TotalDelegated sdk.Dec
+
 // SynchronizeHardDelegatorRewards updates the claim object by adding any accumulated rewards, and setting the reward indexes to the global values.
 // valAddr and shouldIncludeValidator are used to ignore or include delegations to a particular validator when summing up the total delegation.
 // Normally only delegations to Bonded validators are included in the total. This is needed as staking hooks are sometimes called on the wrong side of a validator's state update (from this module's perspective).
@@ -122,6 +124,7 @@ func (k Keeper) SynchronizeHardDelegatorRewards(ctx sdk.Context, delegator sdk.A
 		}
 		totalDelegated = totalDelegated.Add(delegatedTokens)
 	}
+	TestHelper_TotalDelegated = totalDelegated
 	rewardsEarned := rewardsAccumulatedFactor.Mul(totalDelegated).RoundInt()
 
 	// Add rewards to delegator's hard claim

--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -45,23 +45,20 @@ func (k Keeper) AccumulateHardDelegatorRewards(ctx sdk.Context, rewardPeriod typ
 
 // InitializeHardDelegatorReward initializes the delegator reward index of a hard claim
 func (k Keeper) InitializeHardDelegatorReward(ctx sdk.Context, delegator sdk.AccAddress) {
-	delegatorFactor, foundDelegatorFactor := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
-	if !foundDelegatorFactor { // Should always be found...
-		delegatorFactor = sdk.ZeroDec()
-	}
-
-	delegatorRewardIndexes := types.NewRewardIndex(types.BondDenom, delegatorFactor)
-
 	claim, found := k.GetHardLiquidityProviderClaim(ctx, delegator)
 	if !found {
-		// Instantiate claim object
 		claim = types.NewHardLiquidityProviderClaim(delegator, sdk.Coins{}, nil, nil, nil)
 	} else {
 		k.SynchronizeHardDelegatorRewards(ctx, delegator, nil, false)
 		claim, _ = k.GetHardLiquidityProviderClaim(ctx, delegator)
 	}
 
-	claim.DelegatorRewardIndexes = types.RewardIndexes{delegatorRewardIndexes}
+	delegatorFactor, foundDelegatorFactor := k.GetHardDelegatorRewardFactor(ctx, types.BondDenom)
+	if !foundDelegatorFactor { // Should always be found...
+		delegatorFactor = sdk.ZeroDec()
+	}
+
+	claim.DelegatorRewardIndexes = types.RewardIndexes{types.NewRewardIndex(types.BondDenom, delegatorFactor)}
 	k.SetHardLiquidityProviderClaim(ctx, claim)
 }
 

--- a/x/incentive/keeper/rewards_delegator_init_test.go
+++ b/x/incentive/keeper/rewards_delegator_init_test.go
@@ -1,0 +1,115 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// InitializeHardDelegatorRewardTests runs unit tests for the keeper.InitializeHardDelegatorReward method
+//
+// inputs
+// - claim in store if it exists (only claim.DelegatorRewardIndexes)
+// - global indexes in store
+// - delegator function arg
+//
+// outputs
+// - sets or creates a claim
+type InitializeHardDelegatorRewardTests struct {
+	unitTester
+}
+
+func TestInitializeHardDelegatorReward(t *testing.T) {
+	suite.Run(t, new(InitializeHardDelegatorRewardTests))
+}
+
+func (suite *InitializeHardDelegatorRewardTests) storeGlobalDelegatorFactor(rewardIndexes types.RewardIndexes) {
+	factor := rewardIndexes[0]
+	suite.keeper.SetHardDelegatorRewardFactor(suite.ctx, factor.CollateralType, factor.RewardFactor)
+}
+
+func (suite *InitializeHardDelegatorRewardTests) TestClaimIndexesAreSetWhenClaimDoesNotExist() {
+	globalIndex := arbitraryDelegatorRewardIndexes
+	suite.storeGlobalDelegatorFactor(globalIndex)
+
+	delegator := arbitraryAddress()
+	suite.keeper.InitializeHardDelegatorReward(suite.ctx, delegator)
+
+	syncedClaim, f := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, delegator)
+	suite.True(f)
+	suite.Equal(globalIndex, syncedClaim.DelegatorRewardIndexes)
+}
+
+func (suite *InitializeHardDelegatorRewardTests) TestClaimIsSyncedAndIndexesAreSetWhenClaimDoesExist() {
+	validatorAddress := arbitraryValidatorAddress()
+	sk := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{{
+			ValidatorAddress: validatorAddress,
+			Shares:           d("1000"),
+		}},
+		validators: stakingtypes.Validators{{
+			OperatorAddress: validatorAddress,
+			Status:          sdk.Bonded,
+			Tokens:          i(1000),
+			DelegatorShares: d("1000"),
+		}},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, sk)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: arbitraryAddress(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	// Set the global factor to a value different to one in claim so
+	// we can detect if it is overwritten.
+	globalIndex := increaseRewardFactors(claim.DelegatorRewardIndexes)
+	suite.storeGlobalDelegatorFactor(globalIndex)
+
+	suite.keeper.InitializeHardDelegatorReward(suite.ctx, claim.Owner)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndex, syncedClaim.DelegatorRewardIndexes)
+	suite.Truef(syncedClaim.Reward.IsAllGT(claim.Reward), "'%s' not greater than '%s'", syncedClaim.Reward, claim.Reward)
+}
+
+// arbitraryDelegatorRewardIndexes contains only one reward index as there is only every one bond denom
+var arbitraryDelegatorRewardIndexes = types.RewardIndexes{
+	types.NewRewardIndex(types.BondDenom, d("0.2")),
+}
+
+type fakeStakingKeeper struct {
+	delegations stakingtypes.Delegations
+	validators  stakingtypes.Validators
+}
+
+func (k fakeStakingKeeper) TotalBondedTokens(ctx sdk.Context) sdk.Int {
+	panic("unimplemented")
+}
+func (k fakeStakingKeeper) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress, maxRetrieve uint16) []stakingtypes.Delegation {
+	return k.delegations
+}
+func (k fakeStakingKeeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (stakingtypes.Validator, bool) {
+	for _, val := range k.validators {
+		if val.GetOperator().Equals(addr) {
+			return val, true
+		}
+	}
+	return stakingtypes.Validator{}, false
+}
+func (k fakeStakingKeeper) GetValidatorDelegations(ctx sdk.Context, valAddr sdk.ValAddress) []stakingtypes.Delegation {
+	var delegations stakingtypes.Delegations
+	for _, d := range k.delegations {
+		if d.ValidatorAddress.Equals(valAddr) {
+			delegations = append(delegations, d)
+		}
+	}
+	return delegations
+}

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -1,0 +1,356 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// SynchronizeHardDelegatorRewardTests runs unit tests for the keeper.SynchronizeHardDelegatorReward method
+//
+// inputs
+// - claim in store if it exists (only claim.DelegatorRewardIndexes and claim.Reward)
+// - global index in store
+// - function args: delegator address, validator address, shouldIncludeValidator flag
+// - delegator's delegations and the corresponding validators
+//
+// outputs
+// - sets or creates a claim
+type SynchronizeHardDelegatorRewardTests struct {
+	unitTester
+}
+
+func TestSynchronizeHardDelegatorReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeHardDelegatorRewardTests))
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) storeGlobalDelegatorFactor(rewardIndexes types.RewardIndexes) {
+	factor := rewardIndexes[0]
+	suite.keeper.SetHardDelegatorRewardFactor(suite.ctx, factor.CollateralType, factor.RewardFactor)
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestClaimIndexesAreUnchangedWhenGlobalFactorUnchanged() {
+	delegator := arbitraryAddress()
+
+	stakingKeeper := fakeStakingKeeper{} // use an empty staking keeper that returns no delegations
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: delegator,
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.DelegatorRewardIndexes, syncedClaim.DelegatorRewardIndexes)
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestClaimIndexesAreUpdatedWhenGlobalFactorIncreased() {
+	delegator := arbitraryAddress()
+
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, fakeStakingKeeper{})
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner: delegator,
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claim.DelegatorRewardIndexes)
+	suite.storeGlobalDelegatorFactor(globalIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+	suite.Equal(globalIndexes, syncedClaim.DelegatorRewardIndexes)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsUnchangedWhenGlobalFactorUnchanged() {
+	delegator := arbitraryAddress()
+	validatorAddress := arbitraryValidatorAddress()
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddress,
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddress),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: types.RewardIndexes{{
+			CollateralType: types.BondDenom,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+
+	suite.Equal(claim.Reward, syncedClaim.Reward)
+}
+
+// No test for TestRewardIsIncrementedWhenNewRewardAdded as we can currently only have one reward denom for our one bond denom.
+// So new rewards cannot be added.
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsIncreasedWhenGlobalFactorIncreased() {
+	delegator := arbitraryAddress()
+	validatorAddress := arbitraryValidatorAddress()
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddress,
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddress),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: types.RewardIndexes{{
+			CollateralType: types.BondDenom,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(
+		types.RewardIndexes{
+			types.NewRewardIndex(types.BondDenom, d("0.2")),
+		},
+	)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+
+	suite.Equal(
+		cs(c(types.HardLiquidityRewardDenom, 100)).Add(claim.Reward...),
+		syncedClaim.Reward,
+	)
+}
+
+func unslashedBondedValidator(address sdk.ValAddress) stakingtypes.Validator {
+	return stakingtypes.Validator{
+		OperatorAddress: address,
+		Status:          sdk.Bonded,
+
+		// Set the tokens and shares equal so then
+		// a _delegator's_ token amount is equal to their shares amount
+		Tokens:          i(1e12),
+		DelegatorShares: i(1e12).ToDec(),
+	}
+}
+func unslashedNotBondedValidator(address sdk.ValAddress) stakingtypes.Validator {
+	return stakingtypes.Validator{
+		OperatorAddress: address,
+		Status:          sdk.Unbonding,
+
+		// Set the tokens and shares equal so then
+		// a _delegator's_ token amount is equal to their shares amount
+		Tokens:          i(1e12),
+		DelegatorShares: i(1e12).ToDec(),
+	}
+}
+
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenValAddrIsNil() {
+	// when valAddr is nil, get total delegated to bonded validators
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	suite.Equal(
+		d("11"), // delegation to bonded validators
+		keeper.TestHelper_TotalDelegated,
+	)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingAValidator() {
+	// when valAddr is x, get total delegated to bonded validators excluding those to x
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[0], false)
+
+	suite.Equal(
+		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
+		keeper.TestHelper_TotalDelegated,
+	)
+}
+func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingAValidator() {
+	// when valAddr is x, get total delegated to bonded validators including those to x
+	delegator := arbitraryAddress()
+	validatorAddresses := generateValidatorAddresses(4)
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			//bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[0],
+				Shares:           d("1"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[1],
+				Shares:           d("10"),
+			},
+			// not bonded
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[2],
+				Shares:           d("100"),
+			},
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddresses[3],
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddresses[0]),
+			unslashedBondedValidator(validatorAddresses[1]),
+			unslashedNotBondedValidator(validatorAddresses[2]),
+			unslashedNotBondedValidator(validatorAddresses[3]),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[2], true)
+
+	suite.Equal(
+		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
+		keeper.TestHelper_TotalDelegated,
+	)
+}

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -114,8 +114,48 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsUnchangedWhenGloba
 	suite.Equal(claim.Reward, syncedClaim.Reward)
 }
 
-// No test for TestRewardIsIncrementedWhenNewRewardAdded as we can currently only have one reward denom for our one bond denom.
-// So new rewards cannot be added.
+func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsIncreasedWhenNewRewardAdded() {
+	delegator := arbitraryAddress()
+	validatorAddress := arbitraryValidatorAddress()
+	stakingKeeper := fakeStakingKeeper{
+		delegations: stakingtypes.Delegations{
+			{
+				DelegatorAddress: delegator,
+				ValidatorAddress: validatorAddress,
+				Shares:           d("1000"),
+			},
+		},
+		validators: stakingtypes.Validators{
+			unslashedBondedValidator(validatorAddress),
+		},
+	}
+	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
+
+	claim := types.HardLiquidityProviderClaim{
+		BaseMultiClaim: types.BaseMultiClaim{
+			Owner:  delegator,
+			Reward: arbitraryCoins(),
+		},
+		DelegatorRewardIndexes: types.RewardIndexes{},
+	}
+	suite.storeClaim(claim)
+
+	newGlobalIndexes := types.RewardIndexes{{
+		CollateralType: types.BondDenom,
+		RewardFactor:   d("0.1"),
+	}}
+	suite.storeGlobalDelegatorFactor(newGlobalIndexes)
+
+	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
+
+	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
+
+	suite.Equal(newGlobalIndexes, syncedClaim.DelegatorRewardIndexes)
+	suite.Equal(
+		cs(c(types.HardLiquidityRewardDenom, 100)).Add(claim.Reward...),
+		syncedClaim.Reward,
+	)
+}
 
 func (suite *SynchronizeHardDelegatorRewardTests) TestRewardIsIncreasedWhenGlobalFactorIncreased() {
 	delegator := arbitraryAddress()
@@ -267,7 +307,7 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingA
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
 	suite.Equal(
-		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
+		d("10"),
 		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[0], false),
 	)
 }
@@ -310,7 +350,7 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingA
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
 	suite.Equal(
-		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
+		d("111"),
 		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[2], true),
 	)
 }

--- a/x/incentive/keeper/rewards_delegator_sync_test.go
+++ b/x/incentive/keeper/rewards_delegator_sync_test.go
@@ -7,7 +7,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
@@ -224,22 +223,9 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenValAddrIsN
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, nil, false)
-
 	suite.Equal(
 		d("11"), // delegation to bonded validators
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, nil, false),
 	)
 }
 func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingAValidator() {
@@ -280,22 +266,9 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenExcludingA
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[0], false)
-
 	suite.Equal(
 		d("1110"), // FIXME should be d("10"): total delegation to bonded validators, excluding one
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[0], false),
 	)
 }
 func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingAValidator() {
@@ -336,21 +309,8 @@ func (suite *SynchronizeHardDelegatorRewardTests) TestGetDelegatedWhenIncludingA
 	}
 	suite.keeper = suite.NewKeeper(&fakeParamSubspace{}, nil, nil, nil, nil, stakingKeeper)
 
-	claim := types.HardLiquidityProviderClaim{
-		BaseMultiClaim: types.BaseMultiClaim{
-			Owner:  delegator,
-			Reward: arbitraryCoins(),
-		},
-		DelegatorRewardIndexes: arbitraryDelegatorRewardIndexes,
-	}
-	suite.storeClaim(claim)
-
-	suite.storeGlobalDelegatorFactor(claim.DelegatorRewardIndexes)
-
-	suite.keeper.SynchronizeHardDelegatorRewards(suite.ctx, claim.Owner, validatorAddresses[2], true)
-
 	suite.Equal(
 		d("1111"), // FIXME should be d("111"): total delegation to bonded validators, including an unbonding one
-		keeper.TestHelper_TotalDelegated,
+		suite.keeper.GetTotalDelegated(suite.ctx, delegator, validatorAddresses[2], true),
 	)
 }

--- a/x/incentive/keeper/rewards_supply.go
+++ b/x/incentive/keeper/rewards_supply.go
@@ -87,8 +87,8 @@ func (k Keeper) InitializeHardSupplyReward(ctx sdk.Context, deposit hardtypes.De
 
 	var supplyRewardIndexes types.MultiRewardIndexes
 	for _, coin := range deposit.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
+		if !found {
 			globalRewardIndexes = types.RewardIndexes{}
 		}
 		supplyRewardIndexes = supplyRewardIndexes.With(coin.Denom, globalRewardIndexes)
@@ -107,17 +107,26 @@ func (k Keeper) SynchronizeHardSupplyReward(ctx sdk.Context, deposit hardtypes.D
 	}
 
 	for _, coin := range deposit.Amount {
-		globalRewardIndexes, foundGlobalRewardIndexes := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
-		if !foundGlobalRewardIndexes {
+		globalRewardIndexes, found := k.GetHardSupplyRewardIndexes(ctx, coin.Denom)
+		if !found {
+			// The global factor is only not found if
+			// - the supply denom has not started accumulating rewards yet (either there is no reward specified in params, or the reward start time hasn't been hit)
+			// - OR it was wrongly deleted from state (factors should never be removed while unsynced claims exist)
+			// If not found we could either skip this sync, or assume the global factor is zero.
+			// Skipping will avoid storing unnecessary factors in the claim for non rewarded denoms.
+			// And in the event a global factor is wrongly deleted, it will avoid this function panicking when calculating rewards.
 			continue
 		}
 
-		userMultiRewardIndexes, foundUserMultiRewardIndex := claim.SupplyRewardIndexes.Get(coin.Denom)
-		if !foundUserMultiRewardIndex {
-			continue
+		userRewardIndexes, found := claim.SupplyRewardIndexes.Get(coin.Denom)
+		if !found {
+			// Normally the reward indexes should always be found.
+			// But if a denom was not rewarded then becomes rewarded (ie a reward period is added to params), then the indexes will be missing from claims for that supplied denom.
+			// So given the reward period was just added, assume the starting value for any global reward indexes, which is an empty slice.
+			userRewardIndexes = types.RewardIndexes{}
 		}
 
-		newRewards, err := k.CalculateRewards(userMultiRewardIndexes, globalRewardIndexes, coin.Amount)
+		newRewards, err := k.CalculateRewards(userRewardIndexes, globalRewardIndexes, coin.Amount.ToDec())
 		if err != nil {
 			// Global reward factors should never decrease, as it would lead to a negative update to claim.Rewards.
 			// This panics if a global reward factor decreases or disappears between the old and new indexes.

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -77,7 +77,6 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUnchangedWhenG
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced;
 	// Then the new reward's index should be added to the claim.
-	suite.T().Skip("TODO fix this bug")
 
 	claim := types.HardLiquidityProviderClaim{
 		BaseMultiClaim: types.BaseMultiClaim{
@@ -100,6 +99,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNew
 	syncedClaim, _ := suite.keeper.GetHardLiquidityProviderClaim(suite.ctx, claim.Owner)
 	suite.Equal(globalIndexes, syncedClaim.SupplyRewardIndexes)
 }
+
 func (suite *SynchronizeHardSupplyRewardTests) TestClaimIndexesAreUpdatedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the new reward coin's index should be added to the claim.
@@ -183,7 +183,6 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenGlobal
 func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
-	suite.T().Skip("TODO fix this bug")
 
 	originalReward := arbitraryCoins()
 	claim := types.HardLiquidityProviderClaim{

--- a/x/incentive/keeper/rewards_supply_sync_test.go
+++ b/x/incentive/keeper/rewards_supply_sync_test.go
@@ -180,7 +180,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenGlobal
 	)
 }
 
-func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardAdded() {
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardAdded() {
 	// When a new reward is added (via gov) for a hard deposit denom the user has already deposited, and the claim is synced
 	// Then the user earns rewards for the time since the reward was added
 	suite.T().Skip("TODO fix this bug")
@@ -244,7 +244,7 @@ func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNe
 		syncedClaim.Reward,
 	)
 }
-func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenWhenNewRewardDenomAdded() {
+func (suite *SynchronizeHardSupplyRewardTests) TestRewardIsIncrementedWhenNewRewardDenomAdded() {
 	// When a new reward coin is added (via gov) to an already rewarded deposit denom (that the user has already deposited), and the claim is synced;
 	// Then the user earns rewards for the time since the reward was added
 

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -61,7 +61,7 @@ func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]), // TODO add committee members to suite
+		NewCommitteeGenesisState(suite.addrs[:2]),
 		incentBuilder.BuildMarshalled(),
 	)
 }
@@ -498,7 +498,6 @@ func (suite *SupplyRewardsTestSuite) TestSynchronizeHardSupplyReward() {
 				updatedTimeDuration: 86400,
 			},
 		},
-		// TODO test synchronize when there is a reward period with 0 rewardsPerSecond
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -86,13 +86,13 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 		claim = types.NewUSDXMintingClaim(
 			cdp.Owner,
 			sdk.NewCoin(types.USDXMintingRewardDenom, sdk.ZeroInt()),
-			types.RewardIndexes{types.NewRewardIndex(cdp.Type, globalRewardFactor)}, // FIXME factor should be 0.0
+			types.RewardIndexes{},
 		)
 	}
 
 	userRewardFactor, hasRewardIndex := claim.RewardIndexes.Get(cdp.Type)
 	if !hasRewardIndex { // this is the owner's first usdx minting reward for this collateral type
-		userRewardFactor = globalRewardFactor // FIXME should be 0.0
+		userRewardFactor = globalRewardFactor
 	}
 
 	newRewardsAmount := k.calculateSingleReward(userRewardFactor, globalRewardFactor, cdp.GetTotalPrincipal().Amount)

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -101,7 +101,7 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestRewardUnchangedWhenGlobalInd
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
 			Owner:  arbitraryAddress(),
-			Reward: arbitraryCoin(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: unchangingRewardIndexes,
 	}
@@ -163,7 +163,8 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenGloba
 
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
-			Owner: arbitraryAddress(),
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: claimsRewardIndexes,
 	}
@@ -202,7 +203,8 @@ func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenNewRe
 
 	claim := types.USDXMintingClaim{
 		BaseClaim: types.BaseClaim{
-			Owner: arbitraryAddress(),
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
 		},
 		RewardIndexes: claimsRewardIndexes,
 	}

--- a/x/incentive/keeper/rewards_usdx_unit_test.go
+++ b/x/incentive/keeper/rewards_usdx_unit_test.go
@@ -1,0 +1,298 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	cdptypes "github.com/kava-labs/kava/x/cdp/types"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// usdxRewardsUnitTester contains common methods for running unit tests for keeper methods related to the USDX minting rewards
+type usdxRewardsUnitTester struct {
+	unitTester
+}
+
+func (suite *usdxRewardsUnitTester) storeGlobalUSDXIndexes(indexes types.RewardIndexes) {
+	for _, ri := range indexes {
+		suite.keeper.SetUSDXMintingRewardFactor(suite.ctx, ri.CollateralType, ri.RewardFactor)
+	}
+}
+func (suite *usdxRewardsUnitTester) storeClaim(claim types.USDXMintingClaim) {
+	suite.keeper.SetUSDXMintingClaim(suite.ctx, claim)
+}
+
+type InitializeUSDXMintingClaimTests struct {
+	usdxRewardsUnitTester
+}
+
+func TestInitializeUSDXMintingClaims(t *testing.T) {
+	suite.Run(t, new(InitializeUSDXMintingClaimTests))
+}
+
+func (suite *InitializeUSDXMintingClaimTests) TestClaimIndexIsSetWhenClaimDoesNotExist() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	cdp := NewCDPBuilder(arbitraryAddress(), collateralType).Build()
+
+	globalIndexes := types.RewardIndexes{{
+		CollateralType: collateralType,
+		RewardFactor:   d("0.2"),
+	}}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	suite.keeper.InitializeUSDXMintingClaim(suite.ctx, cdp)
+
+	syncedClaim, f := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
+	suite.True(f)
+	suite.Equal(globalIndexes, syncedClaim.RewardIndexes)
+}
+
+func (suite *InitializeUSDXMintingClaimTests) TestClaimIndexIsSetWhenClaimExists() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: types.RewardIndexes{{
+			CollateralType: collateralType,
+			RewardFactor:   d("0.1"),
+		}},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.RewardIndexes{{
+		CollateralType: collateralType,
+		RewardFactor:   d("0.2"),
+	}}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.InitializeUSDXMintingClaim(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, cdp.Owner)
+	suite.Equal(globalIndexes, syncedClaim.RewardIndexes)
+}
+
+type SynchronizeUSDXMintingRewardTests struct {
+	usdxRewardsUnitTester
+}
+
+func TestSynchronizeUSDXMintingReward(t *testing.T) {
+	suite.Run(t, new(SynchronizeUSDXMintingRewardTests))
+}
+func (suite *SynchronizeUSDXMintingRewardTests) TestRewardUnchangedWhenGlobalIndexesUnchanged() {
+	unchangingRewardIndexes := nonEmptyRewardIndexes
+	collateralType := extractFirstCollateralType(unchangingRewardIndexes)
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner:  arbitraryAddress(),
+			Reward: arbitraryCoin(),
+		},
+		RewardIndexes: unchangingRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	suite.storeGlobalUSDXIndexes(unchangingRewardIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+	suite.Equal(claim.Reward, syncedClaim.Reward)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestRewardIsIncrementedWhenGlobalIndexesHaveIncreased() {
+	collateralType := "bnb-a"
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner:  arbitraryAddress(),
+			Reward: c(types.USDXMintingRewardDenom, 0),
+		},
+		RewardIndexes: types.RewardIndexes{
+			{
+				CollateralType: collateralType,
+				RewardFactor:   d("0.1"),
+			},
+		},
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := types.RewardIndexes{
+		{
+			CollateralType: collateralType,
+			RewardFactor:   d("0.2"),
+		},
+	}
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).WithPrincipal(i(1e12)).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+	// reward is ( new index - old index ) * cdp.TotalPrincipal
+	suite.Equal(c(types.USDXMintingRewardDenom, 1e11), syncedClaim.Reward)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenGlobalIndexIncreased() {
+	claimsRewardIndexes := nonEmptyRewardIndexes
+	collateralType := extractFirstCollateralType(claimsRewardIndexes)
+
+	subspace := paramsWithSingleUSDXRewardPeriod(collateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: claimsRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claimsRewardIndexes)
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, collateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+
+	// Only the claim's index for `collateralType` should have been changed
+	i, _ := globalIndexes.Get(collateralType)
+	expectedIndexes := claimsRewardIndexes.With(collateralType, i)
+	suite.Equal(expectedIndexes, syncedClaim.RewardIndexes)
+}
+
+func (suite *SynchronizeUSDXMintingRewardTests) TestClaimIndexIsUpdatedWhenNewRewardAddedAndClaimAlreadyExists() {
+	claimsRewardIndexes := types.RewardIndexes{
+		{
+			CollateralType: "bnb-a",
+			RewardFactor:   d("0.1"),
+		},
+		{
+			CollateralType: "busd-b",
+			RewardFactor:   d("0.4"),
+		},
+	}
+	newRewardIndex := types.NewRewardIndex("xrp-a", d("0.0001"))
+
+	subspace := paramsWithSingleUSDXRewardPeriod(newRewardIndex.CollateralType)
+	suite.keeper = suite.NewKeeper(subspace, nil, nil, nil, nil, nil)
+
+	claim := types.USDXMintingClaim{
+		BaseClaim: types.BaseClaim{
+			Owner: arbitraryAddress(),
+		},
+		RewardIndexes: claimsRewardIndexes,
+	}
+	suite.storeClaim(claim)
+
+	globalIndexes := increaseRewardFactors(claimsRewardIndexes)
+	globalIndexes = append(globalIndexes, newRewardIndex)
+	suite.storeGlobalUSDXIndexes(globalIndexes)
+
+	cdp := NewCDPBuilder(claim.Owner, newRewardIndex.CollateralType).Build()
+
+	suite.keeper.SynchronizeUSDXMintingReward(suite.ctx, cdp)
+
+	syncedClaim, _ := suite.keeper.GetUSDXMintingClaim(suite.ctx, claim.Owner)
+
+	// Only the claim's index for `collateralType` should have been changed
+	expectedIndexes := claimsRewardIndexes.With(newRewardIndex.CollateralType, newRewardIndex.RewardFactor)
+	suite.Equal(expectedIndexes, syncedClaim.RewardIndexes)
+}
+
+type cdpBuilder struct {
+	cdptypes.CDP
+}
+
+func NewCDPBuilder(owner sdk.AccAddress, collateralType string) cdpBuilder {
+	return cdpBuilder{
+		CDP: cdptypes.CDP{
+			Owner: owner,
+			Type:  collateralType,
+			// The zero value of Principal and AccumulatedFees (type sdk.Coin) is invalid as the denom is ""
+			// Set them to the default denom, but with 0 amount.
+			Principal:       c(cdptypes.DefaultStableDenom, 0),
+			AccumulatedFees: c(cdptypes.DefaultStableDenom, 0),
+		}}
+}
+
+func (builder cdpBuilder) Build() cdptypes.CDP { return builder.CDP }
+
+func (builder cdpBuilder) WithPrincipal(principal sdk.Int) cdpBuilder {
+	builder.Principal = sdk.NewCoin(cdptypes.DefaultStableDenom, principal)
+	return builder
+}
+
+var nonEmptyRewardIndexes = types.RewardIndexes{
+	{
+		CollateralType: "bnb-a",
+		RewardFactor:   d("0.1"),
+	},
+	{
+		CollateralType: "busd-b",
+		RewardFactor:   d("0.4"),
+	},
+}
+
+func paramsWithSingleUSDXRewardPeriod(collateralType string) types.ParamSubspace {
+	return &fakeParamSubspace{
+		params: types.Params{
+			USDXMintingRewardPeriods: types.RewardPeriods{
+				{
+					CollateralType: collateralType,
+				},
+			},
+		},
+	}
+}
+
+func extractFirstCollateralType(indexes types.RewardIndexes) string {
+	if len(indexes) == 0 {
+		panic("cannot extract a collateral type from 0 length RewardIndexes")
+	}
+	return indexes[0].CollateralType
+}
+
+/*
+Init
+given a claim doesn't exist, when sync is called, a claim is created with the current global index for cdp.Type
+given a claim does exist, when sync is called, the claim's indexes are updated with the current global index for cdp.Type
+same as above but with new cdp.Type, rather than existing one
+
+other
+given a reward period doesn't exist, do nothing
+given the global index doesn't exist, update index with 0
+
+
+Sync
+given increase in global indexes, new rewards are added
+given unchanged global indexes, no new rewards
+given new global index added, new rewards starting from zero
+
+other
+given no reward period, do nothing
+given no claim, create one with 0 global index
+*/

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -118,6 +118,17 @@ func arbitraryAddress() sdk.AccAddress {
 	_, addresses := app.GeneratePrivKeyAddressPairs(1)
 	return addresses[0]
 }
+func arbitraryValidatorAddress() sdk.ValAddress {
+	return generateValidatorAddresses(1)[0]
+}
+func generateValidatorAddresses(n int) []sdk.ValAddress {
+	_, addresses := app.GeneratePrivKeyAddressPairs(n)
+	var valAddresses []sdk.ValAddress
+	for _, a := range addresses {
+		valAddresses = append(valAddresses, sdk.ValAddress(a))
+	}
+	return valAddresses
+}
 
 var nonEmptyMultiRewardIndexes = types.MultiRewardIndexes{
 	{

--- a/x/incentive/types/claims.go
+++ b/x/incentive/types/claims.go
@@ -402,7 +402,7 @@ func (ris RewardIndexes) GetRewardIndex(denom string) (RewardIndex, bool) {
 	return RewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardFactor by it's denom
 func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	for _, ri := range ris {
 		if ri.CollateralType == denom {
@@ -412,7 +412,7 @@ func (ris RewardIndexes) Get(denom string) (sdk.Dec, bool) {
 	return sdk.Dec{}, false
 }
 
-// With returns a copy of the indexes with a new reward index added
+// With returns a copy of the indexes with a new reward factor added
 func (ris RewardIndexes) With(denom string, factor sdk.Dec) RewardIndexes {
 	newIndexes := make(RewardIndexes, len(ris))
 	copy(newIndexes, ris)
@@ -500,7 +500,7 @@ func (mris MultiRewardIndexes) GetRewardIndex(denom string) (MultiRewardIndex, b
 	return MultiRewardIndex{}, false
 }
 
-// Get fetches a RewardFactor from the indexes by it's denom
+// Get fetches a RewardIndexes by it's denom
 func (mris MultiRewardIndexes) Get(denom string) (RewardIndexes, bool) {
 	for _, mri := range mris {
 		if mri.CollateralType == denom {
@@ -564,7 +564,7 @@ func (mris MultiRewardIndexes) Validate() error {
 	return nil
 }
 
-// copy returns a copy the slice and underlying array
+// copy returns a copy of the slice and underlying array
 func (mris MultiRewardIndexes) copy() MultiRewardIndexes {
 	newIndexes := make(MultiRewardIndexes, len(mris))
 	copy(newIndexes, mris)

--- a/x/incentive/types/claims_test.go
+++ b/x/incentive/types/claims_test.go
@@ -349,7 +349,6 @@ func TestMultiRewardIndexes(t *testing.T) {
 	})
 }
 
-// TODO dedupe with copy in keeper
 func appendUniqueRewardIndex(indexes RewardIndexes) RewardIndexes {
 	const uniqueDenom = "uniquereward"
 

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -3,12 +3,21 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/params"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
 
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 )
+
+// ParamSubspace defines the expected Subspace interfacace
+type ParamSubspace interface {
+	GetParamSet(sdk.Context, params.ParamSet)
+	SetParamSet(sdk.Context, params.ParamSet)
+	WithKeyTable(params.KeyTable) params.Subspace
+	HasKeyTable() bool
+}
 
 // SupplyKeeper defines the expected supply keeper for module accounts
 type SupplyKeeper interface {


### PR DESCRIPTION
Second of three PRs (#929, #928, #927) to add tests and simplify the incentive code.

This PR is the same as #929 , but for the delegator and usdx rewards.

I moved the keeper's param subspace to an interface to allow mocking in the unit tests. I copied it from `cosmos-sdk/x/staking`