### PR TITLE
Swap Genesis State

### DIFF
--- a/migrate/v0_15/migrate.go
+++ b/migrate/v0_15/migrate.go
@@ -304,7 +304,7 @@ func loadStabilityComMembers() ([]sdk.AccAddress, error) {
 
 // Swap introduces new v0.15 swap genesis state
 func Swap() v0_15swap.GenesisState {
-	return v0_15swap.NewGenesisState(v0_15swap.DefaultParams())
+	return v0_15swap.DefaultGenesisState()
 }
 
 // Incentive migrates from a v0.14 incentive genesis state to a v0.15 incentive genesis state

--- a/migrate/v0_15/migrate.go
+++ b/migrate/v0_15/migrate.go
@@ -304,6 +304,7 @@ func loadStabilityComMembers() ([]sdk.AccAddress, error) {
 
 // Swap introduces new v0.15 swap genesis state
 func Swap() v0_15swap.GenesisState {
+	// TODO add swap genesis state
 	return v0_15swap.DefaultGenesisState()
 }
 

--- a/x/swap/alias.go
+++ b/x/swap/alias.go
@@ -25,7 +25,10 @@ const (
 	ModuleAccountName          = types.ModuleAccountName
 	ModuleName                 = types.ModuleName
 	QuerierRoute               = types.QuerierRoute
+	QueryGetDeposits           = types.QueryGetDeposits
 	QueryGetParams             = types.QueryGetParams
+	QueryGetPool               = types.QueryGetPool
+	QueryGetPools              = types.QueryGetPools
 	RouterKey                  = types.RouterKey
 	StoreKey                   = types.StoreKey
 )
@@ -43,6 +46,7 @@ var (
 	NewBasePoolWithExistingShares        = types.NewBasePoolWithExistingShares
 	NewDenominatedPool                   = types.NewDenominatedPool
 	NewDenominatedPoolWithExistingShares = types.NewDenominatedPoolWithExistingShares
+	NewDepositsQueryResult               = types.NewDepositsQueryResult
 	NewGenesisState                      = types.NewGenesisState
 	NewMsgDeposit                        = types.NewMsgDeposit
 	NewMsgSwapExactForTokens             = types.NewMsgSwapExactForTokens
@@ -50,6 +54,10 @@ var (
 	NewMsgWithdraw                       = types.NewMsgWithdraw
 	NewParams                            = types.NewParams
 	NewPoolRecord                        = types.NewPoolRecord
+	NewPoolRecordFromPool                = types.NewPoolRecordFromPool
+	NewPoolStatsQueryResult              = types.NewPoolStatsQueryResult
+	NewQueryDepositsParams               = types.NewQueryDepositsParams
+	NewQueryPoolParams                   = types.NewQueryPoolParams
 	NewShareRecord                       = types.NewShareRecord
 	ParamKeyTable                        = types.ParamKeyTable
 	PoolID                               = types.PoolID
@@ -59,6 +67,8 @@ var (
 
 	// variable aliases
 	DefaultAllowedPools       = types.DefaultAllowedPools
+	DefaultPoolRecords        = types.DefaultPoolRecords
+	DefaultShareRecords       = types.DefaultShareRecords
 	DefaultSwapFee            = types.DefaultSwapFee
 	DepositorPoolSharesPrefix = types.DepositorPoolSharesPrefix
 	ErrDeadlineExceeded       = types.ErrDeadlineExceeded
@@ -86,6 +96,8 @@ type (
 	AllowedPools          = types.AllowedPools
 	BasePool              = types.BasePool
 	DenominatedPool       = types.DenominatedPool
+	DepositsQueryResult   = types.DepositsQueryResult
+	DepositsQueryResults  = types.DepositsQueryResults
 	GenesisState          = types.GenesisState
 	MsgDeposit            = types.MsgDeposit
 	MsgSwapExactForTokens = types.MsgSwapExactForTokens
@@ -94,6 +106,13 @@ type (
 	MsgWithdraw           = types.MsgWithdraw
 	Params                = types.Params
 	PoolRecord            = types.PoolRecord
+	PoolRecords           = types.PoolRecords
+	PoolStatsQueryResult  = types.PoolStatsQueryResult
+	PoolStatsQueryResults = types.PoolStatsQueryResults
+	QueryDepositsParams   = types.QueryDepositsParams
+	QueryPoolParams       = types.QueryPoolParams
 	ShareRecord           = types.ShareRecord
+	ShareRecords          = types.ShareRecords
 	SupplyKeeper          = types.SupplyKeeper
+	SwapHooks             = types.SwapHooks
 )

--- a/x/swap/genesis.go
+++ b/x/swap/genesis.go
@@ -3,9 +3,9 @@ package swap
 import (
 	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/kava-labs/kava/x/swap/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // InitGenesis initializes story state from genesis file

--- a/x/swap/genesis.go
+++ b/x/swap/genesis.go
@@ -15,10 +15,18 @@ func InitGenesis(ctx sdk.Context, k Keeper, gs types.GenesisState) {
 	}
 
 	k.SetParams(ctx, gs.Params)
+	for _, pr := range gs.PoolRecords {
+		k.SetPool(ctx, pr)
+	}
+	for _, sh := range gs.ShareRecords {
+		k.SetDepositorShares(ctx, sh)
+	}
 }
 
 // ExportGenesis exports the genesis state
 func ExportGenesis(ctx sdk.Context, k Keeper) types.GenesisState {
 	params := k.GetParams(ctx)
-	return types.NewGenesisState(params)
+	pools := k.GetAllPools(ctx)
+	shares := k.GetAllDepositorShares(ctx)
+	return types.NewGenesisState(params, pools, shares)
 }

--- a/x/swap/genesis_test.go
+++ b/x/swap/genesis_test.go
@@ -1,0 +1,73 @@
+package swap_test
+
+import (
+	"testing"
+
+	"github.com/kava-labs/kava/x/swap"
+	"github.com/kava-labs/kava/x/swap/testutil"
+	"github.com/kava-labs/kava/x/swap/types"
+	"github.com/stretchr/testify/suite"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type genesisTestSuite struct {
+	testutil.Suite
+}
+
+func (suite *genesisTestSuite) Test_InitGenesis_ValidationPanic() {
+	invalidState := types.NewGenesisState(
+		types.Params{
+			SwapFee: sdk.NewDec(-1),
+		},
+		types.PoolRecords{},
+		types.ShareRecords{},
+	)
+
+	suite.Panics(func() {
+		swap.InitGenesis(suite.Ctx, suite.Keeper, invalidState)
+	}, "expected init genesis to panic with invalid state")
+}
+
+func (suite *genesisTestSuite) Test_InitAndExportGenesis() {
+	depositor_1, err := sdk.AccAddressFromBech32("kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w")
+	suite.Require().NoError(err)
+	depositor_2, err := sdk.AccAddressFromBech32("kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea")
+	suite.Require().NoError(err)
+
+	// slices are sorted by key as stored in the data store, so init and export can be compared with equal
+	state := types.NewGenesisState(
+		types.Params{
+			AllowedPools: swap.AllowedPools{swap.NewAllowedPool("ukava", "usdx")},
+			SwapFee:      sdk.MustNewDecFromStr("0.00255"),
+		},
+		types.PoolRecords{
+			swap.NewPoolRecord(sdk.NewCoins(sdk.NewCoin("hard", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(2e6))), sdk.NewInt(1e6)),
+			swap.NewPoolRecord(sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6))), sdk.NewInt(3e6)),
+		},
+		types.ShareRecords{
+			types.NewShareRecord(depositor_2, "hard/usdx", sdk.NewInt(1e6)),
+			types.NewShareRecord(depositor_1, "ukava/usdx", sdk.NewInt(3e6)),
+		},
+	)
+
+	swap.InitGenesis(suite.Ctx, suite.Keeper, state)
+	suite.Equal(state.Params, suite.Keeper.GetParams(suite.Ctx))
+
+	poolRecord1, _ := suite.Keeper.GetPool(suite.Ctx, "hard/usdx")
+	suite.Equal(state.PoolRecords[0], poolRecord1)
+	poolRecord2, _ := suite.Keeper.GetPool(suite.Ctx, "ukava/usdx")
+	suite.Equal(state.PoolRecords[1], poolRecord2)
+
+	shareRecord1, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_2, "hard/usdx")
+	suite.Equal(state.ShareRecords[0], shareRecord1)
+	shareRecord2, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_1, "ukava/usdx")
+	suite.Equal(state.ShareRecords[1], shareRecord2)
+
+	exportedState := swap.ExportGenesis(suite.Ctx, suite.Keeper)
+	suite.Equal(state, exportedState)
+}
+
+func TestGenesisTestSuite(t *testing.T) {
+	suite.Run(t, new(genesisTestSuite))
+}

--- a/x/swap/keeper/deposit.go
+++ b/x/swap/keeper/deposit.go
@@ -112,7 +112,7 @@ func (k Keeper) initializePool(ctx sdk.Context, poolID string, depositor sdk.Acc
 		return sdk.Coins{}, sdk.ZeroInt(), err
 	}
 
-	poolRecord := types.NewPoolRecord(pool)
+	poolRecord := types.NewPoolRecordFromPool(pool)
 	shareRecord := types.NewShareRecord(depositor, poolRecord.PoolID, pool.TotalShares())
 
 	k.SetPool(ctx, poolRecord)
@@ -129,7 +129,7 @@ func (k Keeper) addLiquidityToPool(ctx sdk.Context, record types.PoolRecord, dep
 
 	depositAmount, shares := pool.AddLiquidity(desiredAmount)
 
-	poolRecord := types.NewPoolRecord(pool)
+	poolRecord := types.NewPoolRecordFromPool(pool)
 
 	shareRecord, found := k.GetDepositorShares(ctx, depositor, poolRecord.PoolID)
 	if found {

--- a/x/swap/keeper/keeper_test.go
+++ b/x/swap/keeper/keeper_test.go
@@ -77,7 +77,7 @@ func (suite *keeperTestSuite) TestPool_Persistance() {
 
 	pool, err := types.NewDenominatedPool(reserves)
 	suite.Nil(err)
-	record := types.NewPoolRecord(pool)
+	record := types.NewPoolRecordFromPool(pool)
 
 	suite.Keeper.SetPool(suite.Ctx, record)
 

--- a/x/swap/keeper/querier_test.go
+++ b/x/swap/keeper/querier_test.go
@@ -70,7 +70,7 @@ func (suite *querierTestSuite) TestQueryPool() {
 
 	pool, err := types.NewDenominatedPool(sdk.NewCoins(coinA, coinB))
 	suite.Nil(err)
-	poolRecord := types.NewPoolRecord(pool)
+	poolRecord := types.NewPoolRecordFromPool(pool)
 	suite.Keeper.SetPool(suite.Ctx, poolRecord)
 
 	ctx := suite.Ctx.WithIsCheckTx(false)
@@ -101,12 +101,12 @@ func (suite *querierTestSuite) TestQueryPools() {
 
 	poolAB, err := types.NewDenominatedPool(sdk.NewCoins(coinA, coinB))
 	suite.Nil(err)
-	poolRecordAB := types.NewPoolRecord(poolAB)
+	poolRecordAB := types.NewPoolRecordFromPool(poolAB)
 	suite.Keeper.SetPool(suite.Ctx, poolRecordAB)
 
 	poolAC, err := types.NewDenominatedPool(sdk.NewCoins(coinA, coinC))
 	suite.Nil(err)
-	poolRecordAC := types.NewPoolRecord(poolAC)
+	poolRecordAC := types.NewPoolRecordFromPool(poolAC)
 	suite.Keeper.SetPool(suite.Ctx, poolRecordAC)
 
 	// Build a map of pools to compare to query results
@@ -142,7 +142,7 @@ func (suite *querierTestSuite) TestQueryDeposit() {
 	coinB := sdk.NewCoin("usdx", sdk.NewInt(200))
 	pool, err := types.NewDenominatedPool(sdk.NewCoins(coinA, coinB))
 	suite.Nil(err)
-	poolRecord := types.NewPoolRecord(pool)
+	poolRecord := types.NewPoolRecordFromPool(pool)
 	suite.Keeper.SetPool(suite.Ctx, poolRecord)
 
 	// Deposit into pool

--- a/x/swap/keeper/swap.go
+++ b/x/swap/keeper/swap.go
@@ -96,7 +96,7 @@ func (k Keeper) commitSwap(
 	feePaid sdk.Coin,
 	exactDirection string,
 ) error {
-	k.SetPool(ctx, types.NewPoolRecord(pool))
+	k.SetPool(ctx, types.NewPoolRecordFromPool(pool))
 
 	if err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, requester, types.ModuleAccountName, sdk.NewCoins(swapInput)); err != nil {
 		return err

--- a/x/swap/keeper/withdraw.go
+++ b/x/swap/keeper/withdraw.go
@@ -76,7 +76,7 @@ func (k Keeper) updatePool(ctx sdk.Context, poolID string, pool *types.Denominat
 	if pool.TotalShares().IsZero() {
 		k.DeletePool(ctx, poolID)
 	} else {
-		k.SetPool(ctx, types.NewPoolRecord(pool))
+		k.SetPool(ctx, types.NewPoolRecordFromPool(pool))
 	}
 }
 

--- a/x/swap/types/genesis.go
+++ b/x/swap/types/genesis.go
@@ -2,15 +2,24 @@ package types
 
 import "bytes"
 
+var (
+	DefaultPoolRecords  = PoolRecords{}
+	DefaultShareRecords = ShareRecords{}
+)
+
 // GenesisState is the state that must be provided at genesis.
 type GenesisState struct {
-	Params Params `json:"params" yaml:"params"`
+	Params       Params `json:"params" yaml:"params"`
+	PoolRecords  `json:"pool_records" yaml:"pool_records"`
+	ShareRecords `json:"share_records" yaml:"share_records"`
 }
 
 // NewGenesisState creates a new genesis state.
-func NewGenesisState(params Params) GenesisState {
+func NewGenesisState(params Params, poolRecords PoolRecords, shareRecords ShareRecords) GenesisState {
 	return GenesisState{
-		Params: params,
+		Params:       params,
+		PoolRecords:  poolRecords,
+		ShareRecords: shareRecords,
 	}
 }
 
@@ -19,13 +28,18 @@ func (gs GenesisState) Validate() error {
 	if err := gs.Params.Validate(); err != nil {
 		return err
 	}
-	return nil
+	if err := gs.PoolRecords.Validate(); err != nil {
+		return err
+	}
+	return gs.ShareRecords.Validate()
 }
 
 // DefaultGenesisState returns a default genesis state
 func DefaultGenesisState() GenesisState {
 	return NewGenesisState(
 		DefaultParams(),
+		DefaultPoolRecords,
+		DefaultShareRecords,
 	)
 }
 

--- a/x/swap/types/genesis.go
+++ b/x/swap/types/genesis.go
@@ -13,7 +13,9 @@ type poolShares struct {
 }
 
 var (
-	DefaultPoolRecords  = PoolRecords{}
+	// DefaultPoolRecords is used to set default records in default genesis state
+	DefaultPoolRecords = PoolRecords{}
+	// DefaultShareRecords is used to set default records in default genesis state
 	DefaultShareRecords = ShareRecords{}
 )
 

--- a/x/swap/types/genesis_test.go
+++ b/x/swap/types/genesis_test.go
@@ -133,8 +133,8 @@ func TestGenesis_Equal(t *testing.T) {
 		sdk.MustNewDecFromStr("0.85"),
 	}
 
-	genesisA := types.GenesisState{params}
-	genesisB := types.GenesisState{params}
+	genesisA := types.GenesisState{params, types.DefaultPoolRecords, types.DefaultShareRecords}
+	genesisB := types.GenesisState{params, types.DefaultPoolRecords, types.DefaultShareRecords}
 
 	assert.True(t, genesisA.Equal(genesisB))
 }
@@ -147,17 +147,17 @@ func TestGenesis_NotEqual(t *testing.T) {
 
 	// Base params
 	genesisAParams := baseParams
-	genesisA := types.GenesisState{genesisAParams}
+	genesisA := types.GenesisState{genesisAParams, types.DefaultPoolRecords, types.DefaultShareRecords}
 
 	// Different swap fee
 	genesisBParams := baseParams
 	genesisBParams.SwapFee = sdk.MustNewDecFromStr("0.84")
-	genesisB := types.GenesisState{genesisBParams}
+	genesisB := types.GenesisState{genesisBParams, types.DefaultPoolRecords, types.DefaultShareRecords}
 
 	// Different pairs
 	genesisCParams := baseParams
 	genesisCParams.AllowedPools = types.NewAllowedPools(types.NewAllowedPool("ukava", "hard"))
-	genesisC := types.GenesisState{genesisCParams}
+	genesisC := types.GenesisState{genesisCParams, types.DefaultPoolRecords, types.DefaultShareRecords}
 
 	// A and B have different swap fees
 	assert.False(t, genesisA.Equal(genesisB))

--- a/x/swap/types/state.go
+++ b/x/swap/types/state.go
@@ -25,10 +25,41 @@ func PoolID(denomA string, denomB string) string {
 // and is used to store the state of a denominated pool
 type PoolRecord struct {
 	// primary key
-	PoolID      string
+	PoolID      string   `json:"pool_id" yaml:"pool_id"`
 	ReservesA   sdk.Coin `json:"reserves_a" yaml:"reserves_a"`
 	ReservesB   sdk.Coin `json:"reserves_b" yaml:"reserves_b"`
 	TotalShares sdk.Int  `json:"total_shares" yaml:"total_shares"`
+}
+
+// NewPoolRecord takes reserve coins and total shares, returning
+// a new pool record with a id
+func NewPoolRecord(reserves sdk.Coins, totalShares sdk.Int) PoolRecord {
+	if len(reserves) != 2 {
+		panic("reserves must have two denominations")
+	}
+
+	poolID := PoolIDFromCoins(reserves)
+
+	return PoolRecord{
+		PoolID:      poolID,
+		ReservesA:   reserves[0],
+		ReservesB:   reserves[1],
+		TotalShares: totalShares,
+	}
+}
+
+// NewPoolRecordFromPool takes a pointer to a denominated pool and returns a
+// pool record for storage in state.
+func NewPoolRecordFromPool(pool *DenominatedPool) PoolRecord {
+	reserves := pool.Reserves()
+	poolID := PoolIDFromCoins(reserves)
+
+	return PoolRecord{
+		PoolID:      poolID,
+		ReservesA:   reserves[0],
+		ReservesB:   reserves[1],
+		TotalShares: pool.TotalShares(),
+	}
 }
 
 func (p PoolRecord) Validate() error {
@@ -47,20 +78,6 @@ func (p PoolRecord) Validate() error {
 // Reserves returns the total reserves for a pool
 func (p PoolRecord) Reserves() sdk.Coins {
 	return sdk.NewCoins(p.ReservesA, p.ReservesB)
-}
-
-// NewPoolRecord takes a pointer to a denominated pool and returns a
-// pool record for storage in state.
-func NewPoolRecord(pool *DenominatedPool) PoolRecord {
-	reserves := pool.Reserves()
-	poolID := PoolIDFromCoins(reserves)
-
-	return PoolRecord{
-		PoolID:      poolID,
-		ReservesA:   reserves[0],
-		ReservesB:   reserves[1],
-		TotalShares: pool.TotalShares(),
-	}
 }
 
 // PoolRecords is a slice of PoolRecord

--- a/x/swap/types/state_test.go
+++ b/x/swap/types/state_test.go
@@ -48,6 +48,35 @@ func TestState_NewPoolRecord(t *testing.T) {
 	assert.Equal(t, record.ReservesB, usdx(50e6))
 	assert.Equal(t, pool.TotalShares(), record.TotalShares)
 	assert.Equal(t, sdk.NewCoins(ukava(10e6), usdx(50e6)), record.Reserves())
+	assert.Nil(t, record.Validate())
+}
+
+func TestState_InvalidPoolRecordNegativeShares(t *testing.T) {
+	record := types.PoolRecord{
+		PoolID:      types.PoolID("ukava", "usdx"),
+		ReservesA:   usdx(50e6),
+		ReservesB:   ukava(10e6),
+		TotalShares: i(-100),
+	}
+	require.Error(t, record.Validate())
+}
+
+func TestState_InvalidPoolRecordNegativeReserves(t *testing.T) {
+	recordA := types.PoolRecord{
+		PoolID:      types.PoolID("ukava", "usdx"),
+		ReservesA:   sdk.Coin{Denom: "usdx", Amount: i(-50e6)},
+		ReservesB:   ukava(10e6),
+		TotalShares: i(100),
+	}
+	require.Error(t, recordA.Validate())
+
+	recordB := types.PoolRecord{
+		PoolID:      types.PoolID("ukava", "usdx"),
+		ReservesA:   usdx(50e6),
+		ReservesB:   sdk.Coin{Denom: "ukava", Amount: i(-10e6)},
+		TotalShares: i(100),
+	}
+	require.Error(t, recordB.Validate())
 }
 
 func TestState_NewShareRecord(t *testing.T) {
@@ -60,4 +89,22 @@ func TestState_NewShareRecord(t *testing.T) {
 	assert.Equal(t, depositor, record.Depositor)
 	assert.Equal(t, poolID, record.PoolID)
 	assert.Equal(t, shares, record.SharesOwned)
+}
+
+func TestState_InvalidShareRecordEmptyDepositor(t *testing.T) {
+	record := types.ShareRecord{
+		Depositor:   sdk.AccAddress{},
+		PoolID:      types.PoolID("ukava", "usdx"),
+		SharesOwned: sdk.NewInt(1e6),
+	}
+	require.Error(t, record.Validate())
+}
+
+func TestState_InvalidShareRecordNegativeShares(t *testing.T) {
+	record := types.ShareRecord{
+		Depositor:   sdk.AccAddress("some user"),
+		PoolID:      types.PoolID("ukava", "usdx"),
+		SharesOwned: sdk.NewInt(-1e6),
+	}
+	require.Error(t, record.Validate())
 }

--- a/x/swap/types/state_test.go
+++ b/x/swap/types/state_test.go
@@ -275,6 +275,28 @@ func TestState_PoolRecord_Validations(t *testing.T) {
 	}
 }
 
+func TestState_PoolRecords_Validation(t *testing.T) {
+	validRecord := types.NewPoolRecord(
+		sdk.NewCoins(usdx(500e6), ukava(100e6)),
+		i(300e6),
+	)
+
+	invalidRecord := types.NewPoolRecord(
+		sdk.NewCoins(usdx(500e6), ukava(100e6)),
+		i(-1),
+	)
+
+	records := types.PoolRecords{
+		validRecord,
+	}
+	assert.NoError(t, records.Validate())
+
+	records = append(records, invalidRecord)
+	err := records.Validate()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "pool 'ukava/usdx' has invalid total shares: -1")
+}
+
 func TestState_NewShareRecord(t *testing.T) {
 	depositor := sdk.AccAddress("some user")
 	poolID := types.PoolID("ukava", "usdx")
@@ -441,4 +463,31 @@ func TestState_ShareRecord_Validations(t *testing.T) {
 			assert.EqualError(t, err, tc.expectedErr)
 		})
 	}
+}
+
+func TestState_ShareRecords_Validation(t *testing.T) {
+	depositor, err := sdk.AccAddressFromBech32("kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w")
+	require.NoError(t, err)
+
+	validRecord := types.NewShareRecord(
+		depositor,
+		"ukava/usdx",
+		i(300e6),
+	)
+
+	invalidRecord := types.NewShareRecord(
+		depositor,
+		"hard/usdx",
+		i(-1),
+	)
+
+	records := types.ShareRecords{
+		validRecord,
+	}
+	assert.NoError(t, records.Validate())
+
+	records = append(records, invalidRecord)
+	err = records.Validate()
+	assert.Error(t, err)
+	assert.EqualError(t, err, "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'hard/usdx' has invalid total shares: -1")
 }

--- a/x/swap/types/state_test.go
+++ b/x/swap/types/state_test.go
@@ -275,6 +275,29 @@ func TestState_PoolRecord_Validations(t *testing.T) {
 	}
 }
 
+func TestState_PoolRecords_OrderedReserves(t *testing.T) {
+	invalidOrder := types.NewPoolRecord(
+		// force order to not be sorted
+		sdk.Coins{usdx(500e6), ukava(100e6)},
+		i(300e6),
+	)
+	assert.Error(t, invalidOrder.Validate())
+
+	validOrder := types.NewPoolRecord(
+		// force order to not be sorted
+		sdk.Coins{ukava(500e6), usdx(100e6)},
+		i(300e6),
+	)
+	assert.NoError(t, validOrder.Validate())
+
+	record_1 := types.NewPoolRecord(sdk.NewCoins(usdx(500e6), ukava(100e6)), i(300e6))
+	record_2 := types.NewPoolRecord(sdk.NewCoins(ukava(100e6), usdx(500e6)), i(300e6))
+	// ensure no regresssions in NewCoins ordering
+	assert.Equal(t, record_1, record_2)
+	assert.Equal(t, "ukava/usdx", record_1.PoolID)
+	assert.Equal(t, "ukava/usdx", record_2.PoolID)
+}
+
 func TestState_PoolRecords_Validation(t *testing.T) {
 	validRecord := types.NewPoolRecord(
 		sdk.NewCoins(usdx(500e6), ukava(100e6)),


### PR DESCRIPTION
- [x] Persists pool and share records on import/export genesis
- [x] Validates Pool record data and ensures there are no duplicates
- [x] Validates share record data and ensures there are no duplicates
- [x] Validates that each pools total shares equals the sum of depositor shares
- [x] Validates Pool Id matches reserves of each pool
- [x] Validates records can not have negative or zero shares
- [x] tests Json and yaml encoding of genesis state