### PR TITLE
Resolve some v44 migration todos

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -15,6 +15,7 @@ import (
 	tmdb "github.com/tendermint/tm-db"
 
 	"github.com/kava-labs/kava/app"
+	bep3types "github.com/kava-labs/kava/x/bep3/types"
 	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 )
 
@@ -22,8 +23,8 @@ func TestAppAnteHandler(t *testing.T) {
 	testPrivKeys, testAddresses := app.GeneratePrivKeyAddressPairs(10)
 	unauthed := testAddresses[0:2]
 	unauthedKeys := testPrivKeys[0:2]
-	// deputy := testAddresses[2]
-	// deputyKey := testPrivKeys[2]
+	deputy := testAddresses[2]
+	deputyKey := testPrivKeys[2]
 	oracles := testAddresses[3:6]
 	oraclesKeys := testPrivKeys[3:6]
 	manual := testAddresses[6:]
@@ -53,8 +54,7 @@ func TestAppAnteHandler(t *testing.T) {
 			sdk.NewCoins(sdk.NewInt64Coin("ukava", 1e9)),
 			testAddresses,
 		),
-		// TODO see below
-		// newBep3GenStateMulti(tApp.AppCodec(), deputy),
+		newBep3GenStateMulti(tApp.AppCodec(), deputy),
 		newPricefeedGenStateMulti(tApp.AppCodec(), oracles),
 	)
 
@@ -76,13 +76,12 @@ func TestAppAnteHandler(t *testing.T) {
 			privKey:    oraclesKeys[1],
 			expectPass: true,
 		},
-		// TODO add back when the bep3 module is reinstantiated
-		// {
-		// 	name:       "deputy",
-		// 	address:    deputy,
-		// 	privKey:    deputyKey,
-		// 	expectPass: true,
-		// },
+		{
+			name:       "deputy",
+			address:    deputy,
+			privKey:    deputyKey,
+			expectPass: true,
+		},
 		{
 			name:       "manual",
 			address:    manual[1],
@@ -129,8 +128,6 @@ func TestAppAnteHandler(t *testing.T) {
 	}
 }
 
-// TODO Test pricefeed oracles and bep3 deputy txs can always get into the mempool.
-
 func newPricefeedGenStateMulti(cdc codec.JSONCodec, oracles []sdk.AccAddress) app.GenesisState {
 	pfGenesis := pricefeedtypes.GenesisState{
 		Params: pricefeedtypes.Params{
@@ -142,39 +139,39 @@ func newPricefeedGenStateMulti(cdc codec.JSONCodec, oracles []sdk.AccAddress) ap
 	return app.GenesisState{pricefeedtypes.ModuleName: cdc.MustMarshalJSON(&pfGenesis)}
 }
 
-// func newBep3GenStateMulti(cdc codec.JSONCodec, deputyAddress sdk.AccAddress) app.GenesisState {
-// 	bep3Genesis := bep3.GenesisState{
-// 		Params: bep3.Params{
-// 			AssetParams: bep3.AssetParams{
-// 				bep3.AssetParam{
-// 					Denom:  "bnb",
-// 					CoinID: 714,
-// 					SupplyLimit: bep3.SupplyLimit{
-// 						Limit:          sdk.NewInt(350000000000000),
-// 						TimeLimited:    false,
-// 						TimeBasedLimit: sdk.ZeroInt(),
-// 						TimePeriod:     time.Hour,
-// 					},
-// 					Active:        true,
-// 					DeputyAddress: deputyAddress,
-// 					FixedFee:      sdk.NewInt(1000),
-// 					MinSwapAmount: sdk.OneInt(),
-// 					MaxSwapAmount: sdk.NewInt(1000000000000),
-// 					MinBlockLock:  bep3.DefaultMinBlockLock,
-// 					MaxBlockLock:  bep3.DefaultMaxBlockLock,
-// 				},
-// 			},
-// 		},
-// 		Supplies: bep3.AssetSupplies{
-// 			bep3.NewAssetSupply(
-// 				sdk.NewCoin("bnb", sdk.ZeroInt()),
-// 				sdk.NewCoin("bnb", sdk.ZeroInt()),
-// 				sdk.NewCoin("bnb", sdk.ZeroInt()),
-// 				sdk.NewCoin("bnb", sdk.ZeroInt()),
-// 				time.Duration(0),
-// 			),
-// 		},
-// 		PreviousBlockTime: bep3.DefaultPreviousBlockTime,
-// 	}
-// 	return app.GenesisState{bep3.ModuleName: cdc.MustMarshalJSON(bep3Genesis)}
-// }
+func newBep3GenStateMulti(cdc codec.JSONCodec, deputyAddress sdk.AccAddress) app.GenesisState {
+	bep3Genesis := bep3types.GenesisState{
+		Params: bep3types.Params{
+			AssetParams: bep3types.AssetParams{
+				bep3types.AssetParam{
+					Denom:  "bnb",
+					CoinID: 714,
+					SupplyLimit: bep3types.SupplyLimit{
+						Limit:          sdk.NewInt(350000000000000),
+						TimeLimited:    false,
+						TimeBasedLimit: sdk.ZeroInt(),
+						TimePeriod:     time.Hour,
+					},
+					Active:        true,
+					DeputyAddress: deputyAddress,
+					FixedFee:      sdk.NewInt(1000),
+					MinSwapAmount: sdk.OneInt(),
+					MaxSwapAmount: sdk.NewInt(1000000000000),
+					MinBlockLock:  bep3types.DefaultMinBlockLock,
+					MaxBlockLock:  bep3types.DefaultMaxBlockLock,
+				},
+			},
+		},
+		Supplies: bep3types.AssetSupplies{
+			bep3types.NewAssetSupply(
+				sdk.NewCoin("bnb", sdk.ZeroInt()),
+				sdk.NewCoin("bnb", sdk.ZeroInt()),
+				sdk.NewCoin("bnb", sdk.ZeroInt()),
+				sdk.NewCoin("bnb", sdk.ZeroInt()),
+				time.Duration(0),
+			),
+		},
+		PreviousBlockTime: bep3types.DefaultPreviousBlockTime,
+	}
+	return app.GenesisState{bep3types.ModuleName: cdc.MustMarshalJSON(&bep3Genesis)}
+}

--- a/app/app.go
+++ b/app/app.go
@@ -421,7 +421,6 @@ func NewApp(
 		scopedIBCKeeper,
 	)
 
-	// TODO No evidence router is added so all submit evidence msgs will fail. Should there be a router added?
 	govRouter := govtypes.NewRouter()
 	govRouter.
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).

--- a/app/app.go
+++ b/app/app.go
@@ -733,8 +733,8 @@ func (app *App) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.Res
 		panic(err)
 	}
 
-	// TODO: upgrade keeper version map?
-	// app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+	app.upgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -677,7 +677,7 @@ func NewApp(
 	app.MountMemoryStores(memKeys)
 
 	// initialize the app
-	var fetchers []ante.AddressFetcher // TODO add bep3 authorized addresses
+	var fetchers []ante.AddressFetcher
 	if options.MempoolEnableAuth {
 		fetchers = append(fetchers,
 			func(sdk.Context) []sdk.AccAddress { return options.MempoolAuthAddresses },

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -6,8 +6,6 @@ import (
 	"github.com/kava-labs/kava/app/params"
 )
 
-// TODO why is this separate from params?
-
 // MakeEncodingConfig creates an EncodingConfig and registers the app's types on it.
 func MakeEncodingConfig() params.EncodingConfig {
 	encodingConfig := params.MakeEncodingConfig()

--- a/app/params/encoding.go
+++ b/app/params/encoding.go
@@ -16,7 +16,7 @@ type EncodingConfig struct {
 	Amino             *codec.LegacyAmino
 }
 
-// MakeEncodingConfig creates an EncodingConfig for an amino based test configuration. // TODO description
+// MakeEncodingConfig creates a new EncodingConfig.
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()

--- a/app/test_builder.go
+++ b/app/test_builder.go
@@ -110,16 +110,3 @@ func newPeriodicVestingAccount(address sdk.AccAddress, periods vestingtypes.Peri
 	baseVestingAccount := vestingtypes.NewBaseVestingAccount(baseAccount, originalVesting, endTime)
 	return vestingtypes.NewPeriodicVestingAccountRaw(baseVestingAccount, firstPeriodStartTimestamp, periods)
 }
-
-// TODO upgrade once validator vesting upgraded
-// // WithEmptyValidatorVestingAccount adds a stub validator vesting account to the genesis state.
-// func (builder AuthGenesisBuilder) WithEmptyValidatorVestingAccount(address sdk.AccAddress) AuthGenesisBuilder {
-// 	// TODO create a validator vesting account builder and remove this method
-// 	bacc := auth.NewBaseAccount(address, nil, nil, 0, 0)
-// 	bva, err := vesting.NewBaseVestingAccount(bacc, nil, 1)
-// 	if err != nil {
-// 		panic(err.Error())
-// 	}
-// 	account := validatorvesting.NewValidatorVestingAccountRaw(bva, 0, nil, sdk.ConsAddress{}, nil, 90)
-// 	return builder.WithAccounts(account)
-// }


### PR DESCRIPTION
Small PR to tidy up some of the TODOs hanging around app since the upgrade to v0.44.

I added the line to set upgrade version map. Not strictly needed, we only need the upgrade module to halt the chain when a software upgrade proposal passes, which it does. This version map just populates an upgrade grpc endpoint.