### PR TITLE
Upgrade incentive client

### DIFF
--- a/x/incentive/client/cli/query.go
+++ b/x/incentive/client/cli/query.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -79,11 +78,11 @@ func queryRewardsCmd() *cobra.Command {
 				return err
 			}
 
-			page := viper.GetInt(flags.FlagPage)
-			limit := viper.GetInt(flags.FlagLimit)
-			strOwner := viper.GetString(flagOwner)
-			strType := viper.GetString(flagType)
-			boolUnsynced := viper.GetBool(flagUnsynced)
+			page, _ := cmd.Flags().GetInt(flags.FlagPage)
+			limit, _ := cmd.Flags().GetInt(flags.FlagLimit)
+			strOwner, _ := cmd.Flags().GetString(flagOwner)
+			strType, _ := cmd.Flags().GetString(flagType)
+			boolUnsynced, _ := cmd.Flags().GetBool(flagUnsynced)
 
 			// Prepare params for querier
 			var owner sdk.AccAddress
@@ -142,16 +141,24 @@ func queryRewardsCmd() *cobra.Command {
 					return err
 				}
 				if len(hardClaims) > 0 {
-					cliCtx.PrintObjectLegacy(hardClaims)
+					if err := cliCtx.PrintObjectLegacy(hardClaims); err != nil {
+						return err
+					}
 				}
 				if len(usdxMintingClaims) > 0 {
-					cliCtx.PrintObjectLegacy(usdxMintingClaims)
+					if err := cliCtx.PrintObjectLegacy(usdxMintingClaims); err != nil {
+						return err
+					}
 				}
 				if len(delegatorClaims) > 0 {
-					cliCtx.PrintObjectLegacy(delegatorClaims)
+					if err := cliCtx.PrintObjectLegacy(delegatorClaims); err != nil {
+						return err
+					}
 				}
 				if len(swapClaims) > 0 {
-					cliCtx.PrintObjectLegacy(swapClaims)
+					if err := cliCtx.PrintObjectLegacy(swapClaims); err != nil {
+						return err
+					}
 				}
 			}
 			return nil

--- a/x/incentive/client/cli/query.go
+++ b/x/incentive/client/cli/query.go
@@ -86,9 +86,11 @@ func queryRewardsCmd() *cobra.Command {
 			boolUnsynced := viper.GetBool(flagUnsynced)
 
 			// Prepare params for querier
-			owner, err := sdk.AccAddressFromBech32(strOwner)
-			if err != nil {
-				return err
+			var owner sdk.AccAddress
+			if strOwner != "" {
+				if owner, err = sdk.AccAddressFromBech32(strOwner); err != nil {
+					return err
+				}
 			}
 
 			switch strings.ToLower(strType) {

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -1,19 +1,15 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -22,87 +18,57 @@ const multiplierFlag = "multiplier"
 const multiplierFlagShort = "m"
 
 // GetTxCmd returns the transaction cli commands for the incentive module
-func GetTxCmd(cdc *codec.Codec) *cobra.Command {
+func GetTxCmd() *cobra.Command {
 	incentiveTxCmd := &cobra.Command{
 		Use:   types.ModuleName,
 		Short: "transaction commands for the incentive module",
 	}
 
-	incentiveTxCmd.AddCommand(flags.PostCommands(
-		getCmdClaimCdp(cdc),
-		getCmdClaimCdpVVesting(cdc),
-		getCmdClaimHard(cdc),
-		getCmdClaimHardVVesting(cdc),
-		getCmdClaimDelegator(cdc),
-		getCmdClaimDelegatorVVesting(cdc),
-		getCmdClaimSwap(cdc),
-		getCmdClaimSwapVVesting(cdc),
-	)...)
+	cmds := []*cobra.Command{
+		getCmdClaimCdp(),
+		getCmdClaimHard(),
+		getCmdClaimDelegator(),
+		getCmdClaimSwap(),
+	}
+
+	for _, cmd := range cmds {
+		flags.AddTxFlagsToCmd(cmd)
+	}
+
+	incentiveTxCmd.AddCommand(cmds...)
 
 	return incentiveTxCmd
 }
 
-func getCmdClaimCdp(cdc *codec.Codec) *cobra.Command {
+func getCmdClaimCdp() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "claim-cdp [multiplier]",
 		Short:   "claim USDX minting rewards using a given multiplier",
 		Long:    `Claim sender's outstanding USDX minting rewards using a given multiplier.`,
-		Example: fmt.Sprintf(`  $ %s tx %s claim-cdp large`, version.ClientName, types.ModuleName),
+		Example: fmt.Sprintf(`  $ %s tx %s claim-cdp large`, version.AppName, types.ModuleName),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			multiplier := args[0]
-
-			msg := types.NewMsgClaimUSDXMintingReward(sender, multiplier)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-
-	return cmd
-}
-
-func getCmdClaimCdpVVesting(cdc *codec.Codec) *cobra.Command {
-
-	cmd := &cobra.Command{
-		Use:   "claim-cdp-vesting [multiplier] [receiver]",
-		Short: "claim USDX minting rewards using a given multiplier on behalf of a validator vesting account",
-		Long: `Claim sender's outstanding USDX minting rewards on behalf of a validator vesting using a given multiplier.
-A receiver address for the rewards is needed as validator vesting accounts cannot receive locked tokens.`,
-		Example: fmt.Sprintf(`  $ %s tx %s claim-cdp-vesting large kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw`, version.ClientName, types.ModuleName),
-		Args:    cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			multiplier := args[0]
-			receiverStr := args[1]
-			receiver, err := sdk.AccAddressFromBech32(receiverStr)
+			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			msg := types.NewMsgClaimUSDXMintingRewardVVesting(sender, receiver, multiplier)
+			sender := cliCtx.GetFromAddress()
+			multiplier := args[0]
+
+			msg := types.NewMsgClaimUSDXMintingReward(sender.String(), multiplier)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), &msg)
 		},
 	}
 
 	return cmd
 }
 
-func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
+func getCmdClaimHard() *cobra.Command {
 	var denomsToClaim map[string]string
 
 	cmd := &cobra.Command{
@@ -110,69 +76,32 @@ func getCmdClaimHard(cdc *codec.Codec) *cobra.Command {
 		Short: "claim sender's Hard module rewards using given multipliers",
 		Long:  `Claim sender's outstanding Hard rewards for deposit/borrow using given multipliers`,
 		Example: strings.Join([]string{
-			fmt.Sprintf(`  $ %s tx %s claim-hard --%s hard=large --%s ukava=small`, version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf(`  $ %s tx %s claim-hard --%s hard=large,ukava=small`, version.ClientName, types.ModuleName, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-hard --%s hard=large --%s ukava=small`, version.AppName, types.ModuleName, multiplierFlag, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-hard --%s hard=large,ukava=small`, version.AppName, types.ModuleName, multiplierFlag),
 		}, "\n"),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			selections := types.NewSelectionsFromMap(denomsToClaim)
-
-			msg := types.NewMsgClaimHardReward(sender, selections...)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
-	return cmd
-}
-
-func getCmdClaimHardVVesting(cdc *codec.Codec) *cobra.Command {
-	var denomsToClaim map[string]string
-
-	cmd := &cobra.Command{
-		Use:   "claim-hard-vesting [receiver]",
-		Short: "claim Hard module rewards on behalf of a validator vesting account using given multipliers",
-		Long: `Claim sender's outstanding hard supply/borrow rewards on behalf of a validator vesting account using given multipliers
-A receiver address for the rewards is needed as validator vesting accounts cannot receive locked tokens.`,
-		Example: strings.Join([]string{
-			fmt.Sprintf("  $ %s tx %s claim-hard-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s hard=large --%s ukava=small", version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf("  $ %s tx %s claim-hard-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s hard=large,ukava=small", version.ClientName, types.ModuleName, multiplierFlag),
-		}, "\n"),
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			receiver, err := sdk.AccAddressFromBech32(args[1])
+			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
+
+			sender := cliCtx.GetFromAddress()
 			selections := types.NewSelectionsFromMap(denomsToClaim)
 
-			msg := types.NewMsgClaimHardRewardVVesting(sender, receiver, selections...)
+			msg := types.NewMsgClaimHardReward(sender.String(), selections)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), &msg)
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
 	cmd.MarkFlagRequired(multiplierFlag)
-
 	return cmd
 }
 
-func getCmdClaimDelegator(cdc *codec.Codec) *cobra.Command {
+func getCmdClaimDelegator() *cobra.Command {
 	var denomsToClaim map[string]string
 
 	cmd := &cobra.Command{
@@ -180,69 +109,32 @@ func getCmdClaimDelegator(cdc *codec.Codec) *cobra.Command {
 		Short: "claim sender's non-sdk delegator rewards using given multipliers",
 		Long:  `Claim sender's outstanding delegator rewards using given multipliers`,
 		Example: strings.Join([]string{
-			fmt.Sprintf(`  $ %s tx %s claim-delegator --%s hard=large --%s swp=small`, version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf(`  $ %s tx %s claim-delegator --%s hard=large,swp=small`, version.ClientName, types.ModuleName, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-delegator --%s hard=large --%s swp=small`, version.AppName, types.ModuleName, multiplierFlag, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-delegator --%s hard=large,swp=small`, version.AppName, types.ModuleName, multiplierFlag),
 		}, "\n"),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			selections := types.NewSelectionsFromMap(denomsToClaim)
-
-			msg := types.NewMsgClaimDelegatorReward(sender, selections...)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
-	return cmd
-}
-
-func getCmdClaimDelegatorVVesting(cdc *codec.Codec) *cobra.Command {
-	var denomsToClaim map[string]string
-
-	cmd := &cobra.Command{
-		Use:   "claim-delegator-vesting [receiver]",
-		Short: "claim non-sdk delegator rewards on behalf of a validator vesting account using given multipliers",
-		Long: `Claim sender's outstanding delegator rewards on behalf of a validator vesting account using given multipliers
-A receiver address for the rewards is needed as validator vesting accounts cannot receive locked tokens.`,
-		Example: strings.Join([]string{
-			fmt.Sprintf("  $ %s tx %s claim-delegator-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s hard=large --%s swp=small", version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf("  $ %s tx %s claim-delegator-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s hard=large,swp=small", version.ClientName, types.ModuleName, multiplierFlag),
-		}, "\n"),
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			receiver, err := sdk.AccAddressFromBech32(args[1])
+			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
+
+			sender := cliCtx.GetFromAddress()
 			selections := types.NewSelectionsFromMap(denomsToClaim)
 
-			msg := types.NewMsgClaimDelegatorRewardVVesting(sender, receiver, selections...)
+			msg := types.NewMsgClaimDelegatorReward(sender.String(), selections)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), &msg)
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
 	cmd.MarkFlagRequired(multiplierFlag)
-
 	return cmd
 }
 
-func getCmdClaimSwap(cdc *codec.Codec) *cobra.Command {
+func getCmdClaimSwap() *cobra.Command {
 	var denomsToClaim map[string]string
 
 	cmd := &cobra.Command{
@@ -250,64 +142,27 @@ func getCmdClaimSwap(cdc *codec.Codec) *cobra.Command {
 		Short: "claim sender's swap rewards using given multipliers",
 		Long:  `Claim sender's outstanding swap rewards using given multipliers`,
 		Example: strings.Join([]string{
-			fmt.Sprintf(`  $ %s tx %s claim-swap --%s swp=large --%s ukava=small`, version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf(`  $ %s tx %s claim-swap --%s swp=large,ukava=small`, version.ClientName, types.ModuleName, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-swap --%s swp=large --%s ukava=small`, version.AppName, types.ModuleName, multiplierFlag, multiplierFlag),
+			fmt.Sprintf(`  $ %s tx %s claim-swap --%s swp=large,ukava=small`, version.AppName, types.ModuleName, multiplierFlag),
 		}, "\n"),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			selections := types.NewSelectionsFromMap(denomsToClaim)
-
-			msg := types.NewMsgClaimSwapReward(sender, selections...)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
-		},
-	}
-	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
-	return cmd
-}
-
-func getCmdClaimSwapVVesting(cdc *codec.Codec) *cobra.Command {
-	var denomsToClaim map[string]string
-
-	cmd := &cobra.Command{
-		Use:   "claim-swap-vesting [receiver]",
-		Short: "claim swap rewards on behalf of a validator vesting account using given multipliers",
-		Long: `Claim sender's outstanding swap rewards on behalf of a validator vesting account using given multipliers
-A receiver address for the rewards is needed as validator vesting accounts cannot receive locked tokens.`,
-		Example: strings.Join([]string{
-			fmt.Sprintf("  $ %s tx %s claim-swap-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s ukava=large --%s swp=small", version.ClientName, types.ModuleName, multiplierFlag, multiplierFlag),
-			fmt.Sprintf("  $ %s tx %s claim-swap-vesting kava15qdefkmwswysgg4qxgqpqr35k3m49pkx2jdfnw --%s ukava=large,swp=small", version.ClientName, types.ModuleName, multiplierFlag),
-		}, "\n"),
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			inBuf := bufio.NewReader(cmd.InOrStdin())
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(utils.GetTxEncoder(cdc))
-
-			sender := cliCtx.GetFromAddress()
-			receiver, err := sdk.AccAddressFromBech32(args[1])
+			cliCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
+
+			sender := cliCtx.GetFromAddress()
 			selections := types.NewSelectionsFromMap(denomsToClaim)
 
-			msg := types.NewMsgClaimSwapRewardVVesting(sender, receiver, selections...)
+			msg := types.NewMsgClaimSwapReward(sender.String(), selections)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
+			return tx.GenerateOrBroadcastTxCLI(cliCtx, cmd.Flags(), &msg)
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
 	cmd.MarkFlagRequired(multiplierFlag)
-
 	return cmd
 }

--- a/x/incentive/client/cli/tx.go
+++ b/x/incentive/client/cli/tx.go
@@ -97,7 +97,9 @@ func getCmdClaimHard() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
+	if err := cmd.MarkFlagRequired(multiplierFlag); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 
@@ -130,7 +132,9 @@ func getCmdClaimDelegator() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
+	if err := cmd.MarkFlagRequired(multiplierFlag); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 
@@ -163,6 +167,8 @@ func getCmdClaimSwap() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringToStringVarP(&denomsToClaim, multiplierFlag, multiplierFlagShort, nil, "specify the denoms to claim, each with a multiplier lockup")
-	cmd.MarkFlagRequired(multiplierFlag)
+	if err := cmd.MarkFlagRequired(multiplierFlag); err != nil {
+		panic(err)
+	}
 	return cmd
 }

--- a/x/incentive/client/rest/query.go
+++ b/x/incentive/client/rest/query.go
@@ -8,20 +8,20 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
-func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
+func registerQueryRoutes(cliCtx client.Context, r *mux.Router) {
 	r.HandleFunc(fmt.Sprintf("/%s/rewards", types.ModuleName), queryRewardsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/parameters", types.ModuleName), queryParamsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/reward-factors", types.ModuleName), queryRewardFactorsHandlerFn(cliCtx)).Methods("GET")
 }
 
-func queryRewardsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+func queryRewardsHandlerFn(cliCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, page, limit, err := rest.ParseHTTPArgsWithLimit(r, 0)
 		if err != nil {
@@ -74,7 +74,7 @@ func queryRewardsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	}
 }
 
-func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+func queryParamsHandlerFn(cliCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {
@@ -94,7 +94,7 @@ func queryParamsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	}
 }
 
-func queryRewardFactorsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+func queryRewardFactorsHandlerFn(cliCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {
@@ -114,8 +114,8 @@ func queryRewardFactorsHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	}
 }
 
-func executeHardRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, params types.QueryRewardsParams) {
-	bz, err := cliCtx.Codec.MarshalJSON(params)
+func executeHardRewardsQuery(w http.ResponseWriter, cliCtx client.Context, params types.QueryRewardsParams) {
+	bz, err := cliCtx.LegacyAmino.MarshalJSON(params)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 		return
@@ -131,8 +131,8 @@ func executeHardRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, p
 	rest.PostProcessResponse(w, cliCtx, res)
 }
 
-func executeUSDXMintingRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, params types.QueryRewardsParams) {
-	bz, err := cliCtx.Codec.MarshalJSON(params)
+func executeUSDXMintingRewardsQuery(w http.ResponseWriter, cliCtx client.Context, params types.QueryRewardsParams) {
+	bz, err := cliCtx.LegacyAmino.MarshalJSON(params)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 		return
@@ -148,8 +148,8 @@ func executeUSDXMintingRewardsQuery(w http.ResponseWriter, cliCtx context.CLICon
 	rest.PostProcessResponse(w, cliCtx, res)
 }
 
-func executeDelegatorRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, params types.QueryRewardsParams) {
-	bz, err := cliCtx.Codec.MarshalJSON(params)
+func executeDelegatorRewardsQuery(w http.ResponseWriter, cliCtx client.Context, params types.QueryRewardsParams) {
+	bz, err := cliCtx.LegacyAmino.MarshalJSON(params)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 		return
@@ -165,8 +165,8 @@ func executeDelegatorRewardsQuery(w http.ResponseWriter, cliCtx context.CLIConte
 	rest.PostProcessResponse(w, cliCtx, res)
 }
 
-func executeSwapRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, params types.QueryRewardsParams) {
-	bz, err := cliCtx.Codec.MarshalJSON(params)
+func executeSwapRewardsQuery(w http.ResponseWriter, cliCtx client.Context, params types.QueryRewardsParams) {
+	bz, err := cliCtx.LegacyAmino.MarshalJSON(params)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 		return
@@ -182,9 +182,9 @@ func executeSwapRewardsQuery(w http.ResponseWriter, cliCtx context.CLIContext, p
 	rest.PostProcessResponse(w, cliCtx, res)
 }
 
-func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, params types.QueryRewardsParams) {
+func executeAllRewardQueries(w http.ResponseWriter, cliCtx client.Context, params types.QueryRewardsParams) {
 
-	paramsBz, err := cliCtx.Codec.MarshalJSON(params)
+	paramsBz, err := cliCtx.LegacyAmino.MarshalJSON(params)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 		return
@@ -195,7 +195,7 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, p
 		return
 	}
 	var hardClaims types.HardLiquidityProviderClaims
-	cliCtx.Codec.MustUnmarshalJSON(hardRes, &hardClaims)
+	cliCtx.LegacyAmino.MustUnmarshalJSON(hardRes, &hardClaims)
 
 	usdxMintingRes, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetUSDXMintingRewards), paramsBz)
 	if err != nil {
@@ -203,7 +203,7 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, p
 		return
 	}
 	var usdxMintingClaims types.USDXMintingClaims
-	cliCtx.Codec.MustUnmarshalJSON(usdxMintingRes, &usdxMintingClaims)
+	cliCtx.LegacyAmino.MustUnmarshalJSON(usdxMintingRes, &usdxMintingClaims)
 
 	delegatorRes, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetDelegatorRewards), paramsBz)
 	if err != nil {
@@ -211,7 +211,7 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, p
 		return
 	}
 	var delegatorClaims types.DelegatorClaims
-	cliCtx.Codec.MustUnmarshalJSON(delegatorRes, &delegatorClaims)
+	cliCtx.LegacyAmino.MustUnmarshalJSON(delegatorRes, &delegatorClaims)
 
 	swapRes, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/incentive/%s", types.QueryGetSwapRewards), paramsBz)
 	if err != nil {
@@ -219,7 +219,7 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, p
 		return
 	}
 	var swapClaims types.SwapClaims
-	cliCtx.Codec.MustUnmarshalJSON(swapRes, &swapClaims)
+	cliCtx.LegacyAmino.MustUnmarshalJSON(swapRes, &swapClaims)
 
 	cliCtx = cliCtx.WithHeight(height)
 
@@ -237,7 +237,7 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx context.CLIContext, p
 		SwapClaims:        swapClaims,
 	}
 
-	resBz, err := cliCtx.Codec.MarshalJSON(res)
+	resBz, err := cliCtx.LegacyAmino.MarshalJSON(res)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal result: %s", err))
 		return

--- a/x/incentive/client/rest/rest.go
+++ b/x/incentive/client/rest/rest.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"github.com/gorilla/mux"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 
@@ -17,7 +17,7 @@ const (
 )
 
 // RegisterRoutes registers incentive-related REST handlers to a router
-func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
+func RegisterRoutes(cliCtx client.Context, r *mux.Router) {
 	registerQueryRoutes(cliCtx, r)
 	registerTxRoutes(cliCtx, r)
 }

--- a/x/incentive/client/rest/tx.go
+++ b/x/incentive/client/rest/tx.go
@@ -7,48 +7,45 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
-	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
-func registerTxRoutes(cliCtx context.CLIContext, r *mux.Router) {
+func registerTxRoutes(cliCtx client.Context, r *mux.Router) {
 	r.HandleFunc("/incentive/claim-cdp", postClaimHandlerFn(cliCtx, usdxMintingGenerator)).Methods("POST")
-	r.HandleFunc("/incentive/claim-cdp-vesting", postClaimVVestingHandlerFn(cliCtx, usdxMintingVVGenerator)).Methods("POST")
-
 	r.HandleFunc("/incentive/claim-hard", postClaimHandlerFn(cliCtx, hardGenerator)).Methods("POST")
-	r.HandleFunc("/incentive/claim-hard-vesting", postClaimVVestingHandlerFn(cliCtx, hardVVGenerator)).Methods("POST")
-
 	r.HandleFunc("/incentive/claim-delegator", postClaimHandlerFn(cliCtx, delegatorGenerator)).Methods("POST")
-	r.HandleFunc("/incentive/claim-delegator-vesting", postClaimVVestingHandlerFn(cliCtx, delegatorVVGenerator)).Methods("POST")
-
 	r.HandleFunc("/incentive/claim-swap", postClaimHandlerFn(cliCtx, swapGenerator)).Methods("POST")
-	r.HandleFunc("/incentive/claim-swap-vesting", postClaimVVestingHandlerFn(cliCtx, swapVVGenerator)).Methods("POST")
 }
 
 func usdxMintingGenerator(req PostClaimReq) (sdk.Msg, error) {
 	if len(req.DenomsToClaim) != 1 {
 		return nil, fmt.Errorf("must only claim %s denom for usdx minting rewards, got '%s", types.USDXMintingRewardDenom, req.DenomsToClaim)
 	}
-	return types.NewMsgClaimUSDXMintingReward(req.Sender, req.DenomsToClaim[0].MultiplierName), nil
+	msg := types.NewMsgClaimUSDXMintingReward(req.Sender.String(), req.DenomsToClaim[0].MultiplierName)
+	return &msg, nil
 }
 func hardGenerator(req PostClaimReq) (sdk.Msg, error) {
-	return types.NewMsgClaimHardReward(req.Sender, req.DenomsToClaim...), nil
+	msg := types.NewMsgClaimHardReward(req.Sender.String(), req.DenomsToClaim)
+	return &msg, nil
 }
 func delegatorGenerator(req PostClaimReq) (sdk.Msg, error) {
-	return types.NewMsgClaimDelegatorReward(req.Sender, req.DenomsToClaim...), nil
+	msg := types.NewMsgClaimDelegatorReward(req.Sender.String(), req.DenomsToClaim)
+	return &msg, nil
 }
 func swapGenerator(req PostClaimReq) (sdk.Msg, error) {
-	return types.NewMsgClaimSwapReward(req.Sender, req.DenomsToClaim...), nil
+	msg := types.NewMsgClaimSwapReward(req.Sender.String(), req.DenomsToClaim)
+	return &msg, nil
 }
 
-func postClaimHandlerFn(cliCtx context.CLIContext, msgGenerator func(req PostClaimReq) (sdk.Msg, error)) http.HandlerFunc {
+func postClaimHandlerFn(cliCtx client.Context, msgGenerator func(req PostClaimReq) (sdk.Msg, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var requestBody PostClaimReq
-		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &requestBody) {
+		if !rest.ReadRESTReq(w, r, cliCtx.LegacyAmino, &requestBody) {
 			return
 		}
 
@@ -58,8 +55,7 @@ func postClaimHandlerFn(cliCtx context.CLIContext, msgGenerator func(req PostCla
 		}
 
 		fromAddr, err := sdk.AccAddressFromBech32(requestBody.BaseReq.From)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		if rest.CheckBadRequestError(w, err) {
 			return
 		}
 
@@ -69,69 +65,13 @@ func postClaimHandlerFn(cliCtx context.CLIContext, msgGenerator func(req PostCla
 		}
 
 		msg, err := msgGenerator(requestBody)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		if rest.CheckBadRequestError(w, err) {
+			return
+		}
+		if rest.CheckBadRequestError(w, msg.ValidateBasic()) {
 			return
 		}
 
-		if err := msg.ValidateBasic(); err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		utils.WriteGenerateStdTxResponse(w, cliCtx, requestBody.BaseReq, []sdk.Msg{msg})
-	}
-}
-
-func usdxMintingVVGenerator(req PostClaimVVestingReq) (sdk.Msg, error) {
-	if len(req.DenomsToClaim) != 1 {
-		return nil, fmt.Errorf("must only claim %s denom for usdx minting rewards, got '%s", types.USDXMintingRewardDenom, req.DenomsToClaim)
-	}
-	return types.NewMsgClaimUSDXMintingRewardVVesting(req.Sender, req.Receiver, req.DenomsToClaim[0].MultiplierName), nil
-}
-func hardVVGenerator(req PostClaimVVestingReq) (sdk.Msg, error) {
-	return types.NewMsgClaimHardRewardVVesting(req.Sender, req.Receiver, req.DenomsToClaim...), nil
-}
-func delegatorVVGenerator(req PostClaimVVestingReq) (sdk.Msg, error) {
-	return types.NewMsgClaimDelegatorRewardVVesting(req.Sender, req.Receiver, req.DenomsToClaim...), nil
-}
-func swapVVGenerator(req PostClaimVVestingReq) (sdk.Msg, error) {
-	return types.NewMsgClaimSwapRewardVVesting(req.Sender, req.Receiver, req.DenomsToClaim...), nil
-}
-
-func postClaimVVestingHandlerFn(cliCtx context.CLIContext, msgGenerator func(req PostClaimVVestingReq) (sdk.Msg, error)) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		var requestBody PostClaimVVestingReq
-		if !rest.ReadRESTReq(w, r, cliCtx.Codec, &requestBody) {
-			return
-		}
-
-		requestBody.BaseReq = requestBody.BaseReq.Sanitize()
-		if !requestBody.BaseReq.ValidateBasic(w) {
-			return
-		}
-
-		fromAddr, err := sdk.AccAddressFromBech32(requestBody.BaseReq.From)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		if !bytes.Equal(fromAddr, requestBody.Sender) {
-			rest.WriteErrorResponse(w, http.StatusUnauthorized, fmt.Sprintf("expected: %s, got: %s", fromAddr, requestBody.Sender))
-			return
-		}
-
-		msg, err := msgGenerator(requestBody)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		if err := msg.ValidateBasic(); err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
-
-		utils.WriteGenerateStdTxResponse(w, cliCtx, requestBody.BaseReq, []sdk.Msg{msg})
+		tx.WriteGeneratedTxResponse(cliCtx, w, requestBody.BaseReq, msg)
 	}
 }

--- a/x/incentive/module.go
+++ b/x/incentive/module.go
@@ -15,8 +15,8 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	// "github.com/kava-labs/kava/x/incentive/client/cli"
-	// "github.com/kava-labs/kava/x/incentive/client/rest"
+	"github.com/kava-labs/kava/x/incentive/client/cli"
+	"github.com/kava-labs/kava/x/incentive/client/rest"
 	"github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -63,7 +63,7 @@ func (a AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry
 
 // RegisterRESTRoutes registers REST routes for the incentive module.
 func (a AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Router) {
-	// TODO: rest.RegisterRoutes(clientCtx, rtr)
+	rest.RegisterRoutes(clientCtx, rtr)
 }
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the incentive module.
@@ -86,12 +86,12 @@ func (AppModule) ConsensusVersion() uint64 {
 
 // GetTxCmd returns the root tx command for the incentive module.
 func (AppModuleBasic) GetTxCmd() *cobra.Command {
-	return nil // TODO: return cli.GetTxCmd()
+	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns no root query command for the incentive module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil // TODO: return cli.GetQueryCmd()
+	return cli.GetQueryCmd()
 }
 
 // AppModule implements the sdk.AppModule interface.


### PR DESCRIPTION
Upgrades incentive client to v44.

Note:
- grpc queries are not created for the incentive module since it adds a lot more extra complexity right now for little benefit. Therefore, the cli is upgraded to use the legacy querier.