### PR TITLE
Fix bep3 msg validation

### DIFF
--- a/x/bep3/types/msg.go
+++ b/x/bep3/types/msg.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -101,7 +102,11 @@ func (msg MsgCreateAtomicSwap) ValidateBasic() error {
 	if len(msg.SenderOtherChain) > MaxOtherChainAddrLength {
 		return fmt.Errorf("the length of sender address on other chain should be less than %d", MaxOtherChainAddrLength)
 	}
-	if len(msg.RandomNumberHash) != RandomNumberHashLength {
+	randomNumberHash, err := hex.DecodeString(msg.RandomNumberHash)
+	if err != nil {
+		return fmt.Errorf("random number hash should be valid hex: %v", err)
+	}
+	if len(randomNumberHash) != RandomNumberHashLength {
 		return fmt.Errorf("the length of random number hash should be %d", RandomNumberHashLength)
 	}
 	if msg.Timestamp <= 0 {

--- a/x/bep3/types/msg.go
+++ b/x/bep3/types/msg.go
@@ -33,8 +33,6 @@ var (
 	_                      sdk.Msg = &MsgClaimAtomicSwap{}
 	_                      sdk.Msg = &MsgRefundAtomicSwap{}
 	AtomicSwapCoinsAccAddr         = sdk.AccAddress(crypto.AddressHash([]byte("KavaAtomicSwapCoins")))
-	// kava prefix address:  [INSERT BEP3-DEPUTY ADDRESS]
-	// tkava prefix address: [INSERT BEP3-DEPUTY ADDRESS]
 )
 
 // NewMsgCreateAtomicSwap initializes a new MsgCreateAtomicSwap
@@ -73,7 +71,10 @@ func (msg MsgCreateAtomicSwap) GetInvolvedAddresses() []sdk.AccAddress {
 
 // GetSigners gets the signers of a MsgCreateAtomicSwap
 func (msg MsgCreateAtomicSwap) GetSigners() []sdk.AccAddress {
-	from, _ := sdk.AccAddressFromBech32(msg.From)
+	from, err := sdk.AccAddressFromBech32(msg.From)
+	if err != nil {
+		panic(err)
+	}
 	return []sdk.AccAddress{from}
 }
 
@@ -157,7 +158,10 @@ func (msg MsgClaimAtomicSwap) GetInvolvedAddresses() []sdk.AccAddress {
 
 // GetSigners gets the signers of a MsgClaimAtomicSwap
 func (msg MsgClaimAtomicSwap) GetSigners() []sdk.AccAddress {
-	from, _ := sdk.AccAddressFromBech32(msg.From)
+	from, err := sdk.AccAddressFromBech32(msg.From)
+	if err != nil {
+		panic(err)
+	}
 	return []sdk.AccAddress{from}
 }
 
@@ -211,7 +215,10 @@ func (msg MsgRefundAtomicSwap) GetInvolvedAddresses() []sdk.AccAddress {
 
 // GetSigners gets the signers of a MsgRefundAtomicSwap
 func (msg MsgRefundAtomicSwap) GetSigners() []sdk.AccAddress {
-	from, _ := sdk.AccAddressFromBech32(msg.From)
+	from, err := sdk.AccAddressFromBech32(msg.From)
+	if err != nil {
+		panic(err)
+	}
 	return []sdk.AccAddress{from}
 }
 

--- a/x/bep3/types/msg_test.go
+++ b/x/bep3/types/msg_test.go
@@ -61,7 +61,7 @@ func (suite *MsgTestSuite) TestMsgCreateAtomicSwap() {
 		{"without other chain fields", binanceAddrs[0], kavaAddrs[0], "", "", randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
 		{"invalid amount", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, nil, 500, false},
 		{"invalid from address", sdk.AccAddress{}, kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
-		{"invalid from address", binanceAddrs[0], sdk.AccAddress{}, kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
+		{"invalid to address", binanceAddrs[0], sdk.AccAddress{}, kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
 		{"invalid rand hash", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), "ff", timestampInt64, coinsSingle, 500, false},
 	}
 

--- a/x/bep3/types/msg_test.go
+++ b/x/bep3/types/msg_test.go
@@ -62,7 +62,7 @@ func (suite *MsgTestSuite) TestMsgCreateAtomicSwap() {
 		{"invalid amount", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, nil, 500, false},
 		{"invalid from address", sdk.AccAddress{}, kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
 		{"invalid from address", binanceAddrs[0], sdk.AccAddress{}, kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
-		{"invalid rand hash", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), "ff", timestampInt64, coinsSingle, 500, true},
+		{"invalid rand hash", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), "ff", timestampInt64, coinsSingle, 500, false},
 	}
 
 	for i, tc := range tests {

--- a/x/bep3/types/msg_test.go
+++ b/x/bep3/types/msg_test.go
@@ -1,25 +1,24 @@
 package types_test
 
 import (
-	"github.com/stretchr/testify/suite"
-
-	"github.com/tendermint/tendermint/crypto"
-	tmbytes "github.com/tendermint/tendermint/libs/bytes"
+	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/crypto"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/bep3/types"
 )
 
 var (
-	coinsSingle       = sdk.NewCoins(sdk.NewInt64Coin("bnb", int64(50000)))
-	coinsZero         = sdk.Coins{sdk.Coin{}}
+	coinsSingle       = sdk.NewCoins(sdk.NewInt64Coin("bnb", 50000))
 	binanceAddrs      = []sdk.AccAddress{}
 	kavaAddrs         = []sdk.AccAddress{}
 	randomNumberBytes = []byte{15}
 	timestampInt64    = int64(100)
-	randomNumberHash  = types.CalculateRandomHash(randomNumberBytes, timestampInt64)
+	randomNumberHash  = tmbytes.HexBytes(types.CalculateRandomHash(randomNumberBytes, timestampInt64))
 )
 
 func init() {
@@ -52,21 +51,22 @@ func (suite *MsgTestSuite) TestMsgCreateAtomicSwap() {
 		to                  sdk.AccAddress
 		recipientOtherChain string
 		senderOtherChain    string
-		randomNumberHash    tmbytes.HexBytes
+		randomNumberHash    string
 		timestamp           int64
 		amount              sdk.Coins
 		heightSpan          uint64
 		expectPass          bool
 	}{
-		{"normal cross-chain", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash, timestampInt64, coinsSingle, 500, true},
-		{"without other chain fields", binanceAddrs[0], kavaAddrs[0], "", "", randomNumberHash, timestampInt64, coinsSingle, 500, false},
-		{"invalid amount", binanceAddrs[0], kavaAddrs[0], "", "", randomNumberHash, timestampInt64, coinsSingle, 500, false},
-		{"invalid from address", sdk.AccAddress{}, kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash, timestampInt64, coinsSingle, 500, false},
-		{"invalid from address", binanceAddrs[0], sdk.AccAddress{}, kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash, timestampInt64, coinsSingle, 500, false},
+		{"normal cross-chain", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, true},
+		{"without other chain fields", binanceAddrs[0], kavaAddrs[0], "", "", randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
+		{"invalid amount", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, nil, 500, false},
+		{"invalid from address", sdk.AccAddress{}, kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
+		{"invalid from address", binanceAddrs[0], sdk.AccAddress{}, kavaAddrs[0].String(), binanceAddrs[0].String(), randomNumberHash.String(), timestampInt64, coinsSingle, 500, false},
+		{"invalid rand hash", binanceAddrs[0], kavaAddrs[0], kavaAddrs[0].String(), binanceAddrs[0].String(), "ff", timestampInt64, coinsSingle, 500, true},
 	}
 
 	for i, tc := range tests {
-		msg := types.NewMsgCreateAtomicSwap(
+		msg := types.MsgCreateAtomicSwap{
 			tc.from.String(),
 			tc.to.String(),
 			tc.recipientOtherChain,
@@ -75,7 +75,7 @@ func (suite *MsgTestSuite) TestMsgCreateAtomicSwap() {
 			tc.timestamp,
 			tc.amount,
 			tc.heightSpan,
-		)
+		}
 		if tc.expectPass {
 			suite.NoError(msg.ValidateBasic(), "test: %v", i)
 		} else {
@@ -136,4 +136,8 @@ func (suite *MsgTestSuite) TestMsgRefundAtomicSwap() {
 			suite.Error(msg.ValidateBasic(), "test: %v", i)
 		}
 	}
+}
+
+func TestMsgTestSuite(t *testing.T) {
+	suite.Run(t, new(MsgTestSuite))
 }


### PR DESCRIPTION
Bep3 msg validation did not check the byte length of the random number hash. Instead it was inspecting the encoded hex string.

This was missed eariler as the msg tests were not running.