### PR TITLE
Make `grpc_query` and `msg_server` consistent across modules

### DIFF
--- a/x/auction/keeper/integration_test.go
+++ b/x/auction/keeper/integration_test.go
@@ -6,7 +6,6 @@ import (
 
 func c(denom string, amount int64) sdk.Coin { return sdk.NewInt64Coin(denom, amount) }
 func cs(coins ...sdk.Coin) sdk.Coins        { return sdk.NewCoins(coins...) }
-func i(n int64) sdk.Int                     { return sdk.NewInt(n) }
 func is(ns ...int64) (is []sdk.Int) {
 	for _, n := range ns {
 		is = append(is, sdk.NewInt(n))

--- a/x/auction/keeper/msg_server.go
+++ b/x/auction/keeper/msg_server.go
@@ -12,7 +12,7 @@ type msgServer struct {
 	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the auction MsgServer interface
 // for the provided Keeper.
 func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}

--- a/x/auction/module.go
+++ b/x/auction/module.go
@@ -133,7 +133,7 @@ func (AppModule) ConsensusVersion() uint64 {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // InitGenesis module init-genesis

--- a/x/bep3/keeper/msg_server.go
+++ b/x/bep3/keeper/msg_server.go
@@ -1,4 +1,4 @@
-package bep3
+package keeper
 
 import (
 	"context"
@@ -6,17 +6,16 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/kava-labs/kava/x/bep3/keeper"
 	"github.com/kava-labs/kava/x/bep3/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the swap MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 

--- a/x/bep3/keeper/msg_server.go
+++ b/x/bep3/keeper/msg_server.go
@@ -13,7 +13,7 @@ type msgServer struct {
 	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the bep3 MsgServer interface
 // for the provided Keeper.
 func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}

--- a/x/bep3/keeper/msg_server_test.go
+++ b/x/bep3/keeper/msg_server_test.go
@@ -1,4 +1,4 @@
-package bep3_test
+package keeper_test
 
 import (
 	"testing"
@@ -30,7 +30,6 @@ type MsgServerTestSuite struct {
 func (suite *MsgServerTestSuite) SetupTest() {
 	tApp := app.NewTestApp()
 	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
-	keeper := tApp.GetBep3Keeper()
 
 	cdc := tApp.AppCodec()
 
@@ -41,8 +40,8 @@ func (suite *MsgServerTestSuite) SetupTest() {
 	tApp.InitializeFromGenesisStates(authGS, NewBep3GenStateMulti(cdc, addrs[0]))
 
 	suite.addrs = addrs
-	suite.msgServer = bep3.NewMsgServerImpl(keeper)
-	suite.keeper = keeper
+	suite.keeper = tApp.GetBep3Keeper()
+	suite.msgServer = keeper.NewMsgServerImpl(suite.keeper)
 	suite.app = tApp
 	suite.ctx = ctx
 }

--- a/x/bep3/module.go
+++ b/x/bep3/module.go
@@ -135,7 +135,7 @@ func (AppModule) QuerierRoute() string {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 

--- a/x/bep3/module.go
+++ b/x/bep3/module.go
@@ -136,7 +136,7 @@ func (AppModule) QuerierRoute() string {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // InitGenesis performs genesis initialization for the bep3 module. It returns

--- a/x/cdp/keeper/msg_server.go
+++ b/x/cdp/keeper/msg_server.go
@@ -11,7 +11,7 @@ type msgServer struct {
 	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the cdp MsgServer interface
 // for the provided Keeper.
 func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}

--- a/x/cdp/keeper/msg_server.go
+++ b/x/cdp/keeper/msg_server.go
@@ -1,35 +1,63 @@
-package hard
+package keeper
 
 import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/kava-labs/kava/x/hard/keeper"
-	"github.com/kava-labs/kava/x/hard/types"
+	"github.com/kava-labs/kava/x/cdp/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the swap MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 
 var _ types.MsgServer = msgServer{}
 
+func (k msgServer) CreateCDP(goCtx context.Context, msg *types.MsgCreateCDP) (*types.MsgCreateCDPResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	err = k.keeper.AddCdp(ctx, sender, msg.Collateral, msg.Principal, msg.CollateralType)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	)
+
+	id, _ := k.keeper.GetCdpID(ctx, sender, msg.CollateralType)
+	return &types.MsgCreateCDPResponse{CdpID: id}, nil
+}
+
 func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types.MsgDepositResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	owner, err := sdk.AccAddressFromBech32(msg.Owner)
+	if err != nil {
+		return nil, err
+	}
 
 	depositor, err := sdk.AccAddressFromBech32(msg.Depositor)
 	if err != nil {
 		return nil, err
 	}
 
-	err = k.keeper.Deposit(ctx, depositor, msg.Amount)
+	err = k.keeper.DepositCollateral(ctx, owner, depositor, msg.Collateral, msg.CollateralType)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +75,17 @@ func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types
 func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*types.MsgWithdrawResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	owner, err := sdk.AccAddressFromBech32(msg.Owner)
+	if err != nil {
+		return nil, err
+	}
+
 	depositor, err := sdk.AccAddressFromBech32(msg.Depositor)
 	if err != nil {
 		return nil, err
 	}
 
-	err = k.keeper.Withdraw(ctx, depositor, msg.Amount)
+	err = k.keeper.WithdrawCollateral(ctx, owner, depositor, msg.Collateral, msg.CollateralType)
 	if err != nil {
 		return nil, err
 	}
@@ -67,30 +100,7 @@ func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*typ
 	return &types.MsgWithdrawResponse{}, nil
 }
 
-func (k msgServer) Borrow(goCtx context.Context, msg *types.MsgBorrow) (*types.MsgBorrowResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	borrower, err := sdk.AccAddressFromBech32(msg.Borrower)
-	if err != nil {
-		return nil, err
-	}
-
-	err = k.keeper.Borrow(ctx, borrower, msg.Amount)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Borrower),
-		),
-	)
-	return &types.MsgBorrowResponse{}, nil
-}
-
-func (k msgServer) Repay(goCtx context.Context, msg *types.MsgRepay) (*types.MsgRepayResponse, error) {
+func (k msgServer) DrawDebt(goCtx context.Context, msg *types.MsgDrawDebt) (*types.MsgDrawDebtResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
@@ -98,12 +108,7 @@ func (k msgServer) Repay(goCtx context.Context, msg *types.MsgRepay) (*types.Msg
 		return nil, err
 	}
 
-	owner, err := sdk.AccAddressFromBech32(msg.Owner)
-	if err != nil {
-		return nil, err
-	}
-
-	err = k.keeper.Repay(ctx, sender, owner, msg.Amount)
+	err = k.keeper.AddPrincipal(ctx, sender, msg.CollateralType, msg.Principal)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +120,30 @@ func (k msgServer) Repay(goCtx context.Context, msg *types.MsgRepay) (*types.Msg
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
 		),
 	)
-	return &types.MsgRepayResponse{}, nil
+	return &types.MsgDrawDebtResponse{}, nil
+}
+
+func (k msgServer) RepayDebt(goCtx context.Context, msg *types.MsgRepayDebt) (*types.MsgRepayDebtResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return nil, err
+	}
+
+	err = k.keeper.RepayPrincipal(ctx, sender, msg.CollateralType, msg.Payment)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+		),
+	)
+	return &types.MsgRepayDebtResponse{}, nil
 }
 
 func (k msgServer) Liquidate(goCtx context.Context, msg *types.MsgLiquidate) (*types.MsgLiquidateResponse, error) {
@@ -131,7 +159,7 @@ func (k msgServer) Liquidate(goCtx context.Context, msg *types.MsgLiquidate) (*t
 		return nil, err
 	}
 
-	err = k.keeper.AttemptKeeperLiquidation(ctx, keeper, borrower)
+	err = k.keeper.AttemptKeeperLiquidation(ctx, keeper, borrower, msg.CollateralType)
 	if err != nil {
 		return nil, err
 	}

--- a/x/cdp/module.go
+++ b/x/cdp/module.go
@@ -138,7 +138,7 @@ func (AppModule) QuerierRoute() string {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 

--- a/x/committee/keeper/msg_server.go
+++ b/x/committee/keeper/msg_server.go
@@ -1,21 +1,20 @@
-package committee
+package keeper
 
 import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/kava-labs/kava/x/committee/keeper"
 	"github.com/kava-labs/kava/x/committee/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the committee MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 

--- a/x/committee/keeper/msg_server_test.go
+++ b/x/committee/keeper/msg_server_test.go
@@ -1,4 +1,4 @@
-package committee_test
+package keeper_test
 
 import (
 	"testing"
@@ -9,29 +9,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	proposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"github.com/gogo/protobuf/proto"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/committee"
 	"github.com/kava-labs/kava/x/committee/keeper"
 	"github.com/kava-labs/kava/x/committee/types"
 	swaptypes "github.com/kava-labs/kava/x/swap/types"
 )
-
-var _ types.PubProposal = &UnregisteredPubProposal{}
-
-// UnregisteredPubProposal is a pubproposal type that is not registered on the amino codec.
-type UnregisteredPubProposal struct {
-	proto.Message
-}
-
-func (*UnregisteredPubProposal) GetTitle() string       { return "unregistered" }
-func (*UnregisteredPubProposal) GetDescription() string { return "unregistered" }
-func (*UnregisteredPubProposal) ProposalRoute() string  { return "unregistered" }
-func (*UnregisteredPubProposal) ProposalType() string   { return "unregistered" }
-func (*UnregisteredPubProposal) ValidateBasic() error   { return nil }
-func (*UnregisteredPubProposal) String() string         { return "unregistered" }
 
 //NewDistributionGenesisWithPool creates a default distribution genesis state with some coins in the community pool.
 //func NewDistributionGenesisWithPool(communityPoolCoins sdk.Coins) app.GenesisState {
@@ -56,7 +40,7 @@ func (suite *MsgServerTestSuite) SetupTest() {
 	_, suite.addresses = app.GeneratePrivKeyAddressPairs(5)
 	suite.app = app.NewTestApp()
 	suite.keeper = suite.app.GetCommitteeKeeper()
-	suite.msgServer = committee.NewMsgServerImpl(suite.keeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.keeper)
 	encodingCfg := app.MakeEncodingConfig()
 	cdc := encodingCfg.Marshaler
 

--- a/x/committee/module.go
+++ b/x/committee/module.go
@@ -126,7 +126,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryHandler(&am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // RegisterInvariants registers committee module's invariants.

--- a/x/committee/module.go
+++ b/x/committee/module.go
@@ -125,7 +125,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 

--- a/x/committee/testutil/suite.go
+++ b/x/committee/testutil/suite.go
@@ -36,7 +36,7 @@ func (suite *Suite) SetupTest() {
 
 	// Set query client
 	queryHelper := suite.App.NewQueryServerTestHelper(suite.Ctx)
-	queryHandler := keeper.NewQueryHandler(&suite.Keeper)
+	queryHandler := keeper.NewQueryServerImpl(suite.Keeper)
 	types.RegisterQueryServer(queryHelper, queryHandler)
 	suite.QueryClient = types.NewQueryClient(queryHelper)
 }

--- a/x/hard/keeper/grpc_query.go
+++ b/x/hard/keeper/grpc_query.go
@@ -20,8 +20,7 @@ type queryServer struct {
 	bankKeeper    types.BankKeeper
 }
 
-// NewQueryServerImpl returns an implementation of the hard QueryServer
-// interface for the provided Keeper.
+// NewQueryServerImpl creates a new server for handling gRPC queries.
 func NewQueryServerImpl(keeper Keeper, ak types.AccountKeeper, bk types.BankKeeper) types.QueryServer {
 	return &queryServer{
 		keeper:        keeper,

--- a/x/hard/keeper/grpc_query.go
+++ b/x/hard/keeper/grpc_query.go
@@ -1,4 +1,4 @@
-package hard
+package keeper
 
 import (
 	"context"
@@ -11,29 +11,28 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/kava-labs/kava/x/hard/keeper"
 	"github.com/kava-labs/kava/x/hard/types"
 )
 
-type QueryServer struct {
-	keeper        keeper.Keeper
+type queryServer struct {
+	keeper        Keeper
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
 }
 
-// NewQueryServer returns an implementation of the hard MsgServer interface
-// for the provided Keeper.
-func NewQueryServerImpl(keeper keeper.Keeper, ak types.AccountKeeper, bk types.BankKeeper) types.QueryServer {
-	return &QueryServer{
+// NewQueryServerImpl returns an implementation of the hard QueryServer
+// interface for the provided Keeper.
+func NewQueryServerImpl(keeper Keeper, ak types.AccountKeeper, bk types.BankKeeper) types.QueryServer {
+	return &queryServer{
 		keeper:        keeper,
 		accountKeeper: ak,
 		bankKeeper:    bk,
 	}
 }
 
-var _ types.QueryServer = QueryServer{}
+var _ types.QueryServer = queryServer{}
 
-func (qs QueryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (s queryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -41,21 +40,21 @@ func (qs QueryServer) Params(ctx context.Context, req *types.QueryParamsRequest)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// Get params
-	params := qs.keeper.GetParams(sdkCtx)
+	params := s.keeper.GetParams(sdkCtx)
 
 	return &types.QueryParamsResponse{
 		Params: params,
 	}, nil
 }
 
-func (qs QueryServer) Accounts(ctx context.Context, req *types.QueryAccountsRequest) (*types.QueryAccountsResponse, error) {
+func (s queryServer) Accounts(ctx context.Context, req *types.QueryAccountsRequest) (*types.QueryAccountsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	macc := qs.accountKeeper.GetModuleAccount(sdkCtx, types.ModuleAccountName)
+	macc := s.accountKeeper.GetModuleAccount(sdkCtx, types.ModuleAccountName)
 
 	accounts := []authtypes.ModuleAccount{
 		*macc.(*authtypes.ModuleAccount),
@@ -66,7 +65,7 @@ func (qs QueryServer) Accounts(ctx context.Context, req *types.QueryAccountsRequ
 	}, nil
 }
 
-func (qs QueryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequest) (*types.QueryDepositsResponse, error) {
+func (s queryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequest) (*types.QueryDepositsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -88,7 +87,7 @@ func (qs QueryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequ
 	var deposits types.Deposits
 	switch {
 	case hasOwner && hasDenom:
-		deposit, found := qs.keeper.GetSyncedDeposit(sdkCtx, owner)
+		deposit, found := s.keeper.GetSyncedDeposit(sdkCtx, owner)
 		if found {
 			for _, coin := range deposit.Amount {
 				if coin.Denom == req.Denom {
@@ -97,19 +96,19 @@ func (qs QueryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequ
 			}
 		}
 	case hasOwner:
-		deposit, found := qs.keeper.GetSyncedDeposit(sdkCtx, owner)
+		deposit, found := s.keeper.GetSyncedDeposit(sdkCtx, owner)
 		if found {
 			deposits = append(deposits, deposit)
 		}
 	case hasDenom:
-		qs.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
+		s.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
 			if deposit.Amount.AmountOf(req.Denom).IsPositive() {
 				deposits = append(deposits, deposit)
 			}
 			return false
 		})
 	default:
-		qs.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
+		s.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
 			deposits = append(deposits, deposit)
 			return false
 		})
@@ -126,7 +125,7 @@ func (qs QueryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequ
 	// Otherwise we need to simulate syncing of each deposit
 	var syncedDeposits types.Deposits
 	for _, deposit := range deposits {
-		syncedDeposit, _ := qs.keeper.GetSyncedDeposit(sdkCtx, deposit.Depositor)
+		syncedDeposit, _ := s.keeper.GetSyncedDeposit(sdkCtx, deposit.Depositor)
 		syncedDeposits = append(syncedDeposits, syncedDeposit)
 	}
 
@@ -151,7 +150,7 @@ func (qs QueryServer) Deposits(ctx context.Context, req *types.QueryDepositsRequ
 	}, nil
 }
 
-func (qs QueryServer) UnsyncedDeposits(ctx context.Context, req *types.QueryUnsyncedDepositsRequest) (*types.QueryUnsyncedDepositsResponse, error) {
+func (s queryServer) UnsyncedDeposits(ctx context.Context, req *types.QueryUnsyncedDepositsRequest) (*types.QueryUnsyncedDepositsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -173,7 +172,7 @@ func (qs QueryServer) UnsyncedDeposits(ctx context.Context, req *types.QueryUnsy
 	var deposits types.Deposits
 	switch {
 	case hasOwner && hasDenom:
-		deposit, found := qs.keeper.GetDeposit(sdkCtx, owner)
+		deposit, found := s.keeper.GetDeposit(sdkCtx, owner)
 		if found {
 			for _, coin := range deposit.Amount {
 				if coin.Denom == req.Denom {
@@ -182,19 +181,19 @@ func (qs QueryServer) UnsyncedDeposits(ctx context.Context, req *types.QueryUnsy
 			}
 		}
 	case hasOwner:
-		deposit, found := qs.keeper.GetDeposit(sdkCtx, owner)
+		deposit, found := s.keeper.GetDeposit(sdkCtx, owner)
 		if found {
 			deposits = append(deposits, deposit)
 		}
 	case hasDenom:
-		qs.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
+		s.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
 			if deposit.Amount.AmountOf(req.Denom).IsPositive() {
 				deposits = append(deposits, deposit)
 			}
 			return false
 		})
 	default:
-		qs.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
+		s.keeper.IterateDeposits(sdkCtx, func(deposit types.Deposit) (stop bool) {
 			deposits = append(deposits, deposit)
 			return false
 		})
@@ -218,7 +217,7 @@ func (qs QueryServer) UnsyncedDeposits(ctx context.Context, req *types.QueryUnsy
 	}, nil
 }
 
-func (qs QueryServer) Borrows(ctx context.Context, req *types.QueryBorrowsRequest) (*types.QueryBorrowsResponse, error) {
+func (s queryServer) Borrows(ctx context.Context, req *types.QueryBorrowsRequest) (*types.QueryBorrowsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -240,7 +239,7 @@ func (qs QueryServer) Borrows(ctx context.Context, req *types.QueryBorrowsReques
 	var borrows types.Borrows
 	switch {
 	case hasOwner && hasDenom:
-		borrow, found := qs.keeper.GetSyncedBorrow(sdkCtx, owner)
+		borrow, found := s.keeper.GetSyncedBorrow(sdkCtx, owner)
 		if found {
 			for _, coin := range borrow.Amount {
 				if coin.Denom == req.Denom {
@@ -249,19 +248,19 @@ func (qs QueryServer) Borrows(ctx context.Context, req *types.QueryBorrowsReques
 			}
 		}
 	case hasOwner:
-		borrow, found := qs.keeper.GetSyncedBorrow(sdkCtx, owner)
+		borrow, found := s.keeper.GetSyncedBorrow(sdkCtx, owner)
 		if found {
 			borrows = append(borrows, borrow)
 		}
 	case hasDenom:
-		qs.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
+		s.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
 			if borrow.Amount.AmountOf(req.Denom).IsPositive() {
 				borrows = append(borrows, borrow)
 			}
 			return false
 		})
 	default:
-		qs.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
+		s.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
 			borrows = append(borrows, borrow)
 			return false
 		})
@@ -278,7 +277,7 @@ func (qs QueryServer) Borrows(ctx context.Context, req *types.QueryBorrowsReques
 	// Otherwise we need to simulate syncing of each borrow
 	var syncedBorrows types.Borrows
 	for _, borrow := range borrows {
-		syncedBorrow, _ := qs.keeper.GetSyncedBorrow(sdkCtx, borrow.Borrower)
+		syncedBorrow, _ := s.keeper.GetSyncedBorrow(sdkCtx, borrow.Borrower)
 		syncedBorrows = append(syncedBorrows, syncedBorrow)
 	}
 
@@ -299,7 +298,7 @@ func (qs QueryServer) Borrows(ctx context.Context, req *types.QueryBorrowsReques
 	}, nil
 }
 
-func (qs QueryServer) UnsyncedBorrows(ctx context.Context, req *types.QueryUnsyncedBorrowsRequest) (*types.QueryUnsyncedBorrowsResponse, error) {
+func (s queryServer) UnsyncedBorrows(ctx context.Context, req *types.QueryUnsyncedBorrowsRequest) (*types.QueryUnsyncedBorrowsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -321,7 +320,7 @@ func (qs QueryServer) UnsyncedBorrows(ctx context.Context, req *types.QueryUnsyn
 	var borrows types.Borrows
 	switch {
 	case hasOwner && hasDenom:
-		borrow, found := qs.keeper.GetBorrow(sdkCtx, owner)
+		borrow, found := s.keeper.GetBorrow(sdkCtx, owner)
 		if found {
 			for _, coin := range borrow.Amount {
 				if coin.Denom == req.Denom {
@@ -330,19 +329,19 @@ func (qs QueryServer) UnsyncedBorrows(ctx context.Context, req *types.QueryUnsyn
 			}
 		}
 	case hasOwner:
-		borrow, found := qs.keeper.GetBorrow(sdkCtx, owner)
+		borrow, found := s.keeper.GetBorrow(sdkCtx, owner)
 		if found {
 			borrows = append(borrows, borrow)
 		}
 	case hasDenom:
-		qs.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
+		s.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
 			if borrow.Amount.AmountOf(req.Denom).IsPositive() {
 				borrows = append(borrows, borrow)
 			}
 			return false
 		})
 	default:
-		qs.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
+		s.keeper.IterateBorrows(sdkCtx, func(borrow types.Borrow) (stop bool) {
 			borrows = append(borrows, borrow)
 			return false
 		})
@@ -366,14 +365,14 @@ func (qs QueryServer) UnsyncedBorrows(ctx context.Context, req *types.QueryUnsyn
 	}, nil
 }
 
-func (qs QueryServer) TotalBorrowed(ctx context.Context, req *types.QueryTotalBorrowedRequest) (*types.QueryTotalBorrowedResponse, error) {
+func (s queryServer) TotalBorrowed(ctx context.Context, req *types.QueryTotalBorrowedRequest) (*types.QueryTotalBorrowedResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	borrowedCoins, found := qs.keeper.GetBorrowedCoins(sdkCtx)
+	borrowedCoins, found := s.keeper.GetBorrowedCoins(sdkCtx)
 	if !found {
 		return nil, types.ErrBorrowedCoinsNotFound
 	}
@@ -388,14 +387,14 @@ func (qs QueryServer) TotalBorrowed(ctx context.Context, req *types.QueryTotalBo
 	}, nil
 }
 
-func (qs QueryServer) TotalDeposited(ctx context.Context, req *types.QueryTotalDepositedRequest) (*types.QueryTotalDepositedResponse, error) {
+func (s queryServer) TotalDeposited(ctx context.Context, req *types.QueryTotalDepositedRequest) (*types.QueryTotalDepositedResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	suppliedCoins, found := qs.keeper.GetSuppliedCoins(sdkCtx)
+	suppliedCoins, found := s.keeper.GetSuppliedCoins(sdkCtx)
 	if !found {
 		return nil, types.ErrSuppliedCoinsNotFound
 	}
@@ -410,7 +409,7 @@ func (qs QueryServer) TotalDeposited(ctx context.Context, req *types.QueryTotalD
 	}, nil
 }
 
-func (qs QueryServer) InterestRate(ctx context.Context, req *types.QueryInterestRateRequest) (*types.QueryInterestRateResponse, error) {
+func (s queryServer) InterestRate(ctx context.Context, req *types.QueryInterestRateRequest) (*types.QueryInterestRateResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -420,39 +419,39 @@ func (qs QueryServer) InterestRate(ctx context.Context, req *types.QueryInterest
 	var moneyMarketInterestRates types.MoneyMarketInterestRates
 	var moneyMarkets types.MoneyMarkets
 	if len(req.Denom) > 0 {
-		moneyMarket, found := qs.keeper.GetMoneyMarket(sdkCtx, req.Denom)
+		moneyMarket, found := s.keeper.GetMoneyMarket(sdkCtx, req.Denom)
 		if !found {
 			return nil, types.ErrMoneyMarketNotFound
 		}
 		moneyMarkets = append(moneyMarkets, moneyMarket)
 	} else {
-		moneyMarkets = qs.keeper.GetAllMoneyMarkets(sdkCtx)
+		moneyMarkets = s.keeper.GetAllMoneyMarkets(sdkCtx)
 	}
 
 	// Calculate the borrow and supply APY interest rates for each money market
 	for _, moneyMarket := range moneyMarkets {
 		denom := moneyMarket.Denom
-		macc := qs.accountKeeper.GetModuleAccount(sdkCtx, types.ModuleName)
-		cash := qs.bankKeeper.GetBalance(sdkCtx, macc.GetAddress(), denom).Amount
+		macc := s.accountKeeper.GetModuleAccount(sdkCtx, types.ModuleName)
+		cash := s.bankKeeper.GetBalance(sdkCtx, macc.GetAddress(), denom).Amount
 
 		borrowed := sdk.NewCoin(denom, sdk.ZeroInt())
-		borrowedCoins, foundBorrowedCoins := qs.keeper.GetBorrowedCoins(sdkCtx)
+		borrowedCoins, foundBorrowedCoins := s.keeper.GetBorrowedCoins(sdkCtx)
 		if foundBorrowedCoins {
 			borrowed = sdk.NewCoin(denom, borrowedCoins.AmountOf(denom))
 		}
 
-		reserves, foundReserves := qs.keeper.GetTotalReserves(sdkCtx)
+		reserves, foundReserves := s.keeper.GetTotalReserves(sdkCtx)
 		if !foundReserves {
 			reserves = sdk.NewCoins()
 		}
 
 		// CalculateBorrowRate calculates the current interest rate based on utilization (the fraction of supply that has ien borrowed)
-		borrowAPY, err := keeper.CalculateBorrowRate(moneyMarket.InterestRateModel, sdk.NewDecFromInt(cash), sdk.NewDecFromInt(borrowed.Amount), sdk.NewDecFromInt(reserves.AmountOf(denom)))
+		borrowAPY, err := CalculateBorrowRate(moneyMarket.InterestRateModel, sdk.NewDecFromInt(cash), sdk.NewDecFromInt(borrowed.Amount), sdk.NewDecFromInt(reserves.AmountOf(denom)))
 		if err != nil {
 			return nil, err
 		}
 
-		utilRatio := keeper.CalculateUtilizationRatio(sdk.NewDecFromInt(cash), sdk.NewDecFromInt(borrowed.Amount), sdk.NewDecFromInt(reserves.AmountOf(denom)))
+		utilRatio := CalculateUtilizationRatio(sdk.NewDecFromInt(cash), sdk.NewDecFromInt(borrowed.Amount), sdk.NewDecFromInt(reserves.AmountOf(denom)))
 		fullSupplyAPY := borrowAPY.Mul(utilRatio)
 		realSupplyAPY := fullSupplyAPY.Mul(sdk.OneDec().Sub(moneyMarket.ReserveFactor))
 
@@ -470,14 +469,14 @@ func (qs QueryServer) InterestRate(ctx context.Context, req *types.QueryInterest
 	}, nil
 }
 
-func (qs QueryServer) Reserves(ctx context.Context, req *types.QueryReservesRequest) (*types.QueryReservesResponse, error) {
+func (s queryServer) Reserves(ctx context.Context, req *types.QueryReservesRequest) (*types.QueryReservesResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
-	reserveCoins, found := qs.keeper.GetTotalReserves(sdkCtx)
+	reserveCoins, found := s.keeper.GetTotalReserves(sdkCtx)
 	if !found {
 		reserveCoins = sdk.Coins{}
 	}
@@ -492,7 +491,7 @@ func (qs QueryServer) Reserves(ctx context.Context, req *types.QueryReservesRequ
 	}, nil
 }
 
-func (qs QueryServer) InterestFactors(ctx context.Context, req *types.QueryInterestFactorsRequest) (*types.QueryInterestFactorsResponse, error) {
+func (s queryServer) InterestFactors(ctx context.Context, req *types.QueryInterestFactorsRequest) (*types.QueryInterestFactorsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
@@ -504,11 +503,11 @@ func (qs QueryServer) InterestFactors(ctx context.Context, req *types.QueryInter
 		// Fetch supply/borrow interest factors for a single denom
 		interestFactor := types.InterestFactor{}
 		interestFactor.Denom = req.Denom
-		supplyInterestFactor, found := qs.keeper.GetSupplyInterestFactor(sdkCtx, req.Denom)
+		supplyInterestFactor, found := s.keeper.GetSupplyInterestFactor(sdkCtx, req.Denom)
 		if found {
 			interestFactor.SupplyInterestFactor = supplyInterestFactor.String()
 		}
-		borrowInterestFactor, found := qs.keeper.GetBorrowInterestFactor(sdkCtx, req.Denom)
+		borrowInterestFactor, found := s.keeper.GetBorrowInterestFactor(sdkCtx, req.Denom)
 		if found {
 			interestFactor.BorrowInterestFactor = borrowInterestFactor.String()
 		}
@@ -516,13 +515,13 @@ func (qs QueryServer) InterestFactors(ctx context.Context, req *types.QueryInter
 	} else {
 		interestFactorMap := make(map[string]types.InterestFactor)
 		// Populate mapping with supply interest factors
-		qs.keeper.IterateSupplyInterestFactors(sdkCtx, func(denom string, factor sdk.Dec) (stop bool) {
+		s.keeper.IterateSupplyInterestFactors(sdkCtx, func(denom string, factor sdk.Dec) (stop bool) {
 			interestFactor := types.InterestFactor{Denom: denom, SupplyInterestFactor: factor.String()}
 			interestFactorMap[denom] = interestFactor
 			return false
 		})
 		// Populate mapping with borrow interest factors
-		qs.keeper.IterateBorrowInterestFactors(sdkCtx, func(denom string, factor sdk.Dec) (stop bool) {
+		s.keeper.IterateBorrowInterestFactors(sdkCtx, func(denom string, factor sdk.Dec) (stop bool) {
 			interestFactor, ok := interestFactorMap[denom]
 			if !ok {
 				newInterestFactor := types.InterestFactor{Denom: denom, BorrowInterestFactor: factor.String()}

--- a/x/hard/keeper/grpc_query_test.go
+++ b/x/hard/keeper/grpc_query_test.go
@@ -1,4 +1,4 @@
-package hard_test
+package keeper_test
 
 import (
 	"testing"
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/hard"
 	"github.com/kava-labs/kava/x/hard/keeper"
 	"github.com/kava-labs/kava/x/hard/types"
 	"github.com/stretchr/testify/suite"
@@ -32,7 +31,7 @@ func (suite *grpcQueryTestSuite) SetupTest() {
 	suite.ctx = suite.tApp.NewContext(true, tmprototypes.Header{}).
 		WithBlockTime(time.Now().UTC())
 	suite.keeper = suite.tApp.GetHardKeeper()
-	suite.queryServer = hard.NewQueryServerImpl(suite.keeper, suite.tApp.GetAccountKeeper(), suite.tApp.GetBankKeeper())
+	suite.queryServer = keeper.NewQueryServerImpl(suite.keeper, suite.tApp.GetAccountKeeper(), suite.tApp.GetBankKeeper())
 
 	err := suite.tApp.FundModuleAccount(
 		suite.ctx,

--- a/x/hard/keeper/integration_test.go
+++ b/x/hard/keeper/integration_test.go
@@ -1,4 +1,4 @@
-package hard_test
+package keeper_test
 
 import (
 	"time"
@@ -9,10 +9,6 @@ import (
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/hard/types"
 	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
-)
-
-const (
-	USDX_CF = 1000000
 )
 
 func NewHARDGenState(cdc codec.JSONCodec) app.GenesisState {
@@ -126,6 +122,3 @@ func NewPricefeedGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 	}
 	return app.GenesisState{pricefeedtypes.ModuleName: cdc.MustMarshalJSON(&pfGenesis)}
 }
-
-func c(denom string, amount int64) sdk.Coin { return sdk.NewInt64Coin(denom, amount) }
-func cs(coins ...sdk.Coin) sdk.Coins        { return sdk.NewCoins(coins...) }

--- a/x/hard/keeper/msg_server.go
+++ b/x/hard/keeper/msg_server.go
@@ -12,7 +12,7 @@ type msgServer struct {
 	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the hard MsgServer interface
 // for the provided Keeper.
 func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}

--- a/x/hard/keeper/msg_server.go
+++ b/x/hard/keeper/msg_server.go
@@ -1,64 +1,34 @@
-package cdp
+package keeper
 
 import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/kava-labs/kava/x/cdp/keeper"
-	"github.com/kava-labs/kava/x/cdp/types"
+
+	"github.com/kava-labs/kava/x/hard/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the swap MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 
 var _ types.MsgServer = msgServer{}
 
-func (k msgServer) CreateCDP(goCtx context.Context, msg *types.MsgCreateCDP) (*types.MsgCreateCDPResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	sender, err := sdk.AccAddressFromBech32(msg.Sender)
-	if err != nil {
-		return nil, err
-	}
-
-	err = k.keeper.AddCdp(ctx, sender, msg.Collateral, msg.Principal, msg.CollateralType)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-	)
-
-	id, _ := k.keeper.GetCdpID(ctx, sender, msg.CollateralType)
-	return &types.MsgCreateCDPResponse{CdpID: id}, nil
-}
-
 func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types.MsgDepositResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	owner, err := sdk.AccAddressFromBech32(msg.Owner)
-	if err != nil {
-		return nil, err
-	}
 
 	depositor, err := sdk.AccAddressFromBech32(msg.Depositor)
 	if err != nil {
 		return nil, err
 	}
 
-	err = k.keeper.DepositCollateral(ctx, owner, depositor, msg.Collateral, msg.CollateralType)
+	err = k.keeper.Deposit(ctx, depositor, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -76,17 +46,12 @@ func (k msgServer) Deposit(goCtx context.Context, msg *types.MsgDeposit) (*types
 func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*types.MsgWithdrawResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	owner, err := sdk.AccAddressFromBech32(msg.Owner)
-	if err != nil {
-		return nil, err
-	}
-
 	depositor, err := sdk.AccAddressFromBech32(msg.Depositor)
 	if err != nil {
 		return nil, err
 	}
 
-	err = k.keeper.WithdrawCollateral(ctx, owner, depositor, msg.Collateral, msg.CollateralType)
+	err = k.keeper.Withdraw(ctx, depositor, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -101,15 +66,15 @@ func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*typ
 	return &types.MsgWithdrawResponse{}, nil
 }
 
-func (k msgServer) DrawDebt(goCtx context.Context, msg *types.MsgDrawDebt) (*types.MsgDrawDebtResponse, error) {
+func (k msgServer) Borrow(goCtx context.Context, msg *types.MsgBorrow) (*types.MsgBorrowResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	borrower, err := sdk.AccAddressFromBech32(msg.Borrower)
 	if err != nil {
 		return nil, err
 	}
 
-	err = k.keeper.AddPrincipal(ctx, sender, msg.CollateralType, msg.Principal)
+	err = k.keeper.Borrow(ctx, borrower, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -118,13 +83,13 @@ func (k msgServer) DrawDebt(goCtx context.Context, msg *types.MsgDrawDebt) (*typ
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
+			sdk.NewAttribute(sdk.AttributeKeySender, msg.Borrower),
 		),
 	)
-	return &types.MsgDrawDebtResponse{}, nil
+	return &types.MsgBorrowResponse{}, nil
 }
 
-func (k msgServer) RepayDebt(goCtx context.Context, msg *types.MsgRepayDebt) (*types.MsgRepayDebtResponse, error) {
+func (k msgServer) Repay(goCtx context.Context, msg *types.MsgRepay) (*types.MsgRepayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	sender, err := sdk.AccAddressFromBech32(msg.Sender)
@@ -132,7 +97,12 @@ func (k msgServer) RepayDebt(goCtx context.Context, msg *types.MsgRepayDebt) (*t
 		return nil, err
 	}
 
-	err = k.keeper.RepayPrincipal(ctx, sender, msg.CollateralType, msg.Payment)
+	owner, err := sdk.AccAddressFromBech32(msg.Owner)
+	if err != nil {
+		return nil, err
+	}
+
+	err = k.keeper.Repay(ctx, sender, owner, msg.Amount)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +114,7 @@ func (k msgServer) RepayDebt(goCtx context.Context, msg *types.MsgRepayDebt) (*t
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
 		),
 	)
-	return &types.MsgRepayDebtResponse{}, nil
+	return &types.MsgRepayResponse{}, nil
 }
 
 func (k msgServer) Liquidate(goCtx context.Context, msg *types.MsgLiquidate) (*types.MsgLiquidateResponse, error) {
@@ -160,7 +130,7 @@ func (k msgServer) Liquidate(goCtx context.Context, msg *types.MsgLiquidate) (*t
 		return nil, err
 	}
 
-	err = k.keeper.AttemptKeeperLiquidation(ctx, keeper, borrower, msg.CollateralType)
+	err = k.keeper.AttemptKeeperLiquidation(ctx, keeper, borrower)
 	if err != nil {
 		return nil, err
 	}

--- a/x/hard/module.go
+++ b/x/hard/module.go
@@ -138,7 +138,7 @@ func (AppModule) QuerierRoute() string {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
 }
 

--- a/x/hard/module.go
+++ b/x/hard/module.go
@@ -139,7 +139,7 @@ func (AppModule) QuerierRoute() string {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
 }
 
 // InitGenesis performs genesis initialization for the hard module. It returns

--- a/x/incentive/testutil/integration.go
+++ b/x/incentive/testutil/integration.go
@@ -17,15 +17,15 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/cdp"
+	cdpkeeper "github.com/kava-labs/kava/x/cdp/keeper"
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
-	"github.com/kava-labs/kava/x/committee"
+	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
 	committeetypes "github.com/kava-labs/kava/x/committee/types"
-	"github.com/kava-labs/kava/x/hard"
+	hardkeeper "github.com/kava-labs/kava/x/hard/keeper"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 	incentivekeeper "github.com/kava-labs/kava/x/incentive/keeper"
 	"github.com/kava-labs/kava/x/incentive/types"
-	"github.com/kava-labs/kava/x/swap"
+	swapkeeper "github.com/kava-labs/kava/x/swap/keeper"
 	swaptypes "github.com/kava-labs/kava/x/swap/types"
 )
 
@@ -129,7 +129,7 @@ func (suite *IntegrationTester) DeliverSwapMsgDeposit(depositor sdk.AccAddress, 
 		slippage,
 		suite.Ctx.BlockTime().Add(time.Hour).Unix(), // ensure msg will not fail due to short deadline
 	)
-	msgServer := swap.NewMsgServerImpl(suite.App.GetSwapKeeper())
+	msgServer := swapkeeper.NewMsgServerImpl(suite.App.GetSwapKeeper())
 	_, err := msgServer.Deposit(sdk.WrapSDKContext(suite.Ctx), msg)
 
 	return err
@@ -137,7 +137,7 @@ func (suite *IntegrationTester) DeliverSwapMsgDeposit(depositor sdk.AccAddress, 
 
 func (suite *IntegrationTester) DeliverHardMsgDeposit(owner sdk.AccAddress, deposit sdk.Coins) error {
 	msg := hardtypes.NewMsgDeposit(owner, deposit)
-	msgServer := hard.NewMsgServerImpl(suite.App.GetHardKeeper())
+	msgServer := hardkeeper.NewMsgServerImpl(suite.App.GetHardKeeper())
 
 	_, err := msgServer.Deposit(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -145,7 +145,7 @@ func (suite *IntegrationTester) DeliverHardMsgDeposit(owner sdk.AccAddress, depo
 
 func (suite *IntegrationTester) DeliverHardMsgBorrow(owner sdk.AccAddress, borrow sdk.Coins) error {
 	msg := hardtypes.NewMsgBorrow(owner, borrow)
-	msgServer := hard.NewMsgServerImpl(suite.App.GetHardKeeper())
+	msgServer := hardkeeper.NewMsgServerImpl(suite.App.GetHardKeeper())
 
 	_, err := msgServer.Borrow(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -153,7 +153,7 @@ func (suite *IntegrationTester) DeliverHardMsgBorrow(owner sdk.AccAddress, borro
 
 func (suite *IntegrationTester) DeliverHardMsgRepay(owner sdk.AccAddress, repay sdk.Coins) error {
 	msg := hardtypes.NewMsgRepay(owner, owner, repay)
-	msgServer := hard.NewMsgServerImpl(suite.App.GetHardKeeper())
+	msgServer := hardkeeper.NewMsgServerImpl(suite.App.GetHardKeeper())
 
 	_, err := msgServer.Repay(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -161,7 +161,7 @@ func (suite *IntegrationTester) DeliverHardMsgRepay(owner sdk.AccAddress, repay 
 
 func (suite *IntegrationTester) DeliverHardMsgWithdraw(owner sdk.AccAddress, withdraw sdk.Coins) error {
 	msg := hardtypes.NewMsgWithdraw(owner, withdraw)
-	msgServer := hard.NewMsgServerImpl(suite.App.GetHardKeeper())
+	msgServer := hardkeeper.NewMsgServerImpl(suite.App.GetHardKeeper())
 
 	_, err := msgServer.Withdraw(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -169,7 +169,7 @@ func (suite *IntegrationTester) DeliverHardMsgWithdraw(owner sdk.AccAddress, wit
 
 func (suite *IntegrationTester) DeliverMsgCreateCDP(owner sdk.AccAddress, collateral, principal sdk.Coin, collateralType string) error {
 	msg := cdptypes.NewMsgCreateCDP(owner, collateral, principal, collateralType)
-	msgServer := cdp.NewMsgServerImpl(suite.App.GetCDPKeeper())
+	msgServer := cdpkeeper.NewMsgServerImpl(suite.App.GetCDPKeeper())
 
 	_, err := msgServer.CreateCDP(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -177,7 +177,7 @@ func (suite *IntegrationTester) DeliverMsgCreateCDP(owner sdk.AccAddress, collat
 
 func (suite *IntegrationTester) DeliverCDPMsgRepay(owner sdk.AccAddress, collateralType string, payment sdk.Coin) error {
 	msg := cdptypes.NewMsgRepayDebt(owner, collateralType, payment)
-	msgServer := cdp.NewMsgServerImpl(suite.App.GetCDPKeeper())
+	msgServer := cdpkeeper.NewMsgServerImpl(suite.App.GetCDPKeeper())
 
 	_, err := msgServer.RepayDebt(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -185,7 +185,7 @@ func (suite *IntegrationTester) DeliverCDPMsgRepay(owner sdk.AccAddress, collate
 
 func (suite *IntegrationTester) DeliverCDPMsgBorrow(owner sdk.AccAddress, collateralType string, draw sdk.Coin) error {
 	msg := cdptypes.NewMsgDrawDebt(owner, collateralType, draw)
-	msgServer := cdp.NewMsgServerImpl(suite.App.GetCDPKeeper())
+	msgServer := cdpkeeper.NewMsgServerImpl(suite.App.GetCDPKeeper())
 
 	_, err := msgServer.DrawDebt(sdk.WrapSDKContext(suite.Ctx), &msg)
 	return err
@@ -203,7 +203,7 @@ func (suite *IntegrationTester) ProposeAndVoteOnNewParams(voter sdk.AccAddress, 
 	)
 	suite.NoError(err)
 
-	msgServer := committee.NewMsgServerImpl(suite.App.GetCommitteeKeeper())
+	msgServer := committeekeeper.NewMsgServerImpl(suite.App.GetCommitteeKeeper())
 
 	res, err := msgServer.SubmitProposal(sdk.WrapSDKContext(suite.Ctx), propose)
 	suite.NoError(err)

--- a/x/issuance/keeper/gprc_query.go
+++ b/x/issuance/keeper/gprc_query.go
@@ -11,16 +11,25 @@ import (
 	"github.com/kava-labs/kava/x/issuance/types"
 )
 
-var _ types.QueryServer = Keeper{}
+type queryServer struct {
+	keeper Keeper
+}
+
+// NewQueryServerImpl creates a new server for handling gRPC queries.
+func NewQueryServerImpl(k Keeper) types.QueryServer {
+	return &queryServer{keeper: k}
+}
+
+var _ types.QueryServer = queryServer{}
 
 // Params implements the gRPC service handler for querying x/issuance parameters.
-func (k Keeper) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (s queryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	params := k.GetParams(sdkCtx)
+	params := s.keeper.GetParams(sdkCtx)
 
 	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/x/issuance/keeper/msg_server.go
+++ b/x/issuance/keeper/msg_server.go
@@ -12,7 +12,7 @@ type msgServer struct {
 	keeper Keeper
 }
 
-// NewMsgServerImpl returns an implementation of the swap MsgServer interface
+// NewMsgServerImpl returns an implementation of the issuance MsgServer interface
 // for the provided Keeper.
 func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}

--- a/x/issuance/module.go
+++ b/x/issuance/module.go
@@ -134,7 +134,7 @@ func (AppModule) ConsensusVersion() uint64 {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // InitGenesis module init-genesis

--- a/x/kavadist/keeper/grpc_query.go
+++ b/x/kavadist/keeper/grpc_query.go
@@ -8,18 +8,27 @@ import (
 	"github.com/kava-labs/kava/x/kavadist/types"
 )
 
-var _ types.QueryServer = Keeper{}
+type queryServer struct {
+	keeper Keeper
+}
 
-func (k Keeper) Balance(ctx context.Context, req *types.QueryBalanceRequest) (*types.QueryBalanceResponse, error) {
+// NewQueryServerImpl creates a new server for handling gRPC queries.
+func NewQueryServerImpl(k Keeper) types.QueryServer {
+	return &queryServer{keeper: k}
+}
+
+var _ types.QueryServer = queryServer{}
+
+func (s queryServer) Balance(ctx context.Context, req *types.QueryBalanceRequest) (*types.QueryBalanceResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	acc := k.accountKeeper.GetModuleAccount(sdkCtx, types.KavaDistMacc)
-	balance := k.bankKeeper.GetAllBalances(sdkCtx, acc.GetAddress())
+	acc := s.keeper.accountKeeper.GetModuleAccount(sdkCtx, types.KavaDistMacc)
+	balance := s.keeper.bankKeeper.GetAllBalances(sdkCtx, acc.GetAddress())
 	return &types.QueryBalanceResponse{Coins: balance}, nil
 }
 
-func (k Keeper) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+func (s queryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	params := k.GetParams(sdkCtx)
+	params := s.keeper.GetParams(sdkCtx)
 
 	return &types.QueryParamsResponse{Params: params}, nil
 }

--- a/x/kavadist/module.go
+++ b/x/kavadist/module.go
@@ -130,7 +130,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // RegisterInvariants registers kavadist module's invariants.

--- a/x/kavadist/testutil/suite.go
+++ b/x/kavadist/testutil/suite.go
@@ -66,7 +66,7 @@ func (suite *Suite) SetupTest() {
 
 	// Set query client
 	queryHelper := tApp.NewQueryServerTestHelper(ctx)
-	types.RegisterQueryServer(queryHelper, suite.Keeper)
+	types.RegisterQueryServer(queryHelper, keeper.NewQueryServerImpl(suite.Keeper))
 	suite.QueryClient = types.NewQueryClient(queryHelper)
 }
 

--- a/x/pricefeed/keeper/grpc_query_test.go
+++ b/x/pricefeed/keeper/grpc_query_test.go
@@ -1,4 +1,4 @@
-package pricefeed_test
+package keeper_test
 
 import (
 	"testing"
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/pricefeed"
 	"github.com/kava-labs/kava/x/pricefeed/keeper"
 	"github.com/kava-labs/kava/x/pricefeed/types"
 	"github.com/stretchr/testify/suite"
@@ -30,7 +29,7 @@ func (suite *grpcQueryTestSuite) SetupTest() {
 	suite.ctx = suite.tApp.NewContext(true, tmprototypes.Header{}).
 		WithBlockTime(time.Now().UTC())
 	suite.keeper = suite.tApp.GetPriceFeedKeeper()
-	suite.queryServer = pricefeed.NewQueryServerImpl(suite.keeper)
+	suite.queryServer = keeper.NewQueryServerImpl(suite.keeper)
 
 	_, addrs := app.GeneratePrivKeyAddressPairs(5)
 	suite.addrs = addrs

--- a/x/pricefeed/keeper/msg_server.go
+++ b/x/pricefeed/keeper/msg_server.go
@@ -1,21 +1,20 @@
-package pricefeed
+package keeper
 
 import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/kava-labs/kava/x/pricefeed/keeper"
 	"github.com/kava-labs/kava/x/pricefeed/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the pricefeed MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 

--- a/x/pricefeed/keeper/msg_server_test.go
+++ b/x/pricefeed/keeper/msg_server_test.go
@@ -1,4 +1,4 @@
-package pricefeed_test
+package keeper_test
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/app"
-	"github.com/kava-labs/kava/x/pricefeed"
+	"github.com/kava-labs/kava/x/pricefeed/keeper"
 	"github.com/kava-labs/kava/x/pricefeed/types"
 	"github.com/stretchr/testify/require"
 	tmprototypes "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -18,7 +18,7 @@ func TestKeeper_PostPrice(t *testing.T) {
 	ctx := tApp.NewContext(true, tmprototypes.Header{}).
 		WithBlockTime(time.Now().UTC())
 	k := tApp.GetPriceFeedKeeper()
-	msgSrv := pricefeed.NewMsgServerImpl(k)
+	msgSrv := keeper.NewMsgServerImpl(k)
 
 	authorizedOracles := addrs[:2]
 	unauthorizedAddrs := addrs[2:]

--- a/x/pricefeed/module.go
+++ b/x/pricefeed/module.go
@@ -134,7 +134,7 @@ func (AppModule) ConsensusVersion() uint64 {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 

--- a/x/pricefeed/module.go
+++ b/x/pricefeed/module.go
@@ -135,7 +135,7 @@ func (AppModule) ConsensusVersion() uint64 {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), NewQueryServerImpl(am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // InitGenesis module init-genesis

--- a/x/swap/keeper/keeper.go
+++ b/x/swap/keeper/keeper.go
@@ -256,3 +256,15 @@ func (k Keeper) updateDepositorShares(ctx sdk.Context, owner sdk.AccAddress, poo
 		k.SetDepositorShares(ctx, shareRecord)
 	}
 }
+
+func (k Keeper) loadDenominatedPool(ctx sdk.Context, poolID string) (*types.DenominatedPool, error) {
+	poolRecord, found := k.GetPool(ctx, poolID)
+	if !found {
+		return &types.DenominatedPool{}, types.ErrInvalidPool
+	}
+	denominatedPool, err := types.NewDenominatedPoolWithExistingShares(poolRecord.Reserves(), poolRecord.TotalShares)
+	if err != nil {
+		return &types.DenominatedPool{}, types.ErrInvalidPool
+	}
+	return denominatedPool, nil
+}

--- a/x/swap/keeper/msg_server.go
+++ b/x/swap/keeper/msg_server.go
@@ -1,4 +1,4 @@
-package swap
+package keeper
 
 import (
 	"context"
@@ -6,17 +6,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/kava-labs/kava/x/swap/keeper"
 	"github.com/kava-labs/kava/x/swap/types"
 )
 
 type msgServer struct {
-	keeper keeper.Keeper
+	keeper Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the swap MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper keeper.Keeper) types.MsgServer {
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{keeper: keeper}
 }
 

--- a/x/swap/keeper/msg_server_test.go
+++ b/x/swap/keeper/msg_server_test.go
@@ -1,11 +1,11 @@
-package swap_test
+package keeper_test
 
 import (
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/kava-labs/kava/x/swap"
+	"github.com/kava-labs/kava/x/swap/keeper"
 	"github.com/kava-labs/kava/x/swap/testutil"
 	"github.com/kava-labs/kava/x/swap/types"
 	"github.com/stretchr/testify/suite"
@@ -26,7 +26,7 @@ type msgServerTestSuite struct {
 
 func (suite *msgServerTestSuite) SetupTest() {
 	suite.Suite.SetupTest()
-	suite.msgServer = swap.NewMsgServerImpl(suite.Keeper)
+	suite.msgServer = keeper.NewMsgServerImpl(suite.Keeper)
 }
 
 func (suite *msgServerTestSuite) TestDeposit_CreatePool() {

--- a/x/swap/module.go
+++ b/x/swap/module.go
@@ -133,7 +133,7 @@ func (AppModule) ConsensusVersion() uint64 {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 

--- a/x/swap/module.go
+++ b/x/swap/module.go
@@ -134,7 +134,7 @@ func (AppModule) ConsensusVersion() uint64 {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), NewMsgServerImpl(am.keeper))
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
 }
 
 // InitGenesis module init-genesis


### PR DESCRIPTION
Moves `grpc_query` and `msg_server` files to module keeper to be consistent across modules and with cosmos-sdk. Replaces QueryServer direct implementation on `Keeper` types to a queryServer type.