### PR TITLE
Implement Base Pool Swap Methods

### DIFF
--- a/x/swap/keeper/deposit.go
+++ b/x/swap/keeper/deposit.go
@@ -18,7 +18,7 @@ import (
 // The slippage is calculated using both the price and inverse price of the provided coinA and coinB.
 // Since adding liquidity is not directional, like a swap would be, using both the price (coinB/coinA),
 // and the inverse price (coinA/coinB), protects the depositor from a large deviation in their deposit.
-
+//
 // The amount deposited may only change by B' < B or A' < A -- either B depreciates, or A depreciates.
 // Therefore, slippage can be written as a function of this depreciation d.  Where the new price is
 // B*(1-d)/A or A*(1-d)/B, and the inverse of each, and is A/(B*(1-d)) and B/(A*(1-d))

--- a/x/swap/simulation/genesis.go
+++ b/x/swap/simulation/genesis.go
@@ -27,7 +27,7 @@ func GenSwapFee(r *rand.Rand) sdk.Dec {
 	return sdk.NewDec(percentage).Quo(sdk.NewDec(100))
 }
 
-// GenSupportedAssets generates random allowed pools
+// GenAllowedPools generates random allowed pools
 func GenAllowedPools(r *rand.Rand) types.AllowedPools {
 	var pools types.AllowedPools
 

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -218,7 +218,8 @@ func (p *BasePool) RemoveLiquidity(shares sdk.Int) (sdk.Int, sdk.Int) {
 	return withdrawA, withdrawB
 }
 
-// SwapAForB trades a for b with a percentage fee, returns b and fee amount in a
+// SwapExactAForB trades an exact value of a for b.  Returns the positive amount b
+// that is removed from the pool and the portion of a that is used for paying the fee.
 func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	b, feeValue := p.swapExactInput(a, p.reservesA, p.reservesB, fee)
 
@@ -229,7 +230,8 @@ func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return b, feeValue
 }
 
-// SwapBForA trades b for a with a percentage fee, returns a and fee amount in b
+// SwapExactAForB trades an exact value of b for a.  Returns the positive amount a
+// that is removed from the pool and the portion of b that is used for paying the fee.
 func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	a, feeValue := p.swapExactInput(b, p.reservesB, p.reservesA, fee)
 
@@ -240,6 +242,13 @@ func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return a, feeValue
 }
 
+// swapExactInput calculates the output amount of a swap using a fixed input, returning this amount in
+// addition to the amount of input that is used to pay the fee.
+//
+// The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
+// by splitting a trade into multiple trades.
+//
+// The swap output is truncated to ensure the pool invariant is always greater than the previous invariant.
 func (p *BasePool) swapExactInput(in, inReserves, outReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapInputIsValid(in)
 	p.assertFeeIsValid(fee)
@@ -256,8 +265,8 @@ func (p *BasePool) swapExactInput(in, inReserves, outReserves sdk.Int, fee sdk.D
 	return out, feeValue
 }
 
-// SwapAForExactB trades a for an exact b.  The amount of a added to the reserves is returned,
-// in addition to the amount of a that was used to pay for fees
+// SwapAForExactB trades a for an exact b.  Returns the positive amount a
+// that is added to the pool, and the portion of a that is used to pay the fee.
 func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	a, feeValue := p.swapExactOutput(b, p.reservesB, p.reservesA, fee)
 
@@ -268,7 +277,8 @@ func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return a, feeValue
 }
 
-// SwapBForA trades b for a with a percentage fee, returns a and fee amount in b
+// SwapBForExactA trades b for an exact a.  Returns the positive amount b
+// that is added to the pool, and the portion of b that is used to pay the fee.
 func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	b, feeValue := p.swapExactOutput(a, p.reservesA, p.reservesB, fee)
 
@@ -279,6 +289,13 @@ func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return b, feeValue
 }
 
+// swapExactInput calculates the input amount of a swap using a fixed output, returning this amount in
+// addition to the amount of input that is used to pay the fee.
+//
+// The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
+// by splitting a trade into multiple trades.
+//
+// The swap input is ceiled to ensure the pool invariant is always greater than the previous invariant.
 func (p *BasePool) swapExactOutput(out, outReserves, inReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapOutputIsValid(out, outReserves)
 	p.assertFeeIsValid(fee)

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -185,16 +185,16 @@ func (p *BasePool) RemoveLiquidity(shares sdk.Int) (sdk.Int, sdk.Int) {
 	return withdrawA, withdrawB
 }
 
-// SwapAForB trades a for b with a percentage fee
-func (p *BasePool) SwapAForB(a sdk.Int, fee sdk.Dec) sdk.Int {
+// SwapAForB trades a for b with a percentage fee, returns b and fee amount in a
+func (p *BasePool) SwapAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	// TODO: implementation
-	return sdk.ZeroInt()
+	return sdk.ZeroInt(), sdk.ZeroInt()
 }
 
-// SwapBForA trades b for a with a percentage fee
-func (p *BasePool) SwapBForA(b sdk.Int, fee sdk.Dec) sdk.Int {
+// SwapBForA trades b for a with a percentage fee, returns a and fee amount in b
+func (p *BasePool) SwapBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	// TODO: implementation
-	return sdk.ZeroInt()
+	return sdk.ZeroInt(), sdk.ZeroInt()
 }
 
 // ShareValue returns the value of the provided shares and panics

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -230,7 +230,7 @@ func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return b, feeValue
 }
 
-// SwapExactAForB trades an exact value of b for a.  Returns the positive amount a
+// SwapExactBForA trades an exact value of b for a.  Returns the positive amount a
 // that is removed from the pool and the portion of b that is used for paying the fee.
 func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	a, feeValue := p.swapExactInput(b, p.reservesB, p.reservesA, fee)

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -197,7 +197,7 @@ func (p *BasePool) AddLiquidity(desiredA sdk.Int, desiredB sdk.Int) (sdk.Int, sd
 }
 
 // RemoveLiquidity removes liquidity from the pool and panics if the
-// the shares provided are greater than the total shares of the pool
+// shares provided are greater than the total shares of the pool
 // or the shares are not positive.
 // In addition, also panics if reserves go negative, which should not happen.
 // If panic occurs, it is a bug.
@@ -248,7 +248,7 @@ func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 // The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
 // by splitting a trade into multiple trades.
 //
-// The swap output is truncated to ensure the pool invariant is always greater than the previous invariant.
+// The swap output is truncated to ensure the pool invariant is always greater than or equal to the previous invariant.
 func (p *BasePool) swapExactInput(in, inReserves, outReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapInputIsValid(in)
 	p.assertFeeIsValid(fee)
@@ -295,7 +295,7 @@ func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 // The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
 // by splitting a trade into multiple trades.
 //
-// The swap input is ceiled to ensure the pool invariant is always greater than the previous invariant.
+// The swap input is ceiled to ensure the pool invariant is always greater than or equal to the previous invariant.
 func (p *BasePool) swapExactOutput(out, outReserves, inReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapOutputIsValid(out, outReserves)
 	p.assertFeeIsValid(fee)

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -221,7 +221,7 @@ func (p *BasePool) RemoveLiquidity(shares sdk.Int) (sdk.Int, sdk.Int) {
 // SwapExactAForB trades an exact value of a for b.  Returns the positive amount b
 // that is removed from the pool and the portion of a that is used for paying the fee.
 func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
-	b, feeValue := p.swapExactInput(a, p.reservesA, p.reservesB, fee)
+	b, feeValue := p.calculateOutputForExactInput(a, p.reservesA, p.reservesB, fee)
 
 	p.assertInvariantAndUpdateRerserves(
 		p.reservesA.Add(a), feeValue, p.reservesB.Sub(b), sdk.ZeroInt(),
@@ -233,7 +233,7 @@ func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 // SwapExactBForA trades an exact value of b for a.  Returns the positive amount a
 // that is removed from the pool and the portion of b that is used for paying the fee.
 func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
-	a, feeValue := p.swapExactInput(b, p.reservesB, p.reservesA, fee)
+	a, feeValue := p.calculateOutputForExactInput(b, p.reservesB, p.reservesA, fee)
 
 	p.assertInvariantAndUpdateRerserves(
 		p.reservesA.Sub(a), sdk.ZeroInt(), p.reservesB.Add(b), feeValue,
@@ -242,14 +242,14 @@ func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return a, feeValue
 }
 
-// swapExactInput calculates the output amount of a swap using a fixed input, returning this amount in
+// calculateOutputForExactInput calculates the output amount of a swap using a fixed input, returning this amount in
 // addition to the amount of input that is used to pay the fee.
 //
 // The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
 // by splitting a trade into multiple trades.
 //
 // The swap output is truncated to ensure the pool invariant is always greater than or equal to the previous invariant.
-func (p *BasePool) swapExactInput(in, inReserves, outReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
+func (p *BasePool) calculateOutputForExactInput(in, inReserves, outReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapInputIsValid(in)
 	p.assertFeeIsValid(fee)
 
@@ -268,7 +268,7 @@ func (p *BasePool) swapExactInput(in, inReserves, outReserves sdk.Int, fee sdk.D
 // SwapAForExactB trades a for an exact b.  Returns the positive amount a
 // that is added to the pool, and the portion of a that is used to pay the fee.
 func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
-	a, feeValue := p.swapExactOutput(b, p.reservesB, p.reservesA, fee)
+	a, feeValue := p.calculateInputForExactOutput(b, p.reservesB, p.reservesA, fee)
 
 	p.assertInvariantAndUpdateRerserves(
 		p.reservesA.Add(a), feeValue, p.reservesB.Sub(b), sdk.ZeroInt(),
@@ -280,7 +280,7 @@ func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 // SwapBForExactA trades b for an exact a.  Returns the positive amount b
 // that is added to the pool, and the portion of b that is used to pay the fee.
 func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
-	b, feeValue := p.swapExactOutput(a, p.reservesA, p.reservesB, fee)
+	b, feeValue := p.calculateInputForExactOutput(a, p.reservesA, p.reservesB, fee)
 
 	p.assertInvariantAndUpdateRerserves(
 		p.reservesA.Sub(a), sdk.ZeroInt(), p.reservesB.Add(b), feeValue,
@@ -289,14 +289,14 @@ func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	return b, feeValue
 }
 
-// swapExactInput calculates the input amount of a swap using a fixed output, returning this amount in
+// calculateInputForExactOutput calculates the input amount of a swap using a fixed output, returning this amount in
 // addition to the amount of input that is used to pay the fee.
 //
 // The fee is ceiled, ensuring a minimum fee of 1 and ensuring fees of a trade can not be reduced
 // by splitting a trade into multiple trades.
 //
 // The swap input is ceiled to ensure the pool invariant is always greater than or equal to the previous invariant.
-func (p *BasePool) swapExactOutput(out, outReserves, inReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
+func (p *BasePool) calculateInputForExactOutput(out, outReserves, inReserves sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	p.assertSwapOutputIsValid(out, outReserves)
 	p.assertFeeIsValid(fee)
 

--- a/x/swap/types/base_pool.go
+++ b/x/swap/types/base_pool.go
@@ -223,7 +223,7 @@ func (p *BasePool) RemoveLiquidity(shares sdk.Int) (sdk.Int, sdk.Int) {
 func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	b, feeValue := p.calculateOutputForExactInput(a, p.reservesA, p.reservesB, fee)
 
-	p.assertInvariantAndUpdateRerserves(
+	p.assertInvariantAndUpdateReserves(
 		p.reservesA.Add(a), feeValue, p.reservesB.Sub(b), sdk.ZeroInt(),
 	)
 
@@ -235,7 +235,7 @@ func (p *BasePool) SwapExactAForB(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 func (p *BasePool) SwapExactBForA(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	a, feeValue := p.calculateOutputForExactInput(b, p.reservesB, p.reservesA, fee)
 
-	p.assertInvariantAndUpdateRerserves(
+	p.assertInvariantAndUpdateReserves(
 		p.reservesA.Sub(a), sdk.ZeroInt(), p.reservesB.Add(b), feeValue,
 	)
 
@@ -270,7 +270,7 @@ func (p *BasePool) calculateOutputForExactInput(in, inReserves, outReserves sdk.
 func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	a, feeValue := p.calculateInputForExactOutput(b, p.reservesB, p.reservesA, fee)
 
-	p.assertInvariantAndUpdateRerserves(
+	p.assertInvariantAndUpdateReserves(
 		p.reservesA.Add(a), feeValue, p.reservesB.Sub(b), sdk.ZeroInt(),
 	)
 
@@ -282,7 +282,7 @@ func (p *BasePool) SwapAForExactB(b sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 func (p *BasePool) SwapBForExactA(a sdk.Int, fee sdk.Dec) (sdk.Int, sdk.Int) {
 	b, feeValue := p.calculateInputForExactOutput(a, p.reservesA, p.reservesB, fee)
 
-	p.assertInvariantAndUpdateRerserves(
+	p.assertInvariantAndUpdateReserves(
 		p.reservesA.Sub(a), sdk.ZeroInt(), p.reservesB.Add(b), feeValue,
 	)
 
@@ -338,7 +338,7 @@ func (p *BasePool) ShareValue(shares sdk.Int) (sdk.Int, sdk.Int) {
 
 // assertInvariantAndUpdateRerserves asserts the constant product invariant is not violated, subtracting
 // any fees first, then updates the pool reserves.  Panics if invariant is violated.
-func (p *BasePool) assertInvariantAndUpdateRerserves(newReservesA, feeA, newReservesB, feeB sdk.Int) {
+func (p *BasePool) assertInvariantAndUpdateReserves(newReservesA, feeA, newReservesB, feeB sdk.Int) {
 	var invariant big.Int
 	invariant.Mul(p.reservesA.BigInt(), p.reservesB.BigInt())
 

--- a/x/swap/types/denominated_pool.go
+++ b/x/swap/types/denominated_pool.go
@@ -101,9 +101,9 @@ func (p *DenominatedPool) ShareValue(shares sdk.Int) sdk.Coins {
 	return p.coins(valueA, valueB)
 }
 
-// Swap swaps a coin in one reserve for the other.  Panics if denom
-// does not match the pool.  Returns the amount received for the input coins,
-// and the amount paid by the fee
+// SwapWithExactInput trades an exact input coin for the other.  Returns the positive other coin amount
+// that is removed from the pool and the portion of the input coin that is used for the fee.
+// It panics if the input denom does not match the pool reserves.
 func (p *DenominatedPool) SwapWithExactInput(swapInput sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
 	var (
 		swapOutput sdk.Int
@@ -122,9 +122,9 @@ func (p *DenominatedPool) SwapWithExactInput(swapInput sdk.Coin, fee sdk.Dec) (s
 	}
 }
 
-// Swap swaps a coin in one reserve for the other.  Panics if denom
-// does not match the pool.  Returns the amount received for the input coins,
-// and the amount paid by the fee
+// SwapWithExactOutput trades a coin for an exact output coin b.  Returns the positive input coin
+// that is added to the pool, and the portion of that input that is used to pay the fee.
+// Panics if the output denom does not match the pool reserves.
 func (p *DenominatedPool) SwapWithExactOutput(swapOutput sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
 	var (
 		swapInput sdk.Int

--- a/x/swap/types/denominated_pool.go
+++ b/x/swap/types/denominated_pool.go
@@ -104,21 +104,42 @@ func (p *DenominatedPool) ShareValue(shares sdk.Int) sdk.Coins {
 // Swap swaps a coin in one reserve for the other.  Panics if denom
 // does not match the pool.  Returns the amount received for the input coins,
 // and the amount paid by the fee
-func (p *DenominatedPool) Swap(coin sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
+func (p *DenominatedPool) SwapWithExactInput(swapInput sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
 	var (
-		swapResult sdk.Int
+		swapOutput sdk.Int
 		feePaid    sdk.Int
 	)
 
-	switch coin.Denom {
+	switch swapInput.Denom {
 	case p.denomA:
-		swapResult, feePaid = p.pool.SwapAForB(coin.Amount, fee)
-		return p.coinB(swapResult), p.coinA(feePaid)
+		swapOutput, feePaid = p.pool.SwapExactAForB(swapInput.Amount, fee)
+		return p.coinB(swapOutput), p.coinA(feePaid)
 	case p.denomB:
-		swapResult, feePaid = p.pool.SwapBForA(coin.Amount, fee)
-		return p.coinA(swapResult), p.coinB(feePaid)
+		swapOutput, feePaid = p.pool.SwapExactBForA(swapInput.Amount, fee)
+		return p.coinA(swapOutput), p.coinB(feePaid)
 	default:
-		panic(fmt.Sprintf("invalid denomination: denom '%s' does not match pool reserves", coin.Denom))
+		panic(fmt.Sprintf("invalid denomination: denom '%s' does not match pool reserves", swapInput.Denom))
+	}
+}
+
+// Swap swaps a coin in one reserve for the other.  Panics if denom
+// does not match the pool.  Returns the amount received for the input coins,
+// and the amount paid by the fee
+func (p *DenominatedPool) SwapWithExactOutput(swapOutput sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
+	var (
+		swapInput sdk.Int
+		feePaid   sdk.Int
+	)
+
+	switch swapOutput.Denom {
+	case p.denomA:
+		swapInput, feePaid = p.pool.SwapBForExactA(swapOutput.Amount, fee)
+		return p.coinB(swapInput), p.coinB(feePaid)
+	case p.denomB:
+		swapInput, feePaid = p.pool.SwapAForExactB(swapOutput.Amount, fee)
+		return p.coinA(swapInput), p.coinA(feePaid)
+	default:
+		panic(fmt.Sprintf("invalid denomination: denom '%s' does not match pool reserves", swapOutput.Denom))
 	}
 }
 

--- a/x/swap/types/denominated_pool.go
+++ b/x/swap/types/denominated_pool.go
@@ -102,20 +102,24 @@ func (p *DenominatedPool) ShareValue(shares sdk.Int) sdk.Coins {
 }
 
 // Swap swaps a coin in one reserve for the other.  Panics if denom
-// does not match the pool.
-func (p *DenominatedPool) Swap(coin sdk.Coin, fee sdk.Dec) sdk.Coin {
-	var result sdk.Coin
+// does not match the pool.  Returns the amount received for the input coins,
+// and the amount paid by the fee
+func (p *DenominatedPool) Swap(coin sdk.Coin, fee sdk.Dec) (sdk.Coin, sdk.Coin) {
+	var (
+		swapResult sdk.Int
+		feePaid    sdk.Int
+	)
 
 	switch coin.Denom {
 	case p.denomA:
-		result = p.coinB(p.pool.SwapAForB(coin.Amount, fee))
+		swapResult, feePaid = p.pool.SwapAForB(coin.Amount, fee)
+		return p.coinB(swapResult), p.coinA(feePaid)
 	case p.denomB:
-		result = p.coinA(p.pool.SwapBForA(coin.Amount, fee))
+		swapResult, feePaid = p.pool.SwapBForA(coin.Amount, fee)
+		return p.coinA(swapResult), p.coinB(feePaid)
 	default:
 		panic(fmt.Sprintf("invalid denomination: denom '%s' does not match pool reserves", coin.Denom))
 	}
-
-	return result
 }
 
 // coins returns a new coins slice with correct reserve denoms from ordered sdk.Ints

--- a/x/swap/types/params.go
+++ b/x/swap/types/params.go
@@ -83,7 +83,7 @@ func validateSwapFee(i interface{}) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	if swapFee.IsNil() || swapFee.IsNegative() || swapFee.GT(MaxSwapFee) {
+	if swapFee.IsNil() || swapFee.IsNegative() || swapFee.GTE(MaxSwapFee) {
 		return fmt.Errorf(fmt.Sprintf("invalid swap fee: %s", swapFee))
 	}
 

--- a/x/swap/types/params_test.go
+++ b/x/swap/types/params_test.go
@@ -184,7 +184,7 @@ func TestParams_Validation(t *testing.T) {
 			testFn: func(params *types.Params) {
 				params.SwapFee = sdk.OneDec()
 			},
-			expectedErr: "",
+			expectedErr: "invalid swap fee: 1.000000000000000000",
 		},
 	}
 

--- a/x/swap/types/state.go
+++ b/x/swap/types/state.go
@@ -31,6 +31,7 @@ type PoolRecord struct {
 	TotalShares sdk.Int  `json:"total_shares" yaml:"total_shares"`
 }
 
+// Reserves returns the total reserves for a pool
 func (p PoolRecord) Reserves() sdk.Coins {
 	return sdk.NewCoins(p.ReservesA, p.ReservesB)
 }


### PR DESCRIPTION
This finishes the `BasePool` implementation.

Trading coins with a fixed input can be done with `SwapExactAForB` and `SwapExactBForA`, and trading coins with an exact output can be with `SwapAForExactB` and `SwapAForExactB`.  The `DenominatedPool` wraps these methods and provides an interface of `SwapExactInput` and `SwapExactOutput`, which handle the from and to conversions of the coin denominations.

The swap methods panic when provided with non-positive values, and the swap for exact output method panics if the output is greater than or equal to the reserves.

Fee validation is changed to require a fee less than 1.  This prevents division by zero when calculating the input fee for an exact output.  The swap methods will panic if the fee is less than 0 or greater or equal to 1.

The invariant of `(inputReserves + (input - fee)) * (outputReserves - output) >= inputReserves * outputReserves` holds for both exact input and exact output swaps.  The invariant requires us to floor on exact input swaps, and ceil on exact output swaps.  Flooring decreases the output when rounding errors occur, and ceiling increases in the input when rounding errors occur -- both resulting in K being increased and benefiting the pool on rounding errors.  The invariant is checked as a runtime assertion to catch any bugs in the math during simulations, and help ensure any enhancements later do not result in regression.