### PR TITLE
Add No Vote Information to Polling Status for Committee Proposals

### DIFF
--- a/x/committee/keeper/proposal.go
+++ b/x/committee/keeper/proposal.go
@@ -258,12 +258,12 @@ func (k Keeper) CloseProposal(ctx sdk.Context, proposal types.Proposal, outcome 
 		case types.MemberCommittee:
 			currVotes := k.TallyMemberCommitteeVotes(ctx, proposal.ID)
 			possibleVotes := sdk.NewDec(int64(len(com.Members)))
-			memberPollingStatus := types.NewProposalPollingStatus(proposal.ID, currVotes,
+			memberPollingStatus := types.NewProposalPollingStatus(proposal.ID, currVotes, sdk.ZeroDec(),
 				currVotes, possibleVotes, com.VoteThreshold, sdk.Dec{Int: nil})
 			proposalTally = memberPollingStatus
 		case types.TokenCommittee:
-			yesVotes, _, currVotes, possibleVotes := k.TallyTokenCommitteeVotes(ctx, proposal.ID, com.TallyDenom)
-			tokenPollingStatus := types.NewProposalPollingStatus(proposal.ID, yesVotes,
+			yesVotes, noVotes, currVotes, possibleVotes := k.TallyTokenCommitteeVotes(ctx, proposal.ID, com.TallyDenom)
+			tokenPollingStatus := types.NewProposalPollingStatus(proposal.ID, yesVotes, noVotes,
 				currVotes, possibleVotes, com.VoteThreshold, com.Quorum)
 			proposalTally = tokenPollingStatus
 		}

--- a/x/committee/keeper/querier.go
+++ b/x/committee/keeper/querier.go
@@ -188,12 +188,12 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	case types.MemberCommittee:
 		currVotes := keeper.TallyMemberCommitteeVotes(ctx, params.ProposalID)
 		possibleVotes := sdk.NewDec(int64(len(com.Members)))
-		memberPollingStatus := types.NewProposalPollingStatus(params.ProposalID, currVotes,
+		memberPollingStatus := types.NewProposalPollingStatus(params.ProposalID, currVotes, sdk.ZeroDec(),
 			currVotes, possibleVotes, com.VoteThreshold, sdk.Dec{Int: nil})
 		pollingStatus = memberPollingStatus
 	case types.TokenCommittee:
-		yesVotes, _, currVotes, possibleVotes := keeper.TallyTokenCommitteeVotes(ctx, params.ProposalID, com.TallyDenom)
-		tokenPollingStatus := types.NewProposalPollingStatus(params.ProposalID, yesVotes,
+		yesVotes, noVotes, currVotes, possibleVotes := keeper.TallyTokenCommitteeVotes(ctx, params.ProposalID, com.TallyDenom)
+		tokenPollingStatus := types.NewProposalPollingStatus(params.ProposalID, yesVotes, noVotes,
 			currVotes, possibleVotes, com.VoteThreshold, com.Quorum)
 		pollingStatus = tokenPollingStatus
 	}

--- a/x/committee/types/querier.go
+++ b/x/committee/types/querier.go
@@ -66,17 +66,19 @@ func NewQueryRawParamsParams(subspace, key string) QueryRawParamsParams {
 type ProposalPollingStatus struct {
 	ProposalID    uint64  `json:"proposal_id" yaml:"proposal_id"`
 	YesVotes      sdk.Dec `json:"yes_votes" yaml:"yes_votes"`
+	NoVotes       sdk.Dec `json:"no_votes" yaml:"no_votes"`
 	CurrentVotes  sdk.Dec `json:"current_votes" yaml:"current_votes"`
 	PossibleVotes sdk.Dec `json:"possible_votes" yaml:"possible_votes"`
 	VoteThreshold sdk.Dec `json:"vote_threshold" yaml:"vote_threshold"`
 	Quorum        sdk.Dec `json:"quorum" yaml:"quorum"`
 }
 
-func NewProposalPollingStatus(proposalID uint64, yesVotes, currentVotes, possibleVotes,
+func NewProposalPollingStatus(proposalID uint64, yesVotes, noVotes, currentVotes, possibleVotes,
 	voteThreshold, quorum sdk.Dec) ProposalPollingStatus {
 	return ProposalPollingStatus{
 		ProposalID:    proposalID,
 		YesVotes:      yesVotes,
+		NoVotes:       noVotes,
 		CurrentVotes:  currentVotes,
 		PossibleVotes: possibleVotes,
 		VoteThreshold: voteThreshold,
@@ -88,11 +90,12 @@ func NewProposalPollingStatus(proposalID uint64, yesVotes, currentVotes, possibl
 func (p ProposalPollingStatus) String() string {
 	return fmt.Sprintf(`Proposal ID: %d
 	Yes votes:         %d
+	No votes:          %d
 	Current votes:     %d
   	Possible votes:    %d
   	Vote threshold:    %d
 	Quorum:        	   %d`,
-		p.ProposalID, p.YesVotes, p.CurrentVotes,
+		p.ProposalID, p.YesVotes, p.NoVotes, p.CurrentVotes,
 		p.PossibleVotes, p.VoteThreshold, p.Quorum,
 	)
 }


### PR DESCRIPTION
This updates the cli and rest responses to include no votes for the current tally.

This allows clients to differentiate between no and abstain votes, and show progress towards the vote threshold.

Note: This solution also updates the event when a proposal is closed - is this OK?  Alternatively, we can separate the event interface from the querier interface and leave the event unchanged.