### PR TITLE
Update Pool ID Separator

### DIFF
--- a/x/incentive/handler_swap_test.go
+++ b/x/incentive/handler_swap_test.go
@@ -119,7 +119,7 @@ func (suite *HandlerTestSuite) TestPayoutSwapClaim() {
 		WithSimpleAccount(userAddr, cs(c("ukava", 1e12), c("busd", 1e12)))
 
 	incentBuilder := suite.incentiveBuilder().
-		WithSimpleSwapRewardPeriod("busd/ukava", cs(c("hard", 1e6), c("swap", 1e6)))
+		WithSimpleSwapRewardPeriod("busd:ukava", cs(c("hard", 1e6), c("swap", 1e6)))
 
 	suite.SetupWithGenState(authBulder, incentBuilder)
 
@@ -163,7 +163,7 @@ func (suite *HandlerTestSuite) TestPayoutSwapClaimSingleDenom() {
 		WithSimpleAccount(userAddr, cs(c("ukava", 1e12), c("busd", 1e12)))
 
 	incentBuilder := suite.incentiveBuilder().
-		WithSimpleSwapRewardPeriod("busd/ukava", cs(c("hard", 1e6), c("swap", 1e6)))
+		WithSimpleSwapRewardPeriod("busd:ukava", cs(c("hard", 1e6), c("swap", 1e6)))
 
 	suite.SetupWithGenState(authBulder, incentBuilder)
 
@@ -211,7 +211,7 @@ func (suite *HandlerTestSuite) TestPayoutSwapClaimVVesting() {
 		WithSimpleAccount(receiverAddr, nil)
 
 	incentBuilder := suite.incentiveBuilder().
-		WithSimpleSwapRewardPeriod("busd/ukava", cs(c("hard", 1e6), c("swap", 1e6)))
+		WithSimpleSwapRewardPeriod("busd:ukava", cs(c("hard", 1e6), c("swap", 1e6)))
 
 	suite.SetupWithGenState(authBulder, incentBuilder)
 
@@ -259,7 +259,7 @@ func (suite *HandlerTestSuite) TestPayoutSwapClaimVVestingSingleDenom() {
 		WithSimpleAccount(receiverAddr, nil)
 
 	incentBuilder := suite.incentiveBuilder().
-		WithSimpleSwapRewardPeriod("busd/ukava", cs(c("hard", 1e6), c("swap", 1e6)))
+		WithSimpleSwapRewardPeriod("busd:ukava", cs(c("hard", 1e6), c("swap", 1e6)))
 
 	suite.SetupWithGenState(authBulder, incentBuilder)
 

--- a/x/swap/genesis_test.go
+++ b/x/swap/genesis_test.go
@@ -46,22 +46,22 @@ func (suite *genesisTestSuite) Test_InitAndExportGenesis() {
 			swap.NewPoolRecord(sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6)), sdk.NewCoin("usdx", sdk.NewInt(5e6))), sdk.NewInt(3e6)),
 		},
 		types.ShareRecords{
-			types.NewShareRecord(depositor_2, "hard/usdx", sdk.NewInt(1e6)),
-			types.NewShareRecord(depositor_1, "ukava/usdx", sdk.NewInt(3e6)),
+			types.NewShareRecord(depositor_2, types.PoolID("hard", "usdx"), sdk.NewInt(1e6)),
+			types.NewShareRecord(depositor_1, types.PoolID("ukava", "usdx"), sdk.NewInt(3e6)),
 		},
 	)
 
 	swap.InitGenesis(suite.Ctx, suite.Keeper, state)
 	suite.Equal(state.Params, suite.Keeper.GetParams(suite.Ctx))
 
-	poolRecord1, _ := suite.Keeper.GetPool(suite.Ctx, "hard/usdx")
+	poolRecord1, _ := suite.Keeper.GetPool(suite.Ctx, types.PoolID("hard", "usdx"))
 	suite.Equal(state.PoolRecords[0], poolRecord1)
-	poolRecord2, _ := suite.Keeper.GetPool(suite.Ctx, "ukava/usdx")
+	poolRecord2, _ := suite.Keeper.GetPool(suite.Ctx, types.PoolID("ukava", "usdx"))
 	suite.Equal(state.PoolRecords[1], poolRecord2)
 
-	shareRecord1, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_2, "hard/usdx")
+	shareRecord1, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_2, types.PoolID("hard", "usdx"))
 	suite.Equal(state.ShareRecords[0], shareRecord1)
-	shareRecord2, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_1, "ukava/usdx")
+	shareRecord2, _ := suite.Keeper.GetDepositorShares(suite.Ctx, depositor_1, types.PoolID("ukava", "usdx"))
 	suite.Equal(state.ShareRecords[1], shareRecord2)
 
 	exportedState := swap.ExportGenesis(suite.Ctx, suite.Keeper)

--- a/x/swap/keeper/deposit_test.go
+++ b/x/swap/keeper/deposit_test.go
@@ -18,7 +18,7 @@ func (suite *keeperTestSuite) TestDeposit_CreatePool_PoolNotAllowed() {
 	amountB := sdk.NewCoin("usdx", sdk.NewInt(50e6))
 
 	err := suite.Keeper.Deposit(suite.Ctx, depositor.GetAddress(), amountA, amountB, sdk.MustNewDecFromStr("0.01"))
-	suite.Require().EqualError(err, "not allowed: can not create pool 'ukava/usdx'")
+	suite.Require().EqualError(err, "not allowed: can not create pool 'ukava:usdx'")
 }
 
 func (suite *keeperTestSuite) TestDeposit_InsufficientFunds() {
@@ -324,7 +324,7 @@ func (suite *keeperTestSuite) TestDeposit_InsufficientLiquidity() {
 			suite.SetupTest()
 
 			record := types.PoolRecord{
-				PoolID:      "ukava/usdx",
+				PoolID:      types.PoolID("ukava", "usdx"),
 				ReservesA:   tc.poolA,
 				ReservesB:   tc.poolB,
 				TotalShares: tc.poolShares,

--- a/x/swap/keeper/keeper_test.go
+++ b/x/swap/keeper/keeper_test.go
@@ -107,7 +107,7 @@ func (suite *keeperTestSuite) TestPool_Persistance() {
 }
 
 func (suite *keeperTestSuite) TestShare_Persistance() {
-	poolID := "ukava/usdx"
+	poolID := types.PoolID("ukava", "usdx")
 	depositor := sdk.AccAddress("testAddress1")
 	shares := sdk.NewInt(3126432331)
 

--- a/x/swap/keeper/swap_test.go
+++ b/x/swap/keeper/swap_test.go
@@ -249,10 +249,10 @@ func (suite *keeperTestSuite) TestSwapExactForTokens_PoolNotFound() {
 	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
 
 	err := suite.Keeper.SwapExactForTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
-	suite.EqualError(err, "invalid pool: pool ukava/usdx not found")
+	suite.EqualError(err, "invalid pool: pool ukava:usdx not found")
 
 	err = suite.Keeper.SwapExactForTokens(suite.Ctx, requester.GetAddress(), coinB, coinA, sdk.MustNewDecFromStr("0.01"))
-	suite.EqualError(err, "invalid pool: pool ukava/usdx not found")
+	suite.EqualError(err, "invalid pool: pool ukava:usdx not found")
 }
 
 func (suite *keeperTestSuite) TestSwapExactForTokens_PanicOnInvalidPool() {
@@ -278,11 +278,11 @@ func (suite *keeperTestSuite) TestSwapExactForTokens_PanicOnInvalidPool() {
 	coinA := sdk.NewCoin("ukava", sdk.NewInt(1e6))
 	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
 
-	suite.PanicsWithValue("invalid pool ukava/usdx: invalid pool: total shares must be greater than zero", func() {
+	suite.PanicsWithValue("invalid pool ukava:usdx: invalid pool: total shares must be greater than zero", func() {
 		_ = suite.Keeper.SwapExactForTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
 	}, "expected invalid pool record to panic")
 
-	suite.PanicsWithValue("invalid pool ukava/usdx: invalid pool: total shares must be greater than zero", func() {
+	suite.PanicsWithValue("invalid pool ukava:usdx: invalid pool: total shares must be greater than zero", func() {
 		_ = suite.Keeper.SwapExactForTokens(suite.Ctx, requester.GetAddress(), coinB, coinA, sdk.MustNewDecFromStr("0.01"))
 	}, "expected invalid pool record to panic")
 }
@@ -560,10 +560,10 @@ func (suite *keeperTestSuite) TestSwapForExactTokens_PoolNotFound() {
 	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
 
 	err := suite.Keeper.SwapForExactTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
-	suite.EqualError(err, "invalid pool: pool ukava/usdx not found")
+	suite.EqualError(err, "invalid pool: pool ukava:usdx not found")
 
 	err = suite.Keeper.SwapForExactTokens(suite.Ctx, requester.GetAddress(), coinB, coinA, sdk.MustNewDecFromStr("0.01"))
-	suite.EqualError(err, "invalid pool: pool ukava/usdx not found")
+	suite.EqualError(err, "invalid pool: pool ukava:usdx not found")
 }
 
 func (suite *keeperTestSuite) TestSwapForExactTokens_PanicOnInvalidPool() {
@@ -589,11 +589,11 @@ func (suite *keeperTestSuite) TestSwapForExactTokens_PanicOnInvalidPool() {
 	coinA := sdk.NewCoin("ukava", sdk.NewInt(1e6))
 	coinB := sdk.NewCoin("usdx", sdk.NewInt(5e6))
 
-	suite.PanicsWithValue("invalid pool ukava/usdx: invalid pool: total shares must be greater than zero", func() {
+	suite.PanicsWithValue("invalid pool ukava:usdx: invalid pool: total shares must be greater than zero", func() {
 		_ = suite.Keeper.SwapForExactTokens(suite.Ctx, requester.GetAddress(), coinA, coinB, sdk.MustNewDecFromStr("0.01"))
 	}, "expected invalid pool record to panic")
 
-	suite.PanicsWithValue("invalid pool ukava/usdx: invalid pool: total shares must be greater than zero", func() {
+	suite.PanicsWithValue("invalid pool ukava:usdx: invalid pool: total shares must be greater than zero", func() {
 		_ = suite.Keeper.SwapForExactTokens(suite.Ctx, requester.GetAddress(), coinB, coinA, sdk.MustNewDecFromStr("0.01"))
 	}, "expected invalid pool record to panic")
 }

--- a/x/swap/keeper/withdraw_test.go
+++ b/x/swap/keeper/withdraw_test.go
@@ -178,7 +178,7 @@ func (suite *keeperTestSuite) TestWithdraw_PanicOnMissingPool() {
 
 	suite.Keeper.DeletePool(suite.Ctx, poolID)
 
-	suite.PanicsWithValue("pool ukava/usdx not found", func() {
+	suite.PanicsWithValue("pool ukava:usdx not found", func() {
 		_ = suite.Keeper.Withdraw(suite.Ctx, owner.GetAddress(), totalShares, reserves[0], reserves[1])
 	}, "expected missing pool record to panic")
 }
@@ -198,7 +198,7 @@ func (suite *keeperTestSuite) TestWithdraw_PanicOnInvalidPool() {
 	poolRecord.TotalShares = sdk.ZeroInt()
 	suite.Keeper.SetPool(suite.Ctx, poolRecord)
 
-	suite.PanicsWithValue("invalid pool ukava/usdx: invalid pool: total shares must be greater than zero", func() {
+	suite.PanicsWithValue("invalid pool ukava:usdx: invalid pool: total shares must be greater than zero", func() {
 		_ = suite.Keeper.Withdraw(suite.Ctx, owner.GetAddress(), totalShares, reserves[0], reserves[1])
 	}, "expected invalid pool record to panic")
 }

--- a/x/swap/types/genesis_test.go
+++ b/x/swap/types/genesis_test.go
@@ -186,13 +186,13 @@ func TestGenesis_JSONEncoding(t *testing.T) {
 		},
 		"pool_records": [
 		  {
-			  "pool_id": "ukava/usdx",
+				"pool_id": "ukava:usdx",
 			  "reserves_a": { "denom": "ukava", "amount": "1000000" },
 			  "reserves_b": { "denom": "usdx", "amount": "5000000" },
 			  "total_shares": "3000000"
 			},
 		  {
-			  "pool_id": "hard/usdx",
+			  "pool_id": "hard:usdx",
 			  "reserves_a": { "denom": "ukava", "amount": "1000000" },
 			  "reserves_b": { "denom": "usdx", "amount": "2000000" },
 			  "total_shares": "2000000"
@@ -201,12 +201,12 @@ func TestGenesis_JSONEncoding(t *testing.T) {
 		"share_records": [
 		  {
 		    "depositor": "kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w",
-		    "pool_id": "ukava/usdx",
+		    "pool_id": "ukava:usdx",
 		    "shares_owned": "100000"
 			},
 		  {
 		    "depositor": "kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea",
-		    "pool_id": "hard/usdx",
+		    "pool_id": "hard:usdx",
 		    "shares_owned": "200000"
 			}
 		]
@@ -231,7 +231,7 @@ func TestGenesis_YAMLEncoding(t *testing.T) {
     token_b: busd
   swap_fee: "0.003000000000000000"
 pool_records:
-- pool_id: ukava/usdx
+- pool_id: ukava:usdx
   reserves_a:
     denom: ukava
     amount: "1000000"
@@ -239,7 +239,7 @@ pool_records:
     denom: usdx
     amount: "5000000"
   total_shares: "3000000"
-- pool_id: hard/usdx
+- pool_id: hard:usdx
   reserves_a:
     denom: hard
     amount: "1000000"
@@ -249,10 +249,10 @@ pool_records:
   total_shares: "1500000"
 share_records:
 - depositor: kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w
-  pool_id: ukava/usdx
+  pool_id: ukava:usdx
   shares_owned: "100000"
 - depositor: kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea
-  pool_id: hard/usdx
+  pool_id: hard:usdx
   shares_owned: "200000"
 `
 
@@ -274,8 +274,8 @@ share_records:
 			types.NewPoolRecord(sdk.NewCoins(hard(1e6), usdx(2e6)), i(15e5)),
 		},
 		types.ShareRecords{
-			types.NewShareRecord(depositor_1, "ukava/usdx", i(1e5)),
-			types.NewShareRecord(depositor_2, "hard/usdx", i(2e5)),
+			types.NewShareRecord(depositor_1, types.PoolID("ukava", "usdx"), i(1e5)),
+			types.NewShareRecord(depositor_2, types.PoolID("hard", "usdx"), i(2e5)),
 		},
 	)
 
@@ -330,15 +330,15 @@ func TestGenesis_Validate_PoolShareIntegration(t *testing.T) {
 				types.NewPoolRecord(sdk.NewCoins(ukava(1e6), usdx(5e6)), i(3e6)),
 			},
 			shareRecords: types.ShareRecords{},
-			expectedErr:  "total depositor shares 0 not equal to pool 'ukava/usdx' total shares 3000000",
+			expectedErr:  "total depositor shares 0 not equal to pool 'ukava:usdx' total shares 3000000",
 		},
 		{
 			name:        "zero pool records, one share record",
 			poolRecords: types.PoolRecords{},
 			shareRecords: types.ShareRecords{
-				types.NewShareRecord(depositor_1, "ukava/usdx", i(5e6)),
+				types.NewShareRecord(depositor_1, types.PoolID("ukava", "usdx"), i(5e6)),
 			},
-			expectedErr: "total depositor shares 5000000 not equal to pool 'ukava/usdx' total shares 0",
+			expectedErr: "total depositor shares 5000000 not equal to pool 'ukava:usdx' total shares 0",
 		},
 		{
 			name: "one pool record, one share record",
@@ -346,9 +346,9 @@ func TestGenesis_Validate_PoolShareIntegration(t *testing.T) {
 				types.NewPoolRecord(sdk.NewCoins(ukava(1e6), usdx(5e6)), i(3e6)),
 			},
 			shareRecords: types.ShareRecords{
-				types.NewShareRecord(depositor_1, "ukava/usdx", i(15e5)),
+				types.NewShareRecord(depositor_1, "ukava:usdx", i(15e5)),
 			},
-			expectedErr: "total depositor shares 1500000 not equal to pool 'ukava/usdx' total shares 3000000",
+			expectedErr: "total depositor shares 1500000 not equal to pool 'ukava:usdx' total shares 3000000",
 		},
 		{
 			name: "more than one pool records, more than one share record",
@@ -357,11 +357,11 @@ func TestGenesis_Validate_PoolShareIntegration(t *testing.T) {
 				types.NewPoolRecord(sdk.NewCoins(hard(1e6), usdx(2e6)), i(2e6)),
 			},
 			shareRecords: types.ShareRecords{
-				types.NewShareRecord(depositor_1, "ukava/usdx", i(15e5)),
-				types.NewShareRecord(depositor_2, "ukava/usdx", i(15e5)),
-				types.NewShareRecord(depositor_1, "hard/usdx", i(1e6)),
+				types.NewShareRecord(depositor_1, types.PoolID("ukava", "usdx"), i(15e5)),
+				types.NewShareRecord(depositor_2, types.PoolID("ukava", "usdx"), i(15e5)),
+				types.NewShareRecord(depositor_1, types.PoolID("hard", "usdx"), i(1e6)),
 			},
-			expectedErr: "total depositor shares 1000000 not equal to pool 'hard/usdx' total shares 2000000",
+			expectedErr: "total depositor shares 1000000 not equal to pool 'hard:usdx' total shares 2000000",
 		},
 		{
 			name: "valid case with many pool records and share records",
@@ -371,11 +371,11 @@ func TestGenesis_Validate_PoolShareIntegration(t *testing.T) {
 				types.NewPoolRecord(sdk.NewCoins(hard(7e6), ukava(10e6)), i(8e6)),
 			},
 			shareRecords: types.ShareRecords{
-				types.NewShareRecord(depositor_1, "ukava/usdx", i(15e5)),
-				types.NewShareRecord(depositor_2, "ukava/usdx", i(15e5)),
-				types.NewShareRecord(depositor_1, "hard/usdx", i(2e6)),
-				types.NewShareRecord(depositor_1, "hard/ukava", i(3e6)),
-				types.NewShareRecord(depositor_2, "hard/ukava", i(5e6)),
+				types.NewShareRecord(depositor_1, types.PoolID("ukava", "usdx"), i(15e5)),
+				types.NewShareRecord(depositor_2, types.PoolID("ukava", "usdx"), i(15e5)),
+				types.NewShareRecord(depositor_1, types.PoolID("hard", "usdx"), i(2e6)),
+				types.NewShareRecord(depositor_1, types.PoolID("hard", "ukava"), i(3e6)),
+				types.NewShareRecord(depositor_2, types.PoolID("hard", "ukava"), i(5e6)),
 			},
 			expectedErr: "",
 		},

--- a/x/swap/types/keys.go
+++ b/x/swap/types/keys.go
@@ -29,7 +29,7 @@ var (
 	PoolKeyPrefix             = []byte{0x01}
 	DepositorPoolSharesPrefix = []byte{0x02}
 
-	sep = []byte(":")
+	sep = []byte("|")
 )
 
 // PoolKey returns a key generated from a poolID

--- a/x/swap/types/keys_test.go
+++ b/x/swap/types/keys_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestKeys(t *testing.T) {
-	key := types.PoolKey("ukava/usdx")
-	assert.Equal(t, "ukava/usdx", string(key))
+	key := types.PoolKey(types.PoolID("ukava", "usdx"))
+	assert.Equal(t, types.PoolID("ukava", "usdx"), string(key))
 
-	key = types.DepositorPoolSharesKey(sdk.AccAddress("testaddress1"), "ukava/usdx")
-	assert.Equal(t, string(sdk.AccAddress("testaddress1"))+":ukava/usdx", string(key))
+	key = types.DepositorPoolSharesKey(sdk.AccAddress("testaddress1"), types.PoolID("ukava", "usdx"))
+	assert.Equal(t, string(sdk.AccAddress("testaddress1"))+"|"+types.PoolID("ukava", "usdx"), string(key))
 }

--- a/x/swap/types/params_test.go
+++ b/x/swap/types/params_test.go
@@ -228,8 +228,8 @@ func TestParams_String(t *testing.T) {
 	require.NoError(t, params.Validate())
 
 	output := params.String()
-	assert.Contains(t, output, "hard/ukava")
-	assert.Contains(t, output, "ukava/usdx")
+	assert.Contains(t, output, types.PoolID("hard", "ukava"))
+	assert.Contains(t, output, types.PoolID("ukava", "usdx"))
 	assert.Contains(t, output, "0.5")
 }
 
@@ -310,7 +310,7 @@ func TestAllowedPool_String(t *testing.T) {
 	require.NoError(t, allowedPool.Validate())
 
 	output := `AllowedPool:
-  Name: hard/ukava
+  Name: hard:ukava
 	Token A: hard
 	Token B: ukava
 `
@@ -324,31 +324,31 @@ func TestAllowedPool_Name(t *testing.T) {
 	}{
 		{
 			tokens: "atoken btoken",
-			name:   "atoken/btoken",
+			name:   "atoken:btoken",
 		},
 		{
 			tokens: "aaa aaaa",
-			name:   "aaa/aaaa",
+			name:   "aaa:aaaa",
 		},
 		{
 			tokens: "aaaa aaab",
-			name:   "aaaa/aaab",
+			name:   "aaaa:aaab",
 		},
 		{
 			tokens: "a001 a002",
-			name:   "a001/a002",
+			name:   "a001:a002",
 		},
 		{
 			tokens: "hard ukava",
-			name:   "hard/ukava",
+			name:   "hard:ukava",
 		},
 		{
 			tokens: "bnb hard",
-			name:   "bnb/hard",
+			name:   "bnb:hard",
 		},
 		{
 			tokens: "bnb xrpb",
-			name:   "bnb/xrpb",
+			name:   "bnb:xrpb",
 		},
 	}
 
@@ -385,7 +385,7 @@ func TestAllowedPools_Validate(t *testing.T) {
 				types.NewAllowedPool("hard", "ukava"),
 				types.NewAllowedPool("hard", "ukava"),
 			),
-			expectedErr: "duplicate pool: hard/ukava",
+			expectedErr: "duplicate pool: hard:ukava",
 		},
 		{
 			name: "duplicate pools",
@@ -395,7 +395,7 @@ func TestAllowedPools_Validate(t *testing.T) {
 				types.NewAllowedPool("btcb", "xrpb"),
 				types.NewAllowedPool("bnb", "usdx"),
 			),
-			expectedErr: "duplicate pool: bnb/usdx",
+			expectedErr: "duplicate pool: bnb:usdx",
 		},
 	}
 

--- a/x/swap/types/state.go
+++ b/x/swap/types/state.go
@@ -8,6 +8,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const PoolKeySep = "/"
+
 // PoolIDFromCoins returns a poolID from a coins object
 func PoolIDFromCoins(coins sdk.Coins) string {
 	return PoolID(coins[0].Denom, coins[1].Denom)
@@ -17,10 +19,10 @@ func PoolIDFromCoins(coins sdk.Coins) string {
 // The name is commutative for any all pairs A,B: f(A,B) == f(B,A).
 func PoolID(denomA string, denomB string) string {
 	if denomB < denomA {
-		return fmt.Sprintf("%s/%s", denomB, denomA)
+		return fmt.Sprintf("%s%s%s", denomB, PoolKeySep, denomA)
 	}
 
-	return fmt.Sprintf("%s/%s", denomA, denomB)
+	return fmt.Sprintf("%s%s%s", denomA, PoolKeySep, denomB)
 }
 
 // PoolRecord represents the state of a liquidity pool

--- a/x/swap/types/state.go
+++ b/x/swap/types/state.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-const PoolKeySep = "/"
+const PoolIDSep = ":"
 
 // PoolIDFromCoins returns a poolID from a coins object
 func PoolIDFromCoins(coins sdk.Coins) string {
@@ -19,10 +19,10 @@ func PoolIDFromCoins(coins sdk.Coins) string {
 // The name is commutative for any all pairs A,B: f(A,B) == f(B,A).
 func PoolID(denomA string, denomB string) string {
 	if denomB < denomA {
-		return fmt.Sprintf("%s%s%s", denomB, PoolKeySep, denomA)
+		return fmt.Sprintf("%s%s%s", denomB, PoolIDSep, denomA)
 	}
 
-	return fmt.Sprintf("%s%s%s", denomA, PoolKeySep, denomB)
+	return fmt.Sprintf("%s%s%s", denomA, PoolIDSep, denomB)
 }
 
 // PoolRecord represents the state of a liquidity pool
@@ -72,7 +72,7 @@ func (p PoolRecord) Validate() error {
 		return errors.New("poolID must be set")
 	}
 
-	tokens := strings.Split(p.PoolID, "/")
+	tokens := strings.Split(p.PoolID, PoolIDSep)
 	if len(tokens) != 2 || tokens[0] == "" || tokens[1] == "" || tokens[1] < tokens[0] || tokens[0] == tokens[1] {
 		return fmt.Errorf("poolID '%s' is invalid", p.PoolID)
 	}
@@ -150,7 +150,7 @@ func (sr ShareRecord) Validate() error {
 		return errors.New("poolID must be set")
 	}
 
-	tokens := strings.Split(sr.PoolID, "/")
+	tokens := strings.Split(sr.PoolID, PoolIDSep)
 	if len(tokens) != 2 || tokens[0] == "" || tokens[1] == "" || tokens[1] < tokens[0] || tokens[0] == tokens[1] {
 		return fmt.Errorf("poolID '%s' is invalid", sr.PoolID)
 	}

--- a/x/swap/types/state_test.go
+++ b/x/swap/types/state_test.go
@@ -18,14 +18,14 @@ func TestState_PoolID(t *testing.T) {
 		reserveB   string
 		expectedID string
 	}{
-		{"atoken", "btoken", "atoken/btoken"},
-		{"btoken", "atoken", "atoken/btoken"},
-		{"aaa", "aaaa", "aaa/aaaa"},
-		{"aaaa", "aaa", "aaa/aaaa"},
-		{"aaaa", "aaab", "aaaa/aaab"},
-		{"aaab", "aaaa", "aaaa/aaab"},
-		{"a001", "a002", "a001/a002"},
-		{"a002", "a001", "a001/a002"},
+		{"atoken", "btoken", "atoken:btoken"},
+		{"btoken", "atoken", "atoken:btoken"},
+		{"aaa", "aaaa", "aaa:aaaa"},
+		{"aaaa", "aaa", "aaa:aaaa"},
+		{"aaaa", "aaab", "aaaa:aaab"},
+		{"aaab", "aaaa", "aaaa:aaab"},
+		{"a001", "a002", "a001:a002"},
+		{"a002", "a001", "a001:a002"},
 	}
 
 	for _, tc := range testCases {
@@ -77,7 +77,7 @@ func TestState_NewPoolRecordFromPool(t *testing.T) {
 
 func TestState_PoolRecord_JSONEncoding(t *testing.T) {
 	raw := `{
-		"pool_id": "ukava/usdx",
+		"pool_id": "ukava:usdx",
 		"reserves_a": { "denom": "ukava", "amount": "1000000" },
 		"reserves_b": { "denom": "usdx", "amount": "5000000" },
 		"total_shares": "3000000"
@@ -87,14 +87,14 @@ func TestState_PoolRecord_JSONEncoding(t *testing.T) {
 	err := json.Unmarshal([]byte(raw), &record)
 	require.NoError(t, err)
 
-	assert.Equal(t, "ukava/usdx", record.PoolID)
+	assert.Equal(t, types.PoolID("ukava", "usdx"), record.PoolID)
 	assert.Equal(t, ukava(1e6), record.ReservesA)
 	assert.Equal(t, usdx(5e6), record.ReservesB)
 	assert.Equal(t, i(3e6), record.TotalShares)
 }
 
 func TestState_PoolRecord_YamlEncoding(t *testing.T) {
-	expected := `pool_id: ukava/usdx
+	expected := `pool_id: ukava:usdx
 reserves_a:
   denom: ukava
   amount: "1000000"
@@ -141,107 +141,107 @@ func TestState_PoolRecord_Validations(t *testing.T) {
 		},
 		{
 			name:        "poolID empty tokens",
-			poolID:      "/",
+			poolID:      ":",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID '/' is invalid",
+			expectedErr: "poolID ':' is invalid",
 		},
 		{
 			name:        "poolID empty token a",
-			poolID:      "/usdx",
+			poolID:      ":usdx",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID '/usdx' is invalid",
+			expectedErr: "poolID ':usdx' is invalid",
 		},
 		{
 			name:        "poolID empty token b",
-			poolID:      "ukava/",
+			poolID:      "ukava:",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'ukava/' is invalid",
+			expectedErr: "poolID 'ukava:' is invalid",
 		},
 		{
 			name:        "poolID is not sorted",
-			poolID:      "usdx/ukava",
+			poolID:      "usdx:ukava",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'usdx/ukava' is invalid",
+			expectedErr: "poolID 'usdx:ukava' is invalid",
 		},
 		{
 			name:        "poolID has invalid denom a",
-			poolID:      "UKAVA/usdx",
+			poolID:      "UKAVA:usdx",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'UKAVA/usdx' is invalid",
+			expectedErr: "poolID 'UKAVA:usdx' is invalid",
 		},
 		{
 			name:        "poolID has invalid denom b",
-			poolID:      "ukava/USDX",
+			poolID:      "ukava:USDX",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'ukava/USDX' is invalid",
+			expectedErr: "poolID 'ukava:USDX' is invalid",
 		},
 		{
 			name:        "poolID has duplicate denoms",
-			poolID:      "ukava/ukava",
+			poolID:      "ukava:ukava",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'ukava/ukava' is invalid",
+			expectedErr: "poolID 'ukava:ukava' is invalid",
 		},
 		{
 			name:        "poolID does not match reserve A",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   hard(5e6),
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'ukava/usdx' does not match reserves",
+			expectedErr: "poolID 'ukava:usdx' does not match reserves",
 		},
 		{
 			name:        "poolID does not match reserve B",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   hard(5e6),
 			totalShares: validRecord.TotalShares,
-			expectedErr: "poolID 'ukava/usdx' does not match reserves",
+			expectedErr: "poolID 'ukava:usdx' does not match reserves",
 		},
 		{
 			name:        "negative reserve a",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   sdk.Coin{Denom: "ukava", Amount: sdk.NewInt(-1)},
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "pool 'ukava/usdx' has invalid reserves: -1ukava",
+			expectedErr: "pool 'ukava:usdx' has invalid reserves: -1ukava",
 		},
 		{
 			name:        "zero reserve a",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   sdk.Coin{Denom: "ukava", Amount: sdk.ZeroInt()},
 			reservesB:   validRecord.ReservesB,
 			totalShares: validRecord.TotalShares,
-			expectedErr: "pool 'ukava/usdx' has invalid reserves: 0ukava",
+			expectedErr: "pool 'ukava:usdx' has invalid reserves: 0ukava",
 		},
 		{
 			name:        "negative reserve b",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   sdk.Coin{Denom: "usdx", Amount: sdk.NewInt(-1)},
 			totalShares: validRecord.TotalShares,
-			expectedErr: "pool 'ukava/usdx' has invalid reserves: -1usdx",
+			expectedErr: "pool 'ukava:usdx' has invalid reserves: -1usdx",
 		},
 		{
 			name:        "zero reserve b",
-			poolID:      "ukava/usdx",
+			poolID:      "ukava:usdx",
 			reservesA:   validRecord.ReservesA,
 			reservesB:   sdk.Coin{Denom: "usdx", Amount: sdk.ZeroInt()},
 			totalShares: validRecord.TotalShares,
-			expectedErr: "pool 'ukava/usdx' has invalid reserves: 0usdx",
+			expectedErr: "pool 'ukava:usdx' has invalid reserves: 0usdx",
 		},
 		{
 			name:        "negative total shares",
@@ -249,7 +249,7 @@ func TestState_PoolRecord_Validations(t *testing.T) {
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: sdk.NewInt(-1),
-			expectedErr: "pool 'ukava/usdx' has invalid total shares: -1",
+			expectedErr: "pool 'ukava:usdx' has invalid total shares: -1",
 		},
 		{
 			name:        "zero total shares",
@@ -257,7 +257,7 @@ func TestState_PoolRecord_Validations(t *testing.T) {
 			reservesA:   validRecord.ReservesA,
 			reservesB:   validRecord.ReservesB,
 			totalShares: sdk.ZeroInt(),
-			expectedErr: "pool 'ukava/usdx' has invalid total shares: 0",
+			expectedErr: "pool 'ukava:usdx' has invalid total shares: 0",
 		},
 	}
 
@@ -294,8 +294,8 @@ func TestState_PoolRecord_OrderedReserves(t *testing.T) {
 	record_2 := types.NewPoolRecord(sdk.NewCoins(ukava(100e6), usdx(500e6)), i(300e6))
 	// ensure no regresssions in NewCoins ordering
 	assert.Equal(t, record_1, record_2)
-	assert.Equal(t, "ukava/usdx", record_1.PoolID)
-	assert.Equal(t, "ukava/usdx", record_2.PoolID)
+	assert.Equal(t, types.PoolID("ukava", "usdx"), record_1.PoolID)
+	assert.Equal(t, types.PoolID("ukava", "usdx"), record_2.PoolID)
 }
 
 func TestState_PoolRecords_Validation(t *testing.T) {
@@ -317,7 +317,7 @@ func TestState_PoolRecords_Validation(t *testing.T) {
 	records = append(records, invalidRecord)
 	err := records.Validate()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "pool 'ukava/usdx' has invalid total shares: -1")
+	assert.EqualError(t, err, "pool 'ukava:usdx' has invalid total shares: -1")
 }
 
 func TestState_PoolRecords_ValidateUniquePools(t *testing.T) {
@@ -340,7 +340,7 @@ func TestState_PoolRecords_ValidateUniquePools(t *testing.T) {
 	assert.NoError(t, validRecords.Validate())
 
 	invalidRecords := types.PoolRecords{record_1, record_2}
-	assert.EqualError(t, invalidRecords.Validate(), "duplicate poolID 'ukava/usdx'")
+	assert.EqualError(t, invalidRecords.Validate(), "duplicate poolID 'ukava:usdx'")
 }
 
 func TestState_NewShareRecord(t *testing.T) {
@@ -358,7 +358,7 @@ func TestState_NewShareRecord(t *testing.T) {
 func TestState_ShareRecord_JSONEncoding(t *testing.T) {
 	raw := `{
 		"depositor": "kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w",
-		"pool_id": "ukava/usdx",
+		"pool_id": "ukava:usdx",
 		"shares_owned": "3000000"
 	}`
 
@@ -367,19 +367,19 @@ func TestState_ShareRecord_JSONEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w", record.Depositor.String())
-	assert.Equal(t, "ukava/usdx", record.PoolID)
+	assert.Equal(t, types.PoolID("ukava", "usdx"), record.PoolID)
 	assert.Equal(t, i(3e6), record.SharesOwned)
 }
 
 func TestState_ShareRecord_YamlEncoding(t *testing.T) {
 	expected := `depositor: kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w
-pool_id: ukava/usdx
+pool_id: ukava:usdx
 shares_owned: "3000000"
 `
 	depositor, err := sdk.AccAddressFromBech32("kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w")
 	require.NoError(t, err)
 
-	record := types.NewShareRecord(depositor, "ukava/usdx", i(3e6))
+	record := types.NewShareRecord(depositor, "ukava:usdx", i(3e6))
 	data, err := yaml.Marshal(record)
 	require.NoError(t, err)
 
@@ -436,65 +436,65 @@ func TestState_ShareRecord_Validations(t *testing.T) {
 		{
 			name:        "poolID empty tokens",
 			depositor:   validRecord.Depositor,
-			poolID:      "/",
+			poolID:      ":",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID '/' is invalid",
+			expectedErr: "poolID ':' is invalid",
 		},
 		{
 			name:        "poolID empty token a",
 			depositor:   validRecord.Depositor,
-			poolID:      "/usdx",
+			poolID:      ":usdx",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID '/usdx' is invalid",
+			expectedErr: "poolID ':usdx' is invalid",
 		},
 		{
 			name:        "poolID empty token b",
 			depositor:   validRecord.Depositor,
-			poolID:      "ukava/",
+			poolID:      "ukava:",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID 'ukava/' is invalid",
+			expectedErr: "poolID 'ukava:' is invalid",
 		},
 		{
 			name:        "poolID is not sorted",
 			depositor:   validRecord.Depositor,
-			poolID:      "usdx/ukava",
+			poolID:      "usdx:ukava",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID 'usdx/ukava' is invalid",
+			expectedErr: "poolID 'usdx:ukava' is invalid",
 		},
 		{
 			name:        "poolID has invalid denom a",
 			depositor:   validRecord.Depositor,
-			poolID:      "UKAVA/usdx",
+			poolID:      "UKAVA:usdx",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID 'UKAVA/usdx' is invalid",
+			expectedErr: "poolID 'UKAVA:usdx' is invalid",
 		},
 		{
 			name:        "poolID has invalid denom b",
 			depositor:   validRecord.Depositor,
-			poolID:      "ukava/USDX",
+			poolID:      "ukava:USDX",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID 'ukava/USDX' is invalid",
+			expectedErr: "poolID 'ukava:USDX' is invalid",
 		},
 		{
 			name:        "poolID has duplicate denoms",
 			depositor:   validRecord.Depositor,
-			poolID:      "ukava/ukava",
+			poolID:      "ukava:ukava",
 			sharesOwned: validRecord.SharesOwned,
-			expectedErr: "poolID 'ukava/ukava' is invalid",
+			expectedErr: "poolID 'ukava:ukava' is invalid",
 		},
 		{
 			name:        "negative total shares",
 			depositor:   validRecord.Depositor,
 			poolID:      validRecord.PoolID,
 			sharesOwned: sdk.NewInt(-1),
-			expectedErr: "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'ukava/usdx' has invalid total shares: -1",
+			expectedErr: "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'ukava:usdx' has invalid total shares: -1",
 		},
 		{
 			name:        "zero total shares",
 			depositor:   validRecord.Depositor,
 			poolID:      validRecord.PoolID,
 			sharesOwned: sdk.ZeroInt(),
-			expectedErr: "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'ukava/usdx' has invalid total shares: 0",
+			expectedErr: "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'ukava:usdx' has invalid total shares: 0",
 		},
 	}
 
@@ -517,13 +517,13 @@ func TestState_ShareRecords_Validation(t *testing.T) {
 
 	validRecord := types.NewShareRecord(
 		depositor,
-		"ukava/usdx",
+		types.PoolID("hard", "usdx"),
 		i(300e6),
 	)
 
 	invalidRecord := types.NewShareRecord(
 		depositor,
-		"hard/usdx",
+		types.PoolID("hard", "usdx"),
 		i(-1),
 	)
 
@@ -535,7 +535,7 @@ func TestState_ShareRecords_Validation(t *testing.T) {
 	records = append(records, invalidRecord)
 	err = records.Validate()
 	assert.Error(t, err)
-	assert.EqualError(t, err, "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'hard/usdx' has invalid total shares: -1")
+	assert.EqualError(t, err, "depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and pool 'hard:usdx' has invalid total shares: -1")
 }
 
 func TestState_ShareRecords_ValidateUniqueShareRecords(t *testing.T) {
@@ -545,14 +545,14 @@ func TestState_ShareRecords_ValidateUniqueShareRecords(t *testing.T) {
 	depositor_2, err := sdk.AccAddressFromBech32("kava1esagqd83rhqdtpy5sxhklaxgn58k2m3s3mnpea")
 	require.NoError(t, err)
 
-	record_1 := types.NewShareRecord(depositor_1, "ukava/usdx", i(20e6))
-	record_2 := types.NewShareRecord(depositor_1, "ukava/usdx", i(10e6))
-	record_3 := types.NewShareRecord(depositor_1, "hard/usdx", i(20e6))
-	record_4 := types.NewShareRecord(depositor_2, "ukava/usdx", i(20e6))
+	record_1 := types.NewShareRecord(depositor_1, "ukava:usdx", i(20e6))
+	record_2 := types.NewShareRecord(depositor_1, "ukava:usdx", i(10e6))
+	record_3 := types.NewShareRecord(depositor_1, "hard:usdx", i(20e6))
+	record_4 := types.NewShareRecord(depositor_2, "ukava:usdx", i(20e6))
 
 	validRecords := types.ShareRecords{record_1, record_3, record_4}
 	assert.NoError(t, validRecords.Validate())
 
 	invalidRecords := types.ShareRecords{record_1, record_3, record_2, record_4}
-	assert.EqualError(t, invalidRecords.Validate(), "duplicate depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and poolID 'ukava/usdx'")
+	assert.EqualError(t, invalidRecords.Validate(), "duplicate depositor 'kava1mq9qxlhze029lm0frzw2xr6hem8c3k9ts54w0w' and poolID 'ukava:usdx'")
 }


### PR DESCRIPTION
Updates the pool id separator to be `:` - `ukava:usdx`, etc.

In addition, updates the store key separator to be `|` in order to not conflict with the pool key separator.