### PR TITLE
Add supply migration for kava-8

### DIFF
--- a/migrate/v0_15/migrate.go
+++ b/migrate/v0_15/migrate.go
@@ -31,6 +31,7 @@ var (
 	GenesisTime                  = time.Date(2021, 8, 30, 15, 0, 0, 0, time.UTC)
 	ChainID                      = "kava-8"
 	SwpDelegatorRewardsPerSecond = sdk.NewCoin("swp", sdk.NewInt(198186))
+	SwpTotalSupply               = sdk.NewCoin("swp", sdk.NewInt(250000000e6))
 )
 
 // Migrate translates a genesis file from kava v0.14 format to kava v0.15 format
@@ -79,7 +80,7 @@ func MigrateAppState(v0_14AppState genutil.AppMap) {
 		var supplyGenState supply.GenesisState
 		v0_14Codec.MustUnmarshalJSON(v0_14AppState[supply.ModuleName], &supplyGenState)
 		delete(v0_14AppState, supply.ModuleName)
-		v0_14AppState[supply.ModuleName] = v0_15Codec.MustMarshalJSON(Supply(supplyGenState, sdk.NewCoin("swp", sdk.NewInt(250000000e6))))
+		v0_14AppState[supply.ModuleName] = v0_15Codec.MustMarshalJSON(Supply(supplyGenState, SwpTotalSupply))
 	}
 
 	// Migrate incentive app state
@@ -266,9 +267,7 @@ func DistributeSwpTokens(genesisState auth.GenesisState) auth.GenesisState {
 	return auth.NewGenesisState(genesisState.Params, accounts)
 }
 
-// MigrateSupply reconciles supply from kava-3 to kava-4
-// deputy balance of bnb coins is removed (deputy now mints coins)
-// hard token supply is added
+// Supply adds SWP token to total supply
 func Supply(supplyGenesisState supply.GenesisState, swpBalance sdk.Coin) supply.GenesisState {
 	supplyGenesisState.Supply = supplyGenesisState.Supply.Add(swpBalance)
 	return supplyGenesisState

--- a/migrate/v0_15/migrate.go
+++ b/migrate/v0_15/migrate.go
@@ -74,6 +74,14 @@ func MigrateAppState(v0_14AppState genutil.AppMap) {
 		v0_14AppState[auth.ModuleName] = v0_15Codec.MustMarshalJSON(Auth(v0_15Codec, authGenState, GenesisTime))
 	}
 
+	// Migrate supply app state
+	if v0_14AppState[supply.ModuleName] != nil {
+		var supplyGenState supply.GenesisState
+		v0_14Codec.MustUnmarshalJSON(v0_14AppState[supply.ModuleName], &supplyGenState)
+		delete(v0_14AppState, supply.ModuleName)
+		v0_14AppState[supply.ModuleName] = v0_15Codec.MustMarshalJSON(Supply(supplyGenState, sdk.NewCoin("swp", sdk.NewInt(250000000e6))))
+	}
+
 	// Migrate incentive app state
 	if v0_14AppState[v0_14incentive.ModuleName] != nil {
 		var incentiveGenState v0_14incentive.GenesisState
@@ -256,6 +264,14 @@ func DistributeSwpTokens(genesisState auth.GenesisState) auth.GenesisState {
 	accounts = append(accounts, &swpEcosystemBacc, swpTeamVestingAccount, swpTreasuryVestingAccount)
 
 	return auth.NewGenesisState(genesisState.Params, accounts)
+}
+
+// MigrateSupply reconciles supply from kava-3 to kava-4
+// deputy balance of bnb coins is removed (deputy now mints coins)
+// hard token supply is added
+func Supply(supplyGenesisState supply.GenesisState, swpBalance sdk.Coin) supply.GenesisState {
+	supplyGenesisState.Supply = supplyGenesisState.Supply.Add(swpBalance)
+	return supplyGenesisState
 }
 
 // Committee migrates from a v0.14 committee genesis state to a v0.15 committee genesis state

--- a/migrate/v0_15/migrate_test.go
+++ b/migrate/v0_15/migrate_test.go
@@ -55,7 +55,7 @@ func TestMigrateFull(t *testing.T) {
 	}
 	require.NotPanics(t, func() {
 		// this runs both InitGenesis for all modules (which panic on errors) and runs all invariants
-		tApp.InitializeFromGenesisStatesWithTime(newGenDoc.GenesisTime, app.GenesisState(newAppState))
+		tApp.InitializeFromGenesisStatesWithTimeAndChainID(newGenDoc.GenesisTime, newGenDoc.ChainID, app.GenesisState(newAppState))
 	})
 }
 


### PR DESCRIPTION
Adds SWP token to `supply.GenesisState` so that `supply` module invariants pass