### PR TITLE
Use multi stage Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,9 @@ COPY . .
 #ENV LEDGER_ENABLED False
 RUN make install
 
+FROM alpine:3.15
+
+RUN apk add bash jq curl
+COPY --from=build-env /go/bin/kava /bin/kava
+
 CMD ["kava"]


### PR DESCRIPTION
Reduces Docker image size from `2.5GB` to `73.5MB`.

`/go/pkg/mod` alone was taking up 1.2GB which is only needed for the build step.