### PR TITLE
Use liquidation market for cdp `MsgLiquidate` validation

### DIFF
--- a/x/cdp/genesis.go
+++ b/x/cdp/genesis.go
@@ -37,7 +37,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, pk types.PricefeedKeeper, ak 
 	for _, col := range gs.Params.CollateralParams {
 		_, found := collateralMap[col.SpotMarketID]
 		if !found {
-			panic(fmt.Sprintf("%s collateral not found in pricefeed", col.Denom))
+			panic(fmt.Sprintf("%s collateral market %v not found in pricefeed", col.Denom, col.SpotMarketID))
 		}
 		// sets the status of the pricefeed in the store
 		// if pricefeed not active, debt operations are paused
@@ -45,7 +45,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, pk types.PricefeedKeeper, ak 
 
 		_, found = collateralMap[col.LiquidationMarketID]
 		if !found {
-			panic(fmt.Sprintf("%s collateral not found in pricefeed", col.Denom))
+			panic(fmt.Sprintf("%s collateral market %v not found in pricefeed", col.Denom, col.LiquidationMarketID))
 		}
 		// sets the status of the pricefeed in the store
 		// if pricefeed not active, debt operations are paused

--- a/x/cdp/keeper/integration_test.go
+++ b/x/cdp/keeper/integration_test.go
@@ -88,14 +88,24 @@ func NewPricefeedGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 		Params: pricefeedtypes.Params{
 			Markets: []pricefeedtypes.Market{
 				{MarketID: "btc:usd", BaseAsset: "btc", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+				{MarketID: "btc:usd:30", BaseAsset: "btc", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 				{MarketID: "xrp:usd", BaseAsset: "xrp", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+				{MarketID: "xrp:usd:30", BaseAsset: "xrp", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 				{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+				{MarketID: "bnb:usd:30", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 				{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+				{MarketID: "busd:usd:30", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
 			},
 		},
 		PostedPrices: []pricefeedtypes.PostedPrice{
 			{
 				MarketID:      "btc:usd",
+				OracleAddress: sdk.AccAddress{},
+				Price:         sdk.MustNewDecFromStr("8000.00"),
+				Expiry:        time.Now().Add(1 * time.Hour),
+			},
+			{
+				MarketID:      "btc:usd:30",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("8000.00"),
 				Expiry:        time.Now().Add(1 * time.Hour),
@@ -107,7 +117,19 @@ func NewPricefeedGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 				Expiry:        time.Now().Add(1 * time.Hour),
 			},
 			{
+				MarketID:      "xrp:usd:30",
+				OracleAddress: sdk.AccAddress{},
+				Price:         sdk.MustNewDecFromStr("0.25"),
+				Expiry:        time.Now().Add(1 * time.Hour),
+			},
+			{
 				MarketID:      "bnb:usd",
+				OracleAddress: sdk.AccAddress{},
+				Price:         sdk.MustNewDecFromStr("17.25"),
+				Expiry:        time.Now().Add(1 * time.Hour),
+			},
+			{
+				MarketID:      "bnb:usd:30",
 				OracleAddress: sdk.AccAddress{},
 				Price:         sdk.MustNewDecFromStr("17.25"),
 				Expiry:        time.Now().Add(1 * time.Hour),
@@ -118,10 +140,17 @@ func NewPricefeedGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 				Price:         sdk.OneDec(),
 				Expiry:        time.Now().Add(1 * time.Hour),
 			},
+			{
+				MarketID:      "busd:usd:30",
+				OracleAddress: sdk.AccAddress{},
+				Price:         sdk.OneDec(),
+				Expiry:        time.Now().Add(1 * time.Hour),
+			},
 		},
 	}
 	return app.GenesisState{pricefeedtypes.ModuleName: cdc.MustMarshalJSON(&pfGenesis)}
 }
+
 func NewCDPGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 	cdpGenesis := types.GenesisState{
 		Params: types.Params{
@@ -140,7 +169,7 @@ func NewCDPGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 					LiquidationPenalty:               d("0.05"),
 					AuctionSize:                      i(7000000000),
 					SpotMarketID:                     "xrp:usd",
-					LiquidationMarketID:              "xrp:usd",
+					LiquidationMarketID:              "xrp:usd:30",
 					KeeperRewardPercentage:           d("0.01"),
 					CheckCollateralizationIndexCount: i(10),
 					ConversionFactor:                 i(6),
@@ -154,7 +183,7 @@ func NewCDPGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 					LiquidationPenalty:               d("0.025"),
 					AuctionSize:                      i(10000000),
 					SpotMarketID:                     "btc:usd",
-					LiquidationMarketID:              "btc:usd",
+					LiquidationMarketID:              "btc:usd:30",
 					KeeperRewardPercentage:           d("0.01"),
 					CheckCollateralizationIndexCount: i(10),
 					ConversionFactor:                 i(8),
@@ -168,7 +197,7 @@ func NewCDPGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 					LiquidationPenalty:               d("0.05"),
 					AuctionSize:                      i(50000000000),
 					SpotMarketID:                     "bnb:usd",
-					LiquidationMarketID:              "bnb:usd",
+					LiquidationMarketID:              "bnb:usd:30",
 					KeeperRewardPercentage:           d("0.01"),
 					CheckCollateralizationIndexCount: i(10),
 					ConversionFactor:                 i(8),
@@ -182,7 +211,7 @@ func NewCDPGenStateMulti(cdc codec.JSONCodec) app.GenesisState {
 					LiquidationPenalty:               d("0.05"),
 					AuctionSize:                      i(10000000000),
 					SpotMarketID:                     "busd:usd",
-					LiquidationMarketID:              "busd:usd",
+					LiquidationMarketID:              "busd:usd:30",
 					KeeperRewardPercentage:           d("0.01"),
 					CheckCollateralizationIndexCount: i(10),
 					ConversionFactor:                 i(8),

--- a/x/cdp/keeper/seize.go
+++ b/x/cdp/keeper/seize.go
@@ -119,7 +119,7 @@ func (k Keeper) ApplyLiquidationPenalty(ctx sdk.Context, collateralType string, 
 
 // ValidateLiquidation validate that adding the input principal puts the cdp below the liquidation ratio
 func (k Keeper) ValidateLiquidation(ctx sdk.Context, collateral sdk.Coin, collateralType string, principal sdk.Coin, fees sdk.Coin) error {
-	collateralizationRatio, err := k.CalculateCollateralizationRatio(ctx, collateral, collateralType, principal, fees, spot)
+	collateralizationRatio, err := k.CalculateCollateralizationRatio(ctx, collateral, collateralType, principal, fees, liquidation)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds tests to cover the following conditions

| Liquidation success | Liquidateable by spot market | Liquidateable by liquidation / twap market |
| ------------------- | ---------------------------- | ------------------------------------------ |
| no                  | yes                          | no                                         |
| yes                 | no                           | yes                                        |

This also changes the `NewCDPGenStateMulti` testing genesis state to use different `SpotMarketID` and `LiquidationMarketID`s. Only the modified test calls `ValidateLiquidation` via `AttemptKeeperLiquidation` and use the changed liquidation market ID.  Other tests use other keeper methods that accept an input market ID so these changes shouldn't (hopefully) affect other tests.