### PR TITLE
Add circulating supply endpoint for SWP

### DIFF
--- a/x/validator-vesting/client/cli/query.go
+++ b/x/validator-vesting/client/cli/query.go
@@ -24,6 +24,7 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		queryTotalSupply(queryRoute, cdc),
 		queryCirculatingSupplyHARD(queryRoute, cdc),
 		queryCirculatingSupplyUSDX(queryRoute, cdc),
+		queryCirculatingSupplySWP(queryRoute, cdc),
 		queryTotalSupplyHARD(queryRoute, cdc),
 		queryTotalSupplyUSDX(queryRoute, cdc),
 	)...)
@@ -121,6 +122,32 @@ func queryCirculatingSupplyUSDX(queryRoute string, cdc *codec.Codec) *cobra.Comm
 
 			// Query
 			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryCirculatingSupplyUSDX), nil)
+			if err != nil {
+				return err
+			}
+			cliCtx = cliCtx.WithHeight(height)
+
+			// Decode and print results
+			var out int64
+			if err := cdc.UnmarshalJSON(res, &out); err != nil {
+				return fmt.Errorf("failed to unmarshal supply: %w", err)
+			}
+			return cliCtx.PrintOutput(out)
+		},
+	}
+}
+
+func queryCirculatingSupplySWP(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "circulating-supply-swp",
+		Short: "Get SWP circulating supply",
+		Long:  "Get the current circulating supply of SWP tokens",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			// Query
+			res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryCirculatingSupplySWP), nil)
 			if err != nil {
 				return err
 			}

--- a/x/validator-vesting/keeper/querier.go
+++ b/x/validator-vesting/keeper/querier.go
@@ -309,7 +309,7 @@ func getCirculatingSupplySWP(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 	}
 
 	// Repeated tokens released
-	teamSwp := int64(5_859_375)
+	teamSwp := int64(4_687_500)
 	treasurySwp := int64(5_859_375)
 	monthlyStakersSwp := int64(520_833)
 	monthlyLPIncentivesSwp := int64(2_343_750)

--- a/x/validator-vesting/keeper/querier.go
+++ b/x/validator-vesting/keeper/querier.go
@@ -25,6 +25,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return getCirculatingSupplyHARD(ctx, req, keeper)
 		case types.QueryCirculatingSupplyUSDX:
 			return getCirculatingSupplyUSDX(ctx, req, keeper)
+		case types.QueryCirculatingSupplySWP:
+			return getCirculatingSupplySWP(ctx, req, keeper)
 		case types.QueryTotalSupplyHARD:
 			return getTotalSupplyHARD(ctx, req, keeper)
 		case types.QueryTotalSupplyUSDX:
@@ -273,6 +275,97 @@ func getCirculatingSupplyUSDX(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	totalSupply := keeper.supplyKeeper.GetSupply(ctx).GetTotal().AmountOf("usdx")
 	supplyInt := sdk.NewDecFromInt(totalSupply).Mul(sdk.MustNewDecFromStr("0.000001")).TruncateInt64()
 	bz, err := types.ModuleCdc.MarshalJSON(supplyInt)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+	}
+	return bz, nil
+}
+
+func getCirculatingSupplySWP(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	// Start values
+	year := 2021
+	month := 8
+
+	var supplyIncreaseDates []time.Time
+
+	// Add month times for 4 years
+	for i := 0; i < 12*4; i++ {
+		// Always day 30 unless it's Feb
+		day := 30
+		if month == 2 {
+			day = 28
+		}
+
+		date := time.Date(year, time.Month(month), day, 15 /* hour */, 0, 0, 0, time.UTC)
+		supplyIncreaseDates = append(supplyIncreaseDates, date)
+
+		// Update year and month
+		if month == 12 {
+			month = 1
+			year += 1
+		} else {
+			month += 1
+		}
+	}
+
+	// Repeated tokens released
+	teamSwp := int64(5_859_375)
+	treasurySwp := int64(5_859_375)
+	monthlyStakersSwp := int64(520_833)
+	monthlyLPIncentivesSwp := int64(2_343_750)
+
+	// []{Ecosystem, Team, Treasury, Kava Stakers, LP Incentives}
+	scheduleAmounts := [][]int64{
+		{12_500_000, 0, 15_625_000, monthlyStakersSwp, monthlyLPIncentivesSwp},  // *** Year ONE ***
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 1
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 2
+		{0, 0, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},          // 3
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 4
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 5
+		{0, 0, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},          // 6
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 7
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 8
+		{0, 0, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},          // 9
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 10
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 11
+		{0, 18_750_000, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp}, // *** Year TWO ***
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 13
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 14
+		{0, teamSwp, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},    // 15
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 16
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 17
+		{0, teamSwp, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},    // 18
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 19
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 20
+		{0, teamSwp, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},    // 21
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 22
+		{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp},                    // 23
+		{0, teamSwp, treasurySwp, monthlyStakersSwp, monthlyLPIncentivesSwp},    // *** Year THREE ***
+	}
+
+	// Months 25-47 are the same
+	for i := 0; i < 23; i++ {
+		scheduleAmounts = append(scheduleAmounts, []int64{0, 0, 0, monthlyStakersSwp, monthlyLPIncentivesSwp})
+	}
+
+	circSupply := sdk.ZeroInt()
+	blockTime := ctx.BlockTime()
+
+	for i := 0; i < len(scheduleAmounts); i++ {
+		if blockTime.Before(supplyIncreaseDates[i]) {
+			break
+		}
+
+		// Sum up each category of token release
+		monthTotal := int64(0)
+		for _, val := range scheduleAmounts[i] {
+			monthTotal += val
+		}
+
+		circSupply = circSupply.Add(sdk.NewInt(monthTotal))
+	}
+
+	bz, err := keeper.cdc.MarshalJSON(circSupply)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}

--- a/x/validator-vesting/types/querier.go
+++ b/x/validator-vesting/types/querier.go
@@ -6,6 +6,7 @@ const (
 	QueryTotalSupply           = "total-supply"
 	QueryCirculatingSupplyHARD = "circulating-supply-hard"
 	QueryCirculatingSupplyUSDX = "circulating-supply-usdx"
+	QueryCirculatingSupplySWP  = "circulating-supply-swp"
 	QueryTotalSupplyHARD       = "total-supply-hard"
 	QueryTotalSupplyUSDX       = "total-supply-usdx"
 )


### PR DESCRIPTION
#### Description

Adds circulating supply endpoint for SWP, for cli and rest. This generates the list of supply increase dates instead of hardcoding the entire list.

#### Tested

Various intervals were tested at different years by shifting the start year back and matched the correct sum according to the release schedule.

Generated values have also been output to double check they are correct, as seen below.

<details><summary>time.Times</summary>

```go
// Day 28 on Feburary
// len 48
2021-08-30 15:00:00 +0000 utc
2021-09-30 15:00:00 +0000 utc
2021-10-30 15:00:00 +0000 utc
2021-11-30 15:00:00 +0000 utc
2021-12-30 15:00:00 +0000 utc
2022-01-30 15:00:00 +0000 utc
2022-02-28 15:00:00 +0000 utc
2022-03-30 15:00:00 +0000 utc
2022-04-30 15:00:00 +0000 utc
2022-05-30 15:00:00 +0000 utc
2022-06-30 15:00:00 +0000 utc
2022-07-30 15:00:00 +0000 utc
2022-08-30 15:00:00 +0000 utc
2022-09-30 15:00:00 +0000 utc
2022-10-30 15:00:00 +0000 utc
2022-11-30 15:00:00 +0000 utc
2022-12-30 15:00:00 +0000 utc
2023-01-30 15:00:00 +0000 utc
2023-02-28 15:00:00 +0000 utc
2023-03-30 15:00:00 +0000 utc
2023-04-30 15:00:00 +0000 utc
2023-05-30 15:00:00 +0000 utc
2023-06-30 15:00:00 +0000 utc
2023-07-30 15:00:00 +0000 utc
2023-08-30 15:00:00 +0000 utc
2023-09-30 15:00:00 +0000 utc
2023-10-30 15:00:00 +0000 utc
2023-11-30 15:00:00 +0000 utc
2023-12-30 15:00:00 +0000 utc
2024-01-30 15:00:00 +0000 utc
2024-02-28 15:00:00 +0000 utc
2024-03-30 15:00:00 +0000 utc
2024-04-30 15:00:00 +0000 utc
2024-05-30 15:00:00 +0000 utc
2024-06-30 15:00:00 +0000 utc
2024-07-30 15:00:00 +0000 utc
2024-08-30 15:00:00 +0000 utc
2024-09-30 15:00:00 +0000 utc
2024-10-30 15:00:00 +0000 utc
2024-11-30 15:00:00 +0000 utc
2024-12-30 15:00:00 +0000 utc
2025-01-30 15:00:00 +0000 utc
2025-02-28 15:00:00 +0000 utc
2025-03-30 15:00:00 +0000 utc
2025-04-30 15:00:00 +0000 utc
2025-05-30 15:00:00 +0000 utc
2025-06-30 15:00:00 +0000 utc
2025-07-30 15:00:00 +0000 utc
```

</details>

<details><summary>schedule amounts</summary>

```go
// []{Ecosystem, Team, Treasury, Kava Stakers, LP Incentives}
// len 48
[[12500000 0 15625000 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 18750000 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 5859375 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 5859375 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 5859375 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 5859375 5859375 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
 [0 0 0 520833 2343750]
]
```

</details>