### PR TITLE
Fix auctions query pagination

### DIFF
--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -122,15 +122,15 @@ func GetCmdQueryAuctions() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			strOwner, err := cmd.Flags().GetString(flagOwner)
+			owner, err := cmd.Flags().GetString(flagOwner)
 			if err != nil {
 				return err
 			}
-			strDenom, err := cmd.Flags().GetString(flagDenom)
+			denom, err := cmd.Flags().GetString(flagDenom)
 			if err != nil {
 				return err
 			}
-			strPhase, err := cmd.Flags().GetString(flagPhase)
+			phase, err := cmd.Flags().GetString(flagPhase)
 			if err != nil {
 				return err
 			}
@@ -149,31 +149,31 @@ func GetCmdQueryAuctions() *cobra.Command {
 				}
 			}
 
-			if len(strOwner) != 0 {
+			if len(owner) != 0 {
 				if auctionType != types.CollateralAuctionType {
 					return fmt.Errorf("cannot apply owner flag to non-collateral auction type")
 				}
-				_, err := sdk.AccAddressFromBech32(strOwner)
+				_, err := sdk.AccAddressFromBech32(owner)
 				if err != nil {
-					return fmt.Errorf("cannot parse address from auction owner %s", strOwner)
+					return fmt.Errorf("cannot parse address from auction owner %s", owner)
 				}
 			}
 
-			if len(strDenom) != 0 {
-				strDenom := strings.TrimSpace(strDenom)
-				err := sdk.ValidateDenom(strDenom)
+			if len(denom) != 0 {
+				denom := strings.TrimSpace(denom)
+				err := sdk.ValidateDenom(denom)
 				if err != nil {
 					return err
 				}
 			}
 
-			if len(strPhase) != 0 {
-				strPhase := strings.ToLower(strings.TrimSpace(strPhase))
+			if len(phase) != 0 {
+				phase := strings.ToLower(strings.TrimSpace(phase))
 				if auctionType != types.CollateralAuctionType && len(auctionType) > 0 {
 					return fmt.Errorf("cannot apply phase flag to non-collateral auction type")
 				}
-				if strPhase != types.ForwardAuctionPhase && strPhase != types.ReverseAuctionPhase {
-					return fmt.Errorf("invalid auction phase %s", strPhase)
+				if phase != types.ForwardAuctionPhase && phase != types.ReverseAuctionPhase {
+					return fmt.Errorf("invalid auction phase %s", phase)
 				}
 			}
 
@@ -185,9 +185,9 @@ func GetCmdQueryAuctions() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 			request := types.QueryAuctionsRequest{
 				Type:       auctionType,
-				Owner:      strOwner,
-				Denom:      strDenom,
-				Phase:      strPhase,
+				Owner:      owner,
+				Denom:      denom,
+				Phase:      phase,
 				Pagination: pageReq,
 			}
 

--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -141,7 +141,8 @@ func GetCmdQueryAuctions() *cobra.Command {
 			}
 
 			if len(auctionType) != 0 {
-				auctionType = strings.ToLower(strings.TrimSpace(auctionType))
+				auctionType = strings.ToLower(auctionType)
+
 				if auctionType != types.CollateralAuctionType &&
 					auctionType != types.SurplusAuctionType &&
 					auctionType != types.DebtAuctionType {
@@ -160,7 +161,6 @@ func GetCmdQueryAuctions() *cobra.Command {
 			}
 
 			if len(denom) != 0 {
-				denom := strings.TrimSpace(denom)
 				err := sdk.ValidateDenom(denom)
 				if err != nil {
 					return err
@@ -168,8 +168,9 @@ func GetCmdQueryAuctions() *cobra.Command {
 			}
 
 			if len(phase) != 0 {
-				phase := strings.ToLower(strings.TrimSpace(phase))
-				if auctionType != types.CollateralAuctionType && len(auctionType) > 0 {
+				phase = strings.ToLower(phase)
+
+				if len(auctionType) > 0 && auctionType != types.CollateralAuctionType {
 					return fmt.Errorf("cannot apply phase flag to non-collateral auction type")
 				}
 				if phase != types.ForwardAuctionPhase && phase != types.ReverseAuctionPhase {

--- a/x/auction/keeper/grpc_query.go
+++ b/x/auction/keeper/grpc_query.go
@@ -75,23 +75,47 @@ func (q *queryServer) Auctions(c context.Context, req *types.QueryAuctionsReques
 	var auctions []*codectypes.Any
 	auctionStore := prefix.NewStore(ctx.KVStore(q.keeper.storeKey), types.AuctionKeyPrefix)
 
-	pageRes, err := query.Paginate(auctionStore, req.Pagination, func(key []byte, value []byte) error {
+	pageRes, err := query.FilteredPaginate(auctionStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		result, err := q.keeper.UnmarshalAuction(value)
 		if err != nil {
-			return err
+			return false, err
 		}
 
-		msg, ok := result.(proto.Message)
-		if !ok {
-			return status.Errorf(codes.Internal, "can't protomarshal %T", msg)
+		// True if empty owner, otherwise check if auction contains owner
+		ownerIsMatch := req.Owner == ""
+		if req.Owner != "" {
+			if cAuc, ok := result.(*types.CollateralAuction); ok {
+				for _, addr := range cAuc.GetLotReturns().Addresses {
+					if addr.String() == req.Owner {
+						ownerIsMatch = true
+						break
+					}
+				}
+			}
 		}
 
-		auctionAny, err := codectypes.NewAnyWithValue(msg)
-		if err != nil {
-			return err
+		phaseIsMatch := req.Phase == "" || req.Phase == result.GetPhase()
+		typeIsMatch := req.Type == "" || req.Type == result.GetType()
+		denomIsMatch := req.Denom == "" || req.Denom == result.GetBid().Denom || req.Denom == result.GetLot().Denom
+
+		if ownerIsMatch && phaseIsMatch && typeIsMatch && denomIsMatch {
+			if accumulate {
+				msg, ok := result.(proto.Message)
+				if !ok {
+					return false, status.Errorf(codes.Internal, "can't protomarshal %T", msg)
+				}
+
+				auctionAny, err := codectypes.NewAnyWithValue(msg)
+				if err != nil {
+					return false, err
+				}
+				auctions = append(auctions, auctionAny)
+			}
+
+			return true, nil
 		}
-		auctions = append(auctions, auctionAny)
-		return nil
+
+		return false, nil
 	})
 	if err != nil {
 		return &types.QueryAuctionsResponse{}, err


### PR DESCRIPTION
Includes pagination request in the query.  Also updates command flags to use cobra instead of viper and simplifies parameter variables.  The few uses of `strings.TrimSpace` were removed since the only time where there would be leading/trailing spaces is when flags include quotes ie `--denom "    ukava    "`