### PR TITLE
Fix incentive usdx reward bug

### DIFF
--- a/x/incentive/keeper/hooks.go
+++ b/x/incentive/keeper/hooks.go
@@ -138,7 +138,7 @@ func (h Hooks) AfterValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, v
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 }
 
-// BeforeDelegationRemoved runs directly before a delegation is deleted
+// BeforeDelegationRemoved runs directly before a delegation is deleted. BeforeDelegationSharesModified is run prior to this.
 func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 }
 

--- a/x/incentive/keeper/integration_test.go
+++ b/x/incentive/keeper/integration_test.go
@@ -188,22 +188,20 @@ func NewStakingGenesisState() app.GenesisState {
 	}
 }
 
-func NewCommitteeGenesisState(members []sdk.AccAddress) app.GenesisState {
+func NewCommitteeGenesisState(committeeID uint64, members ...sdk.AccAddress) app.GenesisState {
 	genState := committeetypes.DefaultGenesisState()
+
 	genState.Committees = committeetypes.Committees{
-		committeetypes.MemberCommittee{
-			BaseCommittee: committeetypes.BaseCommittee{
-				ID:               genState.NextProposalID,
-				Description:      "This committee is for testing.",
-				Members:          members,
-				Permissions:      []committeetypes.Permission{committeetypes.GodPermission{}},
-				VoteThreshold:    d("0.667"),
-				ProposalDuration: time.Hour * 24 * 7,
-				TallyOption:      committeetypes.FirstPastThePost,
-			},
-		},
+		committeetypes.NewMemberCommittee(
+			committeeID,
+			"This committee is for testing.",
+			members,
+			[]committeetypes.Permission{committeetypes.GodPermission{}},
+			sdk.MustNewDecFromStr("0.666666667"),
+			time.Hour*24*7,
+			committeetypes.FirstPastThePost,
+		),
 	}
-	genState.NextProposalID += 1
 	return app.GenesisState{
 		committeetypes.ModuleName: committeetypes.ModuleCdc.MustMarshalJSON(genState),
 	}

--- a/x/incentive/keeper/rewards_borrow_test.go
+++ b/x/incentive/keeper/rewards_borrow_test.go
@@ -129,7 +129,7 @@ func (suite *BorrowRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]),
+		NewCommitteeGenesisState(1, suite.addrs[:2]...),
 		incentBuilder.BuildMarshalled(),
 	)
 }

--- a/x/incentive/keeper/rewards_supply_test.go
+++ b/x/incentive/keeper/rewards_supply_test.go
@@ -130,7 +130,7 @@ func (suite *SupplyRewardsTestSuite) SetupWithGenState(authBuilder app.AuthGenes
 		authBuilder.BuildMarshalled(),
 		NewPricefeedGenStateMultiFromTime(suite.genesisTime),
 		hardBuilder.BuildMarshalled(),
-		NewCommitteeGenesisState(suite.addrs[:2]),
+		NewCommitteeGenesisState(1, suite.addrs[:2]...),
 		incentBuilder.BuildMarshalled(),
 	)
 }

--- a/x/incentive/keeper/rewards_usdx.go
+++ b/x/incentive/keeper/rewards_usdx.go
@@ -59,15 +59,11 @@ func (k Keeper) getUSDXTotalSourceShares(ctx sdk.Context, collateralType string)
 // accrue rewards during the period the cdp was closed. By setting the reward factor to the current global reward factor,
 // any unclaimed rewards are preserved, but no new rewards are added.
 func (k Keeper) InitializeUSDXMintingClaim(ctx sdk.Context, cdp cdptypes.CDP) {
-	_, found := k.GetUSDXMintingRewardPeriod(ctx, cdp.Type)
-	if !found {
-		// this collateral type is not incentivized, do nothing
-		return
-	}
 	claim, found := k.GetUSDXMintingClaim(ctx, cdp.Owner)
 	if !found { // this is the owner's first usdx minting reward claim
 		claim = types.NewUSDXMintingClaim(cdp.Owner, sdk.NewCoin(types.USDXMintingRewardDenom, sdk.ZeroInt()), types.RewardIndexes{})
 	}
+
 	globalRewardFactor, found := k.GetUSDXMintingRewardFactor(ctx, cdp.Type)
 	if !found {
 		globalRewardFactor = sdk.ZeroDec()
@@ -83,11 +79,7 @@ func (k Keeper) SynchronizeUSDXMintingReward(ctx sdk.Context, cdp cdptypes.CDP) 
 
 	claim, found := k.GetUSDXMintingClaim(ctx, cdp.Owner)
 	if !found {
-		claim = types.NewUSDXMintingClaim(
-			cdp.Owner,
-			sdk.NewCoin(types.USDXMintingRewardDenom, sdk.ZeroInt()),
-			types.RewardIndexes{},
-		)
+		return
 	}
 
 	sourceShares, err := cdp.GetNormalizedPrincipal()


### PR DESCRIPTION
This PR fixes a bug in incentive.
When usdx rewards are removed from params, then reinstated later. CDPs owners could be given too much rewards.

Bug:
Previously, If a cdp was created when there are no params, a claim was not created.
Then if params were added, and the cdp synced, a claim would be created with indexes set to 0.

This is fine when the params never existed, as when they're added the indexes will start at 0, which matches the new claims.
However if the params previously existed, then the global indexes will not be zero. So the new claims will incorrectly accrue rewards as if the cdps were created at the start of the chain.

Changes:
- Make USDX rewards work more like the other reward types. Remove params form `Init`, remove claim creation from `Sync`.
- Add integration test to cover bug