### PR TITLE
Update cli to use the correct client ctx fetcher

### DIFF
--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -177,7 +177,7 @@ func GetCmdQueryAuctions() *cobra.Command {
 				params.Phase = auctionPhase
 			}
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/committee/client/cli/query.go
+++ b/x/committee/client/cli/query.go
@@ -61,7 +61,7 @@ func getCmdQueryCommittee() *cobra.Command {
 		Short:   "Query details of a single committee",
 		Example: fmt.Sprintf("%s query %s committee 1", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ func getCmdQueryCommittees() *cobra.Command {
 		Short:   "Query all committees",
 		Example: fmt.Sprintf("%s query %s committees", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ func getCmdQueryNextProposalID() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		Example: fmt.Sprintf("%s query %s next-proposal-id", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func getCmdQueryProposal() *cobra.Command {
 		Short:   "Query details of a single proposal",
 		Example: fmt.Sprintf("%s query %s proposal 2", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func getCmdQueryProposals() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		Example: fmt.Sprintf("%s query %s proposals 1", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -205,7 +205,7 @@ func getCmdQueryVotes() *cobra.Command {
 		Short:   "Query votes on a proposal",
 		Example: fmt.Sprintf("%s query %s votes 2", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ func getCmdQueryTally() *cobra.Command {
 		Long:    "Query the current tally of votes on a proposal to see the progress of the voting.",
 		Example: fmt.Sprintf("%s query %s tally 2", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -271,7 +271,7 @@ func getCmdQueryProposer() *cobra.Command {
 		Long:    "Query which address proposed a proposal with a given ID.",
 		Example: fmt.Sprintf("%s query %s proposer 2", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -299,7 +299,7 @@ func getCmdQueryRawParams() *cobra.Command {
 		Long:    "Query the byte value of any module's parameters. Useful in debugging and verifying governance proposals.",
 		Example: fmt.Sprintf("%s query %s raw-params cdp CollateralParams", version.AppName, types.ModuleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/kavadist/client/cli/query.go
+++ b/x/kavadist/client/cli/query.go
@@ -38,7 +38,7 @@ func queryParamsCmd() *cobra.Command {
 		Long:  "Get the current global kavadist module parameters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
+			cliCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func queryBalanceCmd() *cobra.Command {
 		Long:  "Get the current kavadist module account balance.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx, err := client.GetClientTxContext(cmd)
+			cliCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}

--- a/x/swap/client/cli/query.go
+++ b/x/swap/client/cli/query.go
@@ -50,7 +50,7 @@ func queryParamsCmd(queryRoute string) *cobra.Command {
 		Long:  "Get the current global swap module parameters.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -95,7 +95,7 @@ func queryDepositsCmd(queryRoute string) *cobra.Command {
 				return err
 			}
 
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}
@@ -134,7 +134,7 @@ func queryPoolsCmd(queryRoute string) *cobra.Command {
 		),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I noticed a number of client cli queries are using `GetClientTxContext` as opposed to `GetClientQueryContext`. This PR should fix all existing occurrences of this issue.