### PR TITLE
Update x/hard accounts query to include account coins

### DIFF
--- a/x/hard/keeper/querier.go
+++ b/x/hard/keeper/querier.go
@@ -71,7 +71,17 @@ func queryGetModAccounts(ctx sdk.Context, req abci.RequestQuery, k Keeper, legac
 		accs = append(accs, acc)
 	}
 
-	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, accs)
+	// Include module account coins with its account to keep backwards compatibility with v39 account behavior
+	response := make([]types.ModAccountWithCoins, len(accs))
+	for i, acc := range accs {
+		coins := k.bankKeeper.GetAllBalances(ctx, acc.GetAddress())
+		response[i] = types.ModAccountWithCoins{
+			Account: acc,
+			Coins:   coins,
+		}
+	}
+
+	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, response)
 
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())

--- a/x/hard/types/querier.go
+++ b/x/hard/types/querier.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 // Querier routes for the hard module
@@ -69,6 +71,12 @@ func NewQueryAccountParams(page, limit int, name string) QueryAccountParams {
 		Limit: limit,
 		Name:  name,
 	}
+}
+
+// ModAccountWithCoins includes the module account with its coins
+type ModAccountWithCoins struct {
+	Account authtypes.ModuleAccountI `json:"account" yaml:"account"`
+	Coins   sdk.Coins                `json:"coins" yaml:"coins"`
 }
 
 // QueryBorrowsParams is the params for a filtered borrows query


### PR DESCRIPTION
Add coins to the query response.

New response format:
```
{
  "height": "60",
  "result": [
    {
      "account": {
        "type": "cosmos-sdk/ModuleAccount",
        "value": {
          "address": "kava1mfru9azs5nua2wxcd4sq64g5nt7nn4n8s2w8cu",
          "public_key": "",
          "account_number": 16,
          "sequence": 0,
          "name": "swap",
          "permissions": null
        }
      },
      "coins": [
        {
          "denom": "btcb",
          "amount": "200000000"
        },
      ]
    }
  ]
}
```