### PR TITLE
Fix begin blocker / init genesis order

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -603,15 +603,15 @@ func NewApp(
 		minttypes.ModuleName,
 		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
-		evidencetypes.ModuleName, // TODO why new evidence and staking begin blockers?
+		evidencetypes.ModuleName,
 		stakingtypes.ModuleName,
 		kavadisttypes.ModuleName,
 		auctiontypes.ModuleName,
-		issuancetypes.ModuleName,
-		bep3types.ModuleName,
+		committeetypes.ModuleName, // TODO move to beginning?
 		cdptypes.ModuleName,
+		bep3types.ModuleName,
 		hardtypes.ModuleName,
-		committeetypes.ModuleName,
+		issuancetypes.ModuleName,
 		incentivetypes.ModuleName,
 		ibchost.ModuleName,
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -597,7 +597,11 @@ func NewApp(
 	app.mm.SetOrderBeginBlockers(
 		// Upgrade begin blocker runs migrations on the first block after an upgrade. It should run before any other module.
 		upgradetypes.ModuleName,
+		// Capability begin blocker runs non state changing initialization.
 		capabilitytypes.ModuleName,
+		// Committee begin blocker changes module params by enacting proposals.
+		// Run before to ensure params are updated together before state changes.
+		committeetypes.ModuleName,
 		minttypes.ModuleName,
 		distrtypes.ModuleName,
 		// During begin block slashing happens after distr.BeginBlocker so that
@@ -610,7 +614,6 @@ func NewApp(
 		// Auction begin blocker will close out expired auctions and pay debt back to cdp.
 		// It should be run before cdp begin blocker which cancels out debt with stable and starts more auctions.
 		auctiontypes.ModuleName,
-		committeetypes.ModuleName, // TODO move to beginning?
 		cdptypes.ModuleName,
 		bep3types.ModuleName,
 		hardtypes.ModuleName,

--- a/app/app.go
+++ b/app/app.go
@@ -592,7 +592,6 @@ func NewApp(
 		incentive.NewAppModule(app.incentiveKeeper, app.accountKeeper, app.bankKeeper, app.cdpKeeper),
 	)
 
-
 	// Warning: Some begin blockers must run before others. Ensure the dependencies are understood before modifying this list.
 	app.mm.SetOrderBeginBlockers(
 		// Upgrade begin blocker runs migrations on the first block after an upgrade. It should run before any other module.
@@ -631,31 +630,30 @@ func NewApp(
 	)
 
 	// Warning: Some init genesis methods must run before others. Ensure the dependencies are understood before modifying this list
-	app.mm.SetOrderInitGenesis( // TODO why the different order?
-		capabilitytypes.ModuleName, // initialize capabilities - run before any module creating or claiming capabilities in InitGenesis
-		authtypes.ModuleName,       // loads all accounts - run before any module with a module account
+	app.mm.SetOrderInitGenesis(
+		capabilitytypes.ModuleName, // initialize capabilities, run before any module creating or claiming capabilities in InitGenesis
+		authtypes.ModuleName,       // loads all accounts, run before any module with a module account
 		banktypes.ModuleName,
 		distrtypes.ModuleName,
 		stakingtypes.ModuleName,
-		slashingtypes.ModuleName,
+		slashingtypes.ModuleName, // iterates over validators, run after staking
 		govtypes.ModuleName,
 		minttypes.ModuleName,
 		ibchost.ModuleName,
-		genutiltypes.ModuleName, // genutils must occur after staking so that pools are properly initialized with tokens from genesis accounts.
 		evidencetypes.ModuleName,
 		ibctransfertypes.ModuleName,
-		auctiontypes.ModuleName,
 		kavadisttypes.ModuleName,
 		auctiontypes.ModuleName,
 		issuancetypes.ModuleName,
 		bep3types.ModuleName,
 		pricefeedtypes.ModuleName,
 		swaptypes.ModuleName,
-		cdptypes.ModuleName,
+		cdptypes.ModuleName, // reads market prices, so must run after pricefeed genesis
 		hardtypes.ModuleName,
-		incentivetypes.ModuleName,
+		incentivetypes.ModuleName, // reads cdp params, so must run after cdp genesis // TODO should genutil run after this?
 		committeetypes.ModuleName,
-		crisistypes.ModuleName, // runs the invariants at genesis - should run after other modules
+		genutiltypes.ModuleName, // runs arbitrary txs included in genisis state, so run after modules have been initialized
+		crisistypes.ModuleName,  // runs the invariants at genesis, should run after other modules
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)

--- a/app/app.go
+++ b/app/app.go
@@ -650,7 +650,7 @@ func NewApp(
 		swaptypes.ModuleName,
 		cdptypes.ModuleName, // reads market prices, so must run after pricefeed genesis
 		hardtypes.ModuleName,
-		incentivetypes.ModuleName, // reads cdp params, so must run after cdp genesis // TODO should genutil run after this?
+		incentivetypes.ModuleName, // reads cdp params, so must run after cdp genesis
 		committeetypes.ModuleName,
 		genutiltypes.ModuleName, // runs arbitrary txs included in genisis state, so run after modules have been initialized
 		crisistypes.ModuleName,  // runs the invariants at genesis, should run after other modules


### PR DESCRIPTION
This PR is the result of a mini audit of the begin/end blocker and init genesis orders.

main changes:

- changed the begin blocker order to match kava v0.15 to minimise likelihood of problems
- except I moved committee begin blocker to the start. It's easier to think about cross-module param changes when they don't happen in the middle of the begin blocker. Compared to v0.15 it only moves ahead of auction, and various sdk modules. We've never changed sdk or auction params with committee (afik) so it shouldn't change behaviour we currently rely on.
- added a warning about changing the order. There's unspecified dependencies between modules making it hard to see the consequences of changes. It would be nice if the dependencies were enforced by the code, but I can't think how to do this.
- remove duplicate auction init genesis
- move genutil to the end of genesis - it runs arbitrary txs stored in the genesis file, so modules should be initialized before they're run. The change should be irrelevant for mainnets, where gentxs are not used.