### PR TITLE
Fix legacy amino msg encoding for committee

### DIFF
--- a/x/committee/types/codec.go
+++ b/x/committee/types/codec.go
@@ -60,8 +60,8 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(ParamsChangePermission{}, "kava/ParamsChangePermission", nil)
 
 	// Msgs
-	cdc.RegisterConcrete(MsgSubmitProposal{}, "kava/MsgSubmitProposal", nil)
-	cdc.RegisterConcrete(MsgVote{}, "kava/MsgVote", nil)
+	cdc.RegisterConcrete(&MsgSubmitProposal{}, "kava/MsgSubmitProposal", nil)
+	cdc.RegisterConcrete(&MsgVote{}, "kava/MsgVote", nil)
 }
 
 // RegisterProposalTypeCodec allows external modules to register their own pubproposal types on the


### PR DESCRIPTION
The LegacyAmino codec now requires messages to be registered as references.