### PR TITLE
Fix committee proposal query

### DIFF
--- a/x/committee/client/common/query.go
+++ b/x/committee/client/common/query.go
@@ -73,10 +73,10 @@ func QueryProposalByID(cliCtx client.Context, cdc *codec.LegacyAmino, queryRoute
 	res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", queryRoute, types.QueryProposal), bz)
 
 	if err == nil {
-		var proposal *types.Proposal
+		var proposal types.Proposal
 		cdc.MustUnmarshalJSON(res, &proposal)
 
-		return proposal, height, nil
+		return &proposal, height, nil
 	}
 
 	// NOTE: !errors.Is(err, types.ErrUnknownProposal) does not work here

--- a/x/committee/types/codec.go
+++ b/x/committee/types/codec.go
@@ -10,6 +10,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	proposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 )
 
 var (
@@ -103,6 +104,7 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 		&Proposal{},
 		&distrtypes.CommunityPoolSpendProposal{},
 		&govtypes.TextProposal{},
+		&kavadisttypes.CommunityPoolMultiSpendProposal{},
 		&proposaltypes.ParameterChangeProposal{},
 		&upgradetypes.SoftwareUpgradeProposal{},
 		&upgradetypes.CancelSoftwareUpgradeProposal{},


### PR DESCRIPTION
This fixes the issue where proposal content was not properly unmarshalled in the legacy proposal query.
Also registers the `CommunityPoolMultiSpendProposal` from kavadist as we were missing it.