### PR TITLE
Fix Account Migration for Additive Vesting Periods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
             export GO111MODULE=on
             mkdir -p /tmp/logs /tmp/workspace/profiles
-            for pkg in $(go list ./... | grep -v 'simulation\|migrate\|contrib' | circleci tests split); do
+            for pkg in $(go list ./... | grep -v -P 'simulation|migrate(?!\/v0_15)|contrib' | circleci tests split); do
               id=$(echo "$pkg" | sed 's|[/.]|_|g')
               go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done

--- a/migrate/v0_15/account.go
+++ b/migrate/v0_15/account.go
@@ -35,12 +35,16 @@ func ResetPeriodicVestingAccount(vacc *vesting.PeriodicVestingAccount, startTime
 	newPeriods := vesting.Periods{}
 
 	for _, period := range vacc.VestingPeriods {
-		currentPeriod := currentPeriod + period.Length
+		currentPeriod = currentPeriod + period.Length
 
-		// Periods less than or equal to the newStartTime are still vesting,
-		// so adjust their length and add them to them to the newPeriods
-		if newStartTime <= currentPeriod {
-			period.Length = currentPeriod - newStartTime
+		// Periods less than the newStartTime are still vesting,
+		// so adjust their length and add them to the newPeriods
+		if newStartTime < currentPeriod {
+			// adjust the length of the first vesting period
+			// to be relative to the new start time
+			if len(newPeriods) == 0 {
+				period.Length = currentPeriod - newStartTime
+			}
 
 			newEndTime = newEndTime + period.Length
 			newOriginalVesting = newOriginalVesting.Add(period.Amount...)

--- a/migrate/v0_15/account_test.go
+++ b/migrate/v0_15/account_test.go
@@ -1,7 +1,6 @@
 package v0_15
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -229,8 +228,6 @@ func TestResetPeriodVestingAccount_MultiplePeriods(t *testing.T) {
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 	}
-
-	fmt.Printf("%s\n", spendableBefore.String())
 
 	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(2e6))), vacc.OriginalVesting, "expected original vesting to be updated")
 	assert.Equal(t, newVestingStartTime.Unix(), vacc.StartTime, "expected vesting start time to be updated")

--- a/migrate/v0_15/account_test.go
+++ b/migrate/v0_15/account_test.go
@@ -1,6 +1,7 @@
 package v0_15
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func TestMigrateAccount_PeriodicVestingAccount_Vesting(t *testing.T) {
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 45 * 24 * 60 * 60, // +15 days - vesting
+			Length: 30 * 24 * 60 * 60, // +15 days - vesting
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(2e6))),
 		},
 	}
@@ -186,7 +187,7 @@ func TestResetPeriodVestingAccount_SingleVestingPeriod_ExactStartTime(t *testing
 }
 
 func TestResetPeriodVestingAccount_MultiplePeriods(t *testing.T) {
-	balance := sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(3e6)))
+	balance := sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(4e6)))
 	vestingStartTime := time.Now().Add(-30 * 24 * time.Hour) // 30 days in past
 
 	periods := vesting.Periods{
@@ -195,11 +196,15 @@ func TestResetPeriodVestingAccount_MultiplePeriods(t *testing.T) {
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 30 * 24 * 60 * 60, // 0 days - exact on the start time
+			Length: 15 * 24 * 60 * 60, // 0 days - exact on the start time
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 45 * 24 * 60 * 60, // +15 days - vesting
+			Length: 15 * 24 * 60 * 60, // +15 days - vesting
+			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
+		},
+		vesting.Period{
+			Length: 15 * 24 * 60 * 60, // +30 days - vesting
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 	}
@@ -212,11 +217,11 @@ func TestResetPeriodVestingAccount_MultiplePeriods(t *testing.T) {
 	ResetPeriodicVestingAccount(vacc, newVestingStartTime)
 
 	// new period length 15 days
-	expectedEndtime := newVestingStartTime.Add(15 * 24 * time.Hour).Unix()
+	expectedEndtime := newVestingStartTime.Add(30 * 24 * time.Hour).Unix()
 	// new period length changed, amount unchanged
 	expectedPeriods := vesting.Periods{
 		vesting.Period{
-			Length: 0, // 0 days
+			Length: 15 * 24 * 60 * 60, // 15 days
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
@@ -224,6 +229,8 @@ func TestResetPeriodVestingAccount_MultiplePeriods(t *testing.T) {
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 	}
+
+	fmt.Printf("%s\n", spendableBefore.String())
 
 	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(2e6))), vacc.OriginalVesting, "expected original vesting to be updated")
 	assert.Equal(t, newVestingStartTime.Unix(), vacc.StartTime, "expected vesting start time to be updated")
@@ -242,11 +249,11 @@ func TestResetPeriodVestingAccount_DelegatedVesting_GreaterThanVesting(t *testin
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 30 * 24 * 60 * 60, // 0 days - exact on the start time
+			Length: 15 * 24 * 60 * 60, // 0 days - exact on the start time
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 45 * 24 * 60 * 60, // +15 days - vesting
+			Length: 15 * 24 * 60 * 60, // +15 days - vesting
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 	}
@@ -257,8 +264,8 @@ func TestResetPeriodVestingAccount_DelegatedVesting_GreaterThanVesting(t *testin
 	newVestingStartTime := vestingStartTime.Add(30 * 24 * time.Hour)
 	ResetPeriodicVestingAccount(vacc, newVestingStartTime)
 
-	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))), vacc.DelegatedFree, "expected delegated free to be updated")
-	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(2e6))), vacc.DelegatedVesting, "expected delegated vesting to be updated")
+	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(2e6))), vacc.DelegatedFree, "expected delegated free to be updated")
+	assert.Equal(t, sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))), vacc.DelegatedVesting, "expected delegated vesting to be updated")
 }
 
 func TestResetPeriodVestingAccount_DelegatedVesting_LessThanVested(t *testing.T) {
@@ -271,11 +278,11 @@ func TestResetPeriodVestingAccount_DelegatedVesting_LessThanVested(t *testing.T)
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 30 * 24 * 60 * 60, // 0 days - exact on the start time
+			Length: 15 * 24 * 60 * 60, // 0 days - exact on the start time
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 		vesting.Period{
-			Length: 45 * 24 * 60 * 60, // +15 days - vesting
+			Length: 15 * 24 * 60 * 60, // +15 days - vesting
 			Amount: sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1e6))),
 		},
 	}

--- a/migrate/v0_15/migrate_test.go
+++ b/migrate/v0_15/migrate_test.go
@@ -173,6 +173,9 @@ func TestAuth_AccountConversion(t *testing.T) {
 		// check 365 days
 		futureDate = GenesisTime.Add(365 * 24 * time.Hour)
 		require.Equal(t, oldAcc.SpendableCoins(futureDate), acc.SpendableCoins(futureDate), "expected spendable coins to not change")
+		// check 2 years
+		futureDate = GenesisTime.Add(2 * 365 * 24 * time.Hour)
+		require.Equal(t, oldAcc.SpendableCoins(futureDate), acc.SpendableCoins(futureDate), "expected spendable coins to not change")
 
 		if vacc, ok := acc.(*vesting.PeriodicVestingAccount); ok {
 			// old account must be a periodic vesting account
@@ -195,6 +198,9 @@ func TestAuth_AccountConversion(t *testing.T) {
 
 			// new account as less than or equal
 			require.LessOrEqual(t, len(vacc.VestingPeriods), len(oldVacc.VestingPeriods), "expected vesting periods of new account to be less than or equal to old")
+
+			// end time should not change
+			require.Equal(t, oldVacc.EndTime, vacc.EndTime, "expected end time to not change")
 		}
 	}
 }

--- a/migrate/v0_15/migrate_test.go
+++ b/migrate/v0_15/migrate_test.go
@@ -140,9 +140,13 @@ func TestAuth_AccountConversion(t *testing.T) {
 	bz, err := ioutil.ReadFile(filepath.Join("testdata", "kava-7-test-auth-state.json"))
 	require.NoError(t, err)
 
-	var genesisState auth.GenesisState
 	cdc := app.MakeCodec()
+
+	var genesisState auth.GenesisState
 	cdc.MustUnmarshalJSON(bz, &genesisState)
+
+	var originalGenesisState auth.GenesisState
+	cdc.MustUnmarshalJSON(bz, &originalGenesisState)
 
 	migratedGenesisState := Auth(genesisState, GenesisTime)
 	require.Equal(t, len(genesisState.Accounts), len(migratedGenesisState.Accounts), "expected the number of accounts after migration to be equal")
@@ -150,7 +154,7 @@ func TestAuth_AccountConversion(t *testing.T) {
 	require.NoError(t, err, "expected migrated genesis to be valid")
 
 	for i, acc := range migratedGenesisState.Accounts {
-		oldAcc := genesisState.Accounts[i]
+		oldAcc := originalGenesisState.Accounts[i]
 
 		// total owned coins does not change
 		require.Equal(t, oldAcc.GetCoins(), acc.GetCoins(), "expected base coins to not change")


### PR DESCRIPTION
Fixes the periodic vesting account migration to properly compare old accounts with new accounts in the acceptance test, and updates the reset logic to treat period lengths as additive to correct failing acceptance.

Also, adds support for running v0_15 migration tests in CI.  Requires #994 for tests to pass.