### PR TITLE
Add swap keeper methods

### DIFF
--- a/x/swap/alias.go
+++ b/x/swap/alias.go
@@ -39,6 +39,8 @@ var (
 	NewDenominatedPoolWithExistingShares = types.NewDenominatedPoolWithExistingShares
 	NewGenesisState                      = types.NewGenesisState
 	NewMsgDeposit                        = types.NewMsgDeposit
+	NewMsgSwapExactForTokens             = types.NewMsgSwapExactForTokens
+	NewMsgSwapForExactTokens             = types.NewMsgSwapForExactTokens
 	NewMsgWithdraw                       = types.NewMsgWithdraw
 	NewParams                            = types.NewParams
 	NewPoolRecord                        = types.NewPoolRecord
@@ -72,18 +74,20 @@ var (
 )
 
 type (
-	Keeper          = keeper.Keeper
-	AccountKeeper   = types.AccountKeeper
-	AllowedPool     = types.AllowedPool
-	AllowedPools    = types.AllowedPools
-	BasePool        = types.BasePool
-	DenominatedPool = types.DenominatedPool
-	GenesisState    = types.GenesisState
-	MsgDeposit      = types.MsgDeposit
-	MsgWithDeadline = types.MsgWithDeadline
-	MsgWithdraw     = types.MsgWithdraw
-	Params          = types.Params
-	PoolRecord      = types.PoolRecord
-	ShareRecord     = types.ShareRecord
-	SupplyKeeper    = types.SupplyKeeper
+	Keeper                = keeper.Keeper
+	AccountKeeper         = types.AccountKeeper
+	AllowedPool           = types.AllowedPool
+	AllowedPools          = types.AllowedPools
+	BasePool              = types.BasePool
+	DenominatedPool       = types.DenominatedPool
+	GenesisState          = types.GenesisState
+	MsgDeposit            = types.MsgDeposit
+	MsgSwapExactForTokens = types.MsgSwapExactForTokens
+	MsgSwapForExactTokens = types.MsgSwapForExactTokens
+	MsgWithDeadline       = types.MsgWithDeadline
+	MsgWithdraw           = types.MsgWithdraw
+	Params                = types.Params
+	PoolRecord            = types.PoolRecord
+	ShareRecord           = types.ShareRecord
+	SupplyKeeper          = types.SupplyKeeper
 )

--- a/x/swap/alias.go
+++ b/x/swap/alias.go
@@ -8,20 +8,26 @@ import (
 )
 
 const (
-	AttributeKeyDepositor  = types.AttributeKeyDepositor
-	AttributeKeyOwner      = types.AttributeKeyOwner
-	AttributeKeyPoolID     = types.AttributeKeyPoolID
-	AttributeKeyShares     = types.AttributeKeyShares
-	AttributeValueCategory = types.AttributeValueCategory
-	DefaultParamspace      = types.DefaultParamspace
-	EventTypeSwapDeposit   = types.EventTypeSwapDeposit
-	EventTypeSwapWithdraw  = types.EventTypeSwapWithdraw
-	ModuleAccountName      = types.ModuleAccountName
-	ModuleName             = types.ModuleName
-	QuerierRoute           = types.QuerierRoute
-	QueryGetParams         = types.QueryGetParams
-	RouterKey              = types.RouterKey
-	StoreKey               = types.StoreKey
+	AttributeKeyDepositor      = types.AttributeKeyDepositor
+	AttributeKeyExactDirection = types.AttributeKeyExactDirection
+	AttributeKeyFeePaid        = types.AttributeKeyFeePaid
+	AttributeKeyOwner          = types.AttributeKeyOwner
+	AttributeKeyPoolID         = types.AttributeKeyPoolID
+	AttributeKeyRequester      = types.AttributeKeyRequester
+	AttributeKeyShares         = types.AttributeKeyShares
+	AttributeKeySwapInput      = types.AttributeKeySwapInput
+	AttributeKeySwapOutput     = types.AttributeKeySwapOutput
+	AttributeValueCategory     = types.AttributeValueCategory
+	DefaultParamspace          = types.DefaultParamspace
+	EventTypeSwapDeposit       = types.EventTypeSwapDeposit
+	EventTypeSwapTrade         = types.EventTypeSwapTrade
+	EventTypeSwapWithdraw      = types.EventTypeSwapWithdraw
+	ModuleAccountName          = types.ModuleAccountName
+	ModuleName                 = types.ModuleName
+	QuerierRoute               = types.QuerierRoute
+	QueryGetParams             = types.QueryGetParams
+	RouterKey                  = types.RouterKey
+	StoreKey                   = types.StoreKey
 )
 
 var (

--- a/x/swap/handler_test.go
+++ b/x/swap/handler_test.go
@@ -349,6 +349,44 @@ func (suite *handlerTestSuite) TestWithdraw_DeadlineExceeded() {
 	suite.Nil(res)
 }
 
+func (suite *handlerTestSuite) TestSwapExactForTokens_DeadlineExceeded() {
+	balance := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(10e6)),
+	)
+	requester := suite.CreateAccount(balance)
+
+	swap := swap.NewMsgSwapExactForTokens(
+		requester.GetAddress(),
+		sdk.NewCoin("ukava", sdk.NewInt(5e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(25e5)),
+		sdk.MustNewDecFromStr("0.01"),
+		suite.Ctx.BlockTime().Add(-1*time.Second).Unix(),
+	)
+
+	res, err := suite.handler(suite.Ctx, swap)
+	suite.EqualError(err, fmt.Sprintf("deadline exceeded: block time %d >= deadline %d", suite.Ctx.BlockTime().Unix(), swap.GetDeadline().Unix()))
+	suite.Nil(res)
+}
+
+func (suite *handlerTestSuite) TestSwapForExactTokens_DeadlineExceeded() {
+	balance := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(10e6)),
+	)
+	requester := suite.CreateAccount(balance)
+
+	swap := swap.NewMsgSwapForExactTokens(
+		requester.GetAddress(),
+		sdk.NewCoin("ukava", sdk.NewInt(5e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(25e5)),
+		sdk.MustNewDecFromStr("0.01"),
+		suite.Ctx.BlockTime().Add(-1*time.Second).Unix(),
+	)
+
+	res, err := suite.handler(suite.Ctx, swap)
+	suite.EqualError(err, fmt.Sprintf("deadline exceeded: block time %d >= deadline %d", suite.Ctx.BlockTime().Unix(), swap.GetDeadline().Unix()))
+	suite.Nil(res)
+}
+
 func (suite *handlerTestSuite) TestInvalidMsg() {
 	res, err := suite.handler(suite.Ctx, sdk.NewTestMsg())
 	suite.Nil(res)

--- a/x/swap/keeper/keeper.go
+++ b/x/swap/keeper/keeper.go
@@ -51,6 +51,11 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSubspace.SetParamSet(ctx, &params)
 }
 
+// GetSwapFee returns the swap fee set in the module parameters
+func (k Keeper) GetSwapFee(ctx sdk.Context) sdk.Dec {
+	return k.GetParams(ctx).SwapFee
+}
+
 // GetPool retrieves a pool record from the store
 func (k Keeper) GetPool(ctx sdk.Context, poolID string) (types.PoolRecord, bool) {
 	store := prefix.NewStore(ctx.KVStore(k.key), types.PoolKeyPrefix)

--- a/x/swap/keeper/keeper_test.go
+++ b/x/swap/keeper/keeper_test.go
@@ -69,6 +69,17 @@ func (suite keeperTestSuite) TestParams_Persistance() {
 	suite.Equal(keeper.GetParams(suite.Ctx), params)
 }
 
+func (suite keeperTestSuite) TestParams_GetSwapFee() {
+	keeper := suite.Keeper
+
+	params := types.Params{
+		SwapFee: sdk.MustNewDecFromStr("0.00333"),
+	}
+	keeper.SetParams(suite.Ctx, params)
+
+	suite.Equal(keeper.GetSwapFee(suite.Ctx), params.SwapFee)
+}
+
 func (suite *keeperTestSuite) TestPool_Persistance() {
 	reserves := sdk.NewCoins(
 		sdk.NewCoin("ukava", sdk.NewInt(10e6)),

--- a/x/swap/keeper/swap.go
+++ b/x/swap/keeper/swap.go
@@ -1,17 +1,91 @@
 package keeper
 
 import (
+	"fmt"
+
+	"github.com/kava-labs/kava/x/swap/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	//sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	//"github.com/kava-labs/kava/x/swap/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // SwapExactForTokens swaps an exact coin a input for a coin b output
 func (k *Keeper) SwapExactForTokens(ctx sdk.Context, requester sdk.AccAddress, exactCoinA, coinB sdk.Coin, slippage sdk.Dec) error {
+	poolID := types.PoolID(exactCoinA.Denom, coinB.Denom)
+
+	poolRecord, found := k.GetPool(ctx, poolID)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrInvalidPool, "pool %s not found", poolID)
+	}
+
+	pool, err := types.NewDenominatedPoolWithExistingShares(poolRecord.Reserves(), poolRecord.TotalShares)
+	if err != nil {
+		panic(fmt.Sprintf("invalid pool %s: %s", poolID, err))
+	}
+
+	swapOutput, feePaid := pool.SwapWithExactInput(exactCoinA, k.GetSwapFee(ctx))
+	k.SetPool(ctx, types.NewPoolRecord(pool))
+
+	if err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, requester, types.ModuleAccountName, sdk.NewCoins(exactCoinA)); err != nil {
+		return err
+	}
+
+	if err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, requester, sdk.NewCoins(swapOutput)); err != nil {
+		return err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSwapTrade,
+			sdk.NewAttribute(types.AttributeKeyPoolID, poolID),
+			sdk.NewAttribute(types.AttributeKeyRequester, requester.String()),
+			sdk.NewAttribute(types.AttributeKeySwapInput, exactCoinA.String()),
+			sdk.NewAttribute(types.AttributeKeySwapOutput, swapOutput.String()),
+			sdk.NewAttribute(types.AttributeKeyFeePaid, feePaid.String()),
+			sdk.NewAttribute(types.AttributeKeyExactDirection, "input"),
+		),
+	)
+
 	return nil
 }
 
 // SwapExactForTokens swaps a coin a input for an exact coin b output
-func (k *Keeper) SwapForExactTokens(ctx sdk.Context, requester sdk.AccAddress, exactCoinA, coinB sdk.Coin, slippage sdk.Dec) error {
+func (k *Keeper) SwapForExactTokens(ctx sdk.Context, requester sdk.AccAddress, coinA, exactCoinB sdk.Coin, slippage sdk.Dec) error {
+	poolID := types.PoolID(coinA.Denom, exactCoinB.Denom)
+
+	poolRecord, found := k.GetPool(ctx, poolID)
+	if !found {
+		return sdkerrors.Wrapf(types.ErrInvalidPool, "pool %s not found", poolID)
+	}
+
+	pool, err := types.NewDenominatedPoolWithExistingShares(poolRecord.Reserves(), poolRecord.TotalShares)
+	if err != nil {
+		panic(fmt.Sprintf("invalid pool %s: %s", poolID, err))
+	}
+
+	// TODO: validate output is not greater than pool reserves
+	swapInput, feePaid := pool.SwapWithExactOutput(exactCoinB, k.GetSwapFee(ctx))
+	k.SetPool(ctx, types.NewPoolRecord(pool))
+
+	if err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, requester, types.ModuleAccountName, sdk.NewCoins(swapInput)); err != nil {
+		return err
+	}
+
+	if err := k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, requester, sdk.NewCoins(exactCoinB)); err != nil {
+		return err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSwapTrade,
+			sdk.NewAttribute(types.AttributeKeyPoolID, poolID),
+			sdk.NewAttribute(types.AttributeKeyRequester, requester.String()),
+			sdk.NewAttribute(types.AttributeKeySwapInput, swapInput.String()),
+			sdk.NewAttribute(types.AttributeKeySwapOutput, exactCoinB.String()),
+			sdk.NewAttribute(types.AttributeKeyFeePaid, feePaid.String()),
+			sdk.NewAttribute(types.AttributeKeyExactDirection, "output"),
+		),
+	)
+
 	return nil
 }

--- a/x/swap/keeper/swap.go
+++ b/x/swap/keeper/swap.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	//sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	//"github.com/kava-labs/kava/x/swap/types"
+)
+
+// SwapExactForTokens swaps an exact coin a input for a coin b output
+func (k *Keeper) SwapExactForTokens(ctx sdk.Context, requester sdk.AccAddress, exactCoinA, coinB sdk.Coin, slippage sdk.Dec) error {
+	return nil
+}
+
+// SwapExactForTokens swaps a coin a input for an exact coin b output
+func (k *Keeper) SwapForExactTokens(ctx sdk.Context, requester sdk.AccAddress, exactCoinA, coinB sdk.Coin, slippage sdk.Dec) error {
+	return nil
+}

--- a/x/swap/keeper/swap_test.go
+++ b/x/swap/keeper/swap_test.go
@@ -1,10 +1,12 @@
 package keeper_test
 
 import (
-	//"fmt"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/x/swap/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
 func (suite *keeperTestSuite) TestSwapExactForTokens() {
@@ -46,6 +48,94 @@ func (suite *keeperTestSuite) TestSwapExactForTokens() {
 	))
 }
 
+func (suite *keeperTestSuite) TestSwapExactForTokens_Slippage() {
+	owner := suite.CreateAccount(sdk.Coins{})
+	reserves := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(500e6)),
+	)
+	totalShares := sdk.NewInt(30e6)
+	suite.setupPool(reserves, totalShares, owner.GetAddress())
+
+	testCases := []struct {
+		coinA      sdk.Coin
+		coinB      sdk.Coin
+		slippage   sdk.Dec
+		fee        sdk.Dec
+		shouldFail bool
+	}{
+		// positive slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(2e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(50e6)), sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(50e6)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		// positive slippage with zero slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(2e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(50e6)), sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(50e6)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		// exact zero slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4950495)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4935790)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4705299)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(990099)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(987158)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(941059)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), false},
+		// slippage failure, zero slippage tolerance
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4950496)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4935793)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4705300)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(990100)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(987159)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(941060)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), true},
+		// slippage failure, 1 percent slippage
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(5000501)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4985647)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4752828)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(1000101)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(997130)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(950565)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), true},
+		// slippage OK, 1 percent slippage
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(5000500)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4985646)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(4752827)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(1000100)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(997129)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.NewCoin("ukava", sdk.NewInt(950564)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), false},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("coinA=%s coinB=%s slippage=%s fee=%s", tc.coinA, tc.coinB, tc.slippage, tc.fee), func() {
+			suite.SetupTest()
+			suite.Keeper.SetParams(suite.Ctx, types.Params{
+				SwapFee: tc.fee,
+			})
+			owner := suite.CreateAccount(sdk.Coins{})
+			reserves := sdk.NewCoins(
+				sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+				sdk.NewCoin("usdx", sdk.NewInt(500e6)),
+			)
+			totalShares := sdk.NewInt(30e6)
+			suite.setupPool(reserves, totalShares, owner.GetAddress())
+			balance := sdk.NewCoins(
+				sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+				sdk.NewCoin("usdx", sdk.NewInt(100e6)),
+			)
+			requester := suite.NewAccountFromAddr(sdk.AccAddress("requester"), balance)
+
+			ctx := suite.App.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+			err := suite.Keeper.SwapExactForTokens(ctx, requester.GetAddress(), tc.coinA, tc.coinB, tc.slippage)
+
+			if tc.shouldFail {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "slippage exceeded")
+			} else {
+				suite.NoError(err)
+			}
+		})
+	}
+}
+
 func (suite *keeperTestSuite) TestSwapForExactTokens() {
 	suite.Keeper.SetParams(suite.Ctx, types.Params{
 		SwapFee: sdk.MustNewDecFromStr("0.0025"),
@@ -83,4 +173,92 @@ func (suite *keeperTestSuite) TestSwapForExactTokens() {
 		sdk.NewAttribute(types.AttributeKeyFeePaid, "2509ukava"),
 		sdk.NewAttribute(types.AttributeKeyExactDirection, "output"),
 	))
+}
+
+func (suite *keeperTestSuite) TestSwapForExactTokens_Slippage() {
+	owner := suite.CreateAccount(sdk.Coins{})
+	reserves := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(500e6)),
+	)
+	totalShares := sdk.NewInt(30e6)
+	suite.setupPool(reserves, totalShares, owner.GetAddress())
+
+	testCases := []struct {
+		coinA      sdk.Coin
+		coinB      sdk.Coin
+		slippage   sdk.Dec
+		fee        sdk.Dec
+		shouldFail bool
+	}{
+		// positive slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(100e6)), sdk.NewCoin("ukava", sdk.NewInt(10e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(100e6)), sdk.NewCoin("ukava", sdk.NewInt(10e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.0025"), false},
+		// positive slippage with zero slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(5e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(100e6)), sdk.NewCoin("ukava", sdk.NewInt(10e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(100e6)), sdk.NewCoin("ukava", sdk.NewInt(10e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.0025"), false},
+		// exact zero slippage OK
+		{sdk.NewCoin("ukava", sdk.NewInt(1010102)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1010102)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1010102)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050506)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050506)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050506)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), false},
+		// slippage failure, zero slippage tolerance
+		{sdk.NewCoin("ukava", sdk.NewInt(1010101)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1010101)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1010101)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050505)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050505)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5050505)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.ZeroDec(), sdk.MustNewDecFromStr("0.05"), true},
+		// slippage failure, 1 percent slippage
+		{sdk.NewCoin("ukava", sdk.NewInt(1000000)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1000000)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("ukava", sdk.NewInt(1000000)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000000)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000000)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), true},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000000)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), true},
+		// slippage OK, 1 percent slippage
+		{sdk.NewCoin("ukava", sdk.NewInt(1000001)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1000001)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("ukava", sdk.NewInt(1000001)), sdk.NewCoin("usdx", sdk.NewInt(5e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000001)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000001)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.003"), false},
+		{sdk.NewCoin("usdx", sdk.NewInt(5000001)), sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.MustNewDecFromStr("0.01"), sdk.MustNewDecFromStr("0.05"), false},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("coinA=%s coinB=%s slippage=%s fee=%s", tc.coinA, tc.coinB, tc.slippage, tc.fee), func() {
+			suite.SetupTest()
+			suite.Keeper.SetParams(suite.Ctx, types.Params{
+				SwapFee: tc.fee,
+			})
+			owner := suite.CreateAccount(sdk.Coins{})
+			reserves := sdk.NewCoins(
+				sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+				sdk.NewCoin("usdx", sdk.NewInt(500e6)),
+			)
+			totalShares := sdk.NewInt(30e6)
+			suite.setupPool(reserves, totalShares, owner.GetAddress())
+			balance := sdk.NewCoins(
+				sdk.NewCoin("ukava", sdk.NewInt(100e6)),
+				sdk.NewCoin("usdx", sdk.NewInt(100e6)),
+			)
+			requester := suite.NewAccountFromAddr(sdk.AccAddress("requester"), balance)
+
+			ctx := suite.App.NewContext(true, abci.Header{Height: 1, Time: tmtime.Now()})
+			err := suite.Keeper.SwapForExactTokens(ctx, requester.GetAddress(), tc.coinA, tc.coinB, tc.slippage)
+
+			if tc.shouldFail {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "slippage exceeded")
+			} else {
+				suite.NoError(err)
+			}
+		})
+	}
 }

--- a/x/swap/keeper/swap_test.go
+++ b/x/swap/keeper/swap_test.go
@@ -1,7 +1,86 @@
 package keeper_test
 
+import (
+	//"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kava-labs/kava/x/swap/types"
+)
+
 func (suite *keeperTestSuite) TestSwapExactForTokens() {
+	suite.Keeper.SetParams(suite.Ctx, types.Params{
+		SwapFee: sdk.MustNewDecFromStr("0.0025"),
+	})
+	owner := suite.CreateAccount(sdk.Coins{})
+	reserves := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(1000e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(5000e6)),
+	)
+	totalShares := sdk.NewInt(30e6)
+	poolID := suite.setupPool(reserves, totalShares, owner.GetAddress())
+
+	balance := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(10e6)),
+	)
+	requester := suite.NewAccountFromAddr(sdk.AccAddress("requester"), balance)
+	coinA := sdk.NewCoin("ukava", sdk.NewInt(1e6))
+	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
+
+	err := suite.Keeper.SwapExactForTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
+	suite.Require().NoError(err)
+
+	expectedOutput := sdk.NewCoin("usdx", sdk.NewInt(4982529))
+
+	suite.AccountBalanceEqual(requester, balance.Sub(sdk.NewCoins(coinA)).Add(expectedOutput))
+	suite.ModuleAccountBalanceEqual(reserves.Add(coinA).Sub(sdk.NewCoins(expectedOutput)))
+	suite.PoolLiquidityEqual(reserves.Add(coinA).Sub(sdk.NewCoins(expectedOutput)))
+
+	suite.EventsContains(suite.Ctx.EventManager().Events(), sdk.NewEvent(
+		types.EventTypeSwapTrade,
+		sdk.NewAttribute(types.AttributeKeyPoolID, poolID),
+		sdk.NewAttribute(types.AttributeKeyRequester, requester.GetAddress().String()),
+		sdk.NewAttribute(types.AttributeKeySwapInput, coinA.String()),
+		sdk.NewAttribute(types.AttributeKeySwapOutput, expectedOutput.String()),
+		sdk.NewAttribute(types.AttributeKeyFeePaid, "2500ukava"),
+		sdk.NewAttribute(types.AttributeKeyExactDirection, "input"),
+	))
 }
 
 func (suite *keeperTestSuite) TestSwapForExactTokens() {
+	suite.Keeper.SetParams(suite.Ctx, types.Params{
+		SwapFee: sdk.MustNewDecFromStr("0.0025"),
+	})
+	owner := suite.CreateAccount(sdk.Coins{})
+	reserves := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(1000e6)),
+		sdk.NewCoin("usdx", sdk.NewInt(5000e6)),
+	)
+	totalShares := sdk.NewInt(30e6)
+	poolID := suite.setupPool(reserves, totalShares, owner.GetAddress())
+
+	balance := sdk.NewCoins(
+		sdk.NewCoin("ukava", sdk.NewInt(10e6)),
+	)
+	requester := suite.NewAccountFromAddr(sdk.AccAddress("requester"), balance)
+	coinA := sdk.NewCoin("ukava", sdk.NewInt(1e6))
+	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
+
+	err := suite.Keeper.SwapForExactTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
+	suite.Require().NoError(err)
+
+	expectedInput := sdk.NewCoin("ukava", sdk.NewInt(1003511))
+
+	suite.AccountBalanceEqual(requester, balance.Sub(sdk.NewCoins(expectedInput)).Add(coinB))
+	suite.ModuleAccountBalanceEqual(reserves.Add(expectedInput).Sub(sdk.NewCoins(coinB)))
+	suite.PoolLiquidityEqual(reserves.Add(expectedInput).Sub(sdk.NewCoins(coinB)))
+
+	suite.EventsContains(suite.Ctx.EventManager().Events(), sdk.NewEvent(
+		types.EventTypeSwapTrade,
+		sdk.NewAttribute(types.AttributeKeyPoolID, poolID),
+		sdk.NewAttribute(types.AttributeKeyRequester, requester.GetAddress().String()),
+		sdk.NewAttribute(types.AttributeKeySwapInput, expectedInput.String()),
+		sdk.NewAttribute(types.AttributeKeySwapOutput, coinB.String()),
+		sdk.NewAttribute(types.AttributeKeyFeePaid, "2509ukava"),
+		sdk.NewAttribute(types.AttributeKeyExactDirection, "output"),
+	))
 }

--- a/x/swap/keeper/swap_test.go
+++ b/x/swap/keeper/swap_test.go
@@ -1,0 +1,7 @@
+package keeper_test
+
+func (suite *keeperTestSuite) TestSwapExactForTokens() {
+}
+
+func (suite *keeperTestSuite) TestSwapForExactTokens() {
+}

--- a/x/swap/testutil/suite.go
+++ b/x/swap/testutil/suite.go
@@ -20,6 +20,8 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
+var DefaultSwapFee = sdk.MustNewDecFromStr("0.003")
+
 // Suite implements a test suite for the swap module integration tests
 type Suite struct {
 	suite.Suite
@@ -111,7 +113,7 @@ func (suite *Suite) CreatePool(reserves sdk.Coins) error {
 	depositor := suite.CreateAccount(reserves)
 	pool := swap.NewAllowedPool(reserves[0].Denom, reserves[1].Denom)
 	suite.Require().NoError(pool.Validate())
-	suite.Keeper.SetParams(suite.Ctx, swap.NewParams(swap.NewAllowedPools(pool), swap.DefaultSwapFee))
+	suite.Keeper.SetParams(suite.Ctx, swap.NewParams(swap.NewAllowedPools(pool), DefaultSwapFee))
 
 	return suite.Keeper.Deposit(suite.Ctx, depositor.GetAddress(), reserves[0], reserves[1], sdk.MustNewDecFromStr("1"))
 }

--- a/x/swap/types/codec.go
+++ b/x/swap/types/codec.go
@@ -16,4 +16,6 @@ func init() {
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(MsgDeposit{}, "swap/MsgDeposit", nil)
 	cdc.RegisterConcrete(MsgWithdraw{}, "swap/MsgWithdraw", nil)
+	cdc.RegisterConcrete(MsgSwapExactForTokens{}, "swap/MsgSwapExactForTokens", nil)
+	cdc.RegisterConcrete(MsgSwapForExactTokens{}, "swap/MsgSwapForExactTokens", nil)
 }

--- a/x/swap/types/events.go
+++ b/x/swap/types/events.go
@@ -2,11 +2,17 @@ package types
 
 // Event types for swap module
 const (
-	AttributeValueCategory = ModuleName
-	EventTypeSwapDeposit   = "swap_deposit"
-	EventTypeSwapWithdraw  = "swap_withdraw"
-	AttributeKeyPoolID     = "pool_id"
-	AttributeKeyDepositor  = "depositor"
-	AttributeKeyShares     = "shares"
-	AttributeKeyOwner      = "owner"
+	AttributeValueCategory     = ModuleName
+	EventTypeSwapDeposit       = "swap_deposit"
+	EventTypeSwapWithdraw      = "swap_withdraw"
+	EventTypeSwapTrade         = "swap_trade"
+	AttributeKeyPoolID         = "pool_id"
+	AttributeKeyDepositor      = "depositor"
+	AttributeKeyShares         = "shares"
+	AttributeKeyOwner          = "owner"
+	AttributeKeyRequester      = "requester"
+	AttributeKeySwapInput      = "input"
+	AttributeKeySwapOutput     = "output"
+	AttributeKeyFeePaid        = "fee"
+	AttributeKeyExactDirection = "exact"
 )

--- a/x/swap/types/msg.go
+++ b/x/swap/types/msg.go
@@ -12,6 +12,10 @@ var (
 	_ MsgWithDeadline = &MsgDeposit{}
 	_ sdk.Msg         = &MsgWithdraw{}
 	_ MsgWithDeadline = &MsgWithdraw{}
+	_ sdk.Msg         = &MsgSwapExactForTokens{}
+	_ MsgWithDeadline = &MsgSwapExactForTokens{}
+	_ sdk.Msg         = &MsgSwapForExactTokens{}
+	_ MsgWithDeadline = &MsgSwapForExactTokens{}
 )
 
 // MsgWithDeadline allows messages to define a deadline of when they are considered invalid
@@ -177,5 +181,165 @@ func (msg MsgWithdraw) GetDeadline() time.Time {
 
 // DeadlineExceeded returns if the msg has exceeded it's deadline
 func (msg MsgWithdraw) DeadlineExceeded(blockTime time.Time) bool {
+	return blockTime.Unix() >= msg.Deadline
+}
+
+// MsgSwapExactForTokens trades an exact coinA for coinB
+type MsgSwapExactForTokens struct {
+	Requester   sdk.AccAddress `json:"requester" yaml:"requester"`
+	ExactTokenA sdk.Coin       `json:"exact_token_a" yaml:"exact_token_a"`
+	TokenB      sdk.Coin       `json:"token_b" yaml:"token_b"`
+	Slippage    sdk.Dec        `json:"slippage" yaml:"slippage"`
+	Deadline    int64          `json:"deadline" yaml:"deadline"`
+}
+
+// NewMsgSwapExactForTokens returns a new MsgSwapExactForTokens
+func NewMsgSwapExactForTokens(requester sdk.AccAddress, exactTokenA sdk.Coin, tokenB sdk.Coin, slippage sdk.Dec, deadline int64) MsgSwapExactForTokens {
+	return MsgSwapExactForTokens{
+		Requester:   requester,
+		ExactTokenA: exactTokenA,
+		TokenB:      tokenB,
+		Slippage:    slippage,
+		Deadline:    deadline,
+	}
+}
+
+// Route return the message type used for routing the message.
+func (msg MsgSwapExactForTokens) Route() string { return RouterKey }
+
+// Type returns a human-readable string for the message, intended for utilization within tags.
+func (msg MsgSwapExactForTokens) Type() string { return "swap_exact_for_tokens" }
+
+// ValidateBasic does a simple validation check that doesn't require access to any other information.
+func (msg MsgSwapExactForTokens) ValidateBasic() error {
+	if msg.Requester.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "requester address cannot be empty")
+	}
+
+	if !msg.ExactTokenA.IsValid() || msg.ExactTokenA.IsZero() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "exact token a deposit amount %s", msg.ExactTokenA)
+	}
+
+	if !msg.TokenB.IsValid() || msg.TokenB.IsZero() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "token b deposit amount %s", msg.TokenB)
+	}
+
+	if msg.ExactTokenA.Denom == msg.TokenB.Denom {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "denominations can not be equal")
+	}
+
+	if msg.Slippage.IsNil() {
+		return sdkerrors.Wrapf(ErrInvalidSlippage, "slippage must be set")
+	}
+
+	if msg.Slippage.IsNegative() {
+		return sdkerrors.Wrapf(ErrInvalidSlippage, "slippage can not be negative")
+	}
+
+	if msg.Deadline <= 0 {
+		return sdkerrors.Wrapf(ErrInvalidDeadline, "deadline %d", msg.Deadline)
+	}
+
+	return nil
+}
+
+// GetSignBytes gets the canonical byte representation of the Msg.
+func (msg MsgSwapExactForTokens) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// GetSigners returns the addresses of signers that must sign.
+func (msg MsgSwapExactForTokens) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Requester}
+}
+
+// GetDeadline returns the time at which the msg is considered invalid
+func (msg MsgSwapExactForTokens) GetDeadline() time.Time {
+	return time.Unix(msg.Deadline, 0)
+}
+
+// DeadlineExceeded returns if the msg has exceeded it's deadline
+func (msg MsgSwapExactForTokens) DeadlineExceeded(blockTime time.Time) bool {
+	return blockTime.Unix() >= msg.Deadline
+}
+
+// MsgSwapForExactTokens trades coinA for an exact coinB
+type MsgSwapForExactTokens struct {
+	Requester   sdk.AccAddress `json:"requester" yaml:"requester"`
+	TokenA      sdk.Coin       `json:"token_a" yaml:"token_a"`
+	ExactTokenB sdk.Coin       `json:"exact_token_b" yaml:"exact_token_b"`
+	Slippage    sdk.Dec        `json:"slippage" yaml:"slippage"`
+	Deadline    int64          `json:"deadline" yaml:"deadline"`
+}
+
+// NewMsgSwapForExactTokens returns a new MsgSwapForExactTokens
+func NewMsgSwapForExactTokens(requester sdk.AccAddress, tokenA sdk.Coin, exactTokenB sdk.Coin, slippage sdk.Dec, deadline int64) MsgSwapForExactTokens {
+	return MsgSwapForExactTokens{
+		Requester:   requester,
+		TokenA:      tokenA,
+		ExactTokenB: exactTokenB,
+		Slippage:    slippage,
+		Deadline:    deadline,
+	}
+}
+
+// Route return the message type used for routing the message.
+func (msg MsgSwapForExactTokens) Route() string { return RouterKey }
+
+// Type returns a human-readable string for the message, intended for utilization within tags.
+func (msg MsgSwapForExactTokens) Type() string { return "swap_for_exact_tokens" }
+
+// ValidateBasic does a simple validation check that doesn't require access to any other information.
+func (msg MsgSwapForExactTokens) ValidateBasic() error {
+	if msg.Requester.Empty() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "requester address cannot be empty")
+	}
+
+	if !msg.TokenA.IsValid() || msg.TokenA.IsZero() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "token a deposit amount %s", msg.TokenA)
+	}
+
+	if !msg.ExactTokenB.IsValid() || msg.ExactTokenB.IsZero() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "exact token b deposit amount %s", msg.ExactTokenB)
+	}
+
+	if msg.TokenA.Denom == msg.ExactTokenB.Denom {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "denominations can not be equal")
+	}
+
+	if msg.Slippage.IsNil() {
+		return sdkerrors.Wrapf(ErrInvalidSlippage, "slippage must be set")
+	}
+
+	if msg.Slippage.IsNegative() {
+		return sdkerrors.Wrapf(ErrInvalidSlippage, "slippage can not be negative")
+	}
+
+	if msg.Deadline <= 0 {
+		return sdkerrors.Wrapf(ErrInvalidDeadline, "deadline %d", msg.Deadline)
+	}
+
+	return nil
+}
+
+// GetSignBytes gets the canonical byte representation of the Msg.
+func (msg MsgSwapForExactTokens) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// GetSigners returns the addresses of signers that must sign.
+func (msg MsgSwapForExactTokens) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Requester}
+}
+
+// GetDeadline returns the time at which the msg is considered invalid
+func (msg MsgSwapForExactTokens) GetDeadline() time.Time {
+	return time.Unix(msg.Deadline, 0)
+}
+
+// DeadlineExceeded returns if the msg has exceeded it's deadline
+func (msg MsgSwapForExactTokens) DeadlineExceeded(blockTime time.Time) bool {
 	return blockTime.Unix() >= msg.Deadline
 }


### PR DESCRIPTION
Adds support for swapping with exact input and exact outputs with slippage and deadline.

- [x] Swap Messages
- [x] Swap Events
- [x] Handler, Keeper w/ test coverage of swap functionality
- [ ] Add keeper tests to ensure only spendable coins are tradable
- [ ] Add test coverage for pool & denominated pool errors/panics
- [ ] Validate exact swap output is less than pool reserves in keeper
- [ ] Add rest tx endpoints for swap messages