### PR TITLE
removed duplicate line and added correct endpoint description in swagger

### DIFF
--- a/swagger-ui/swagger.yaml
+++ b/swagger-ui/swagger.yaml
@@ -2125,7 +2125,7 @@ paths:
           description: Server internal error
   /hard/interest-rate:
     get:
-      summary: Get total hard reserve coins
+      summary: Get the hard module interest rates
       tags:
         - Hard
       produces:


### PR DESCRIPTION
Removed the duplication of [Line 2098](https://github.com/Kava-Labs/kava/blob/7a00dcd06cda92a9d1528b752e31370206874135/swagger-ui/swagger.yaml#L2098) and added correct description for the `/hard/interest-rate` endpoint.