### PR TITLE
Fix bug in syncing swap rewards

### DIFF
--- a/x/incentive/keeper/rewards_delegator.go
+++ b/x/incentive/keeper/rewards_delegator.go
@@ -154,13 +154,6 @@ func (k Keeper) GetTotalDelegated(ctx sdk.Context, delegator sdk.AccAddress, val
 	return totalDelegated
 }
 
-// ZeroDelegatorClaim zeroes out the claim object's rewards and returns the updated claim object
-func (k Keeper) ZeroDelegatorClaim(ctx sdk.Context, claim types.DelegatorClaim) types.DelegatorClaim {
-	claim.Reward = sdk.NewCoins()
-	k.SetDelegatorClaim(ctx, claim)
-	return claim
-}
-
 // SimulateDelegatorSynchronization calculates a user's outstanding delegator rewards by simulating reward synchronization
 func (k Keeper) SimulateDelegatorSynchronization(ctx sdk.Context, claim types.DelegatorClaim) types.DelegatorClaim {
 	for _, ri := range claim.RewardIndexes {


### PR DESCRIPTION
This is a resubmission of #973 having rebased the changes

The GetSynchronizedSwapClaim method had a bug where it would not sync rewards for recently rewarded pools.

For example. Given a user with a hard:usdx swap deposit, and that pool receiving no rewards. If rewards were added (via gov) and the user claimed their swap reward, they would miss out on rewards for their hard:usdx deposit.
Though if they ever modified their deposit it would sync correctly.

I also reviewed hard and delegator for the same behaviour.