### PR TITLE
Add support for subparam rules for ParamsChangePermission

### DIFF
--- a/docs/core/proto-docs.md
+++ b/docs/core/proto-docs.md
@@ -2205,7 +2205,7 @@ SubparamRequirement contains requirements for a single record in a subparam valu
 | ----- | ---- | ----- | ----------- |
 | `key` | [string](#string) |  | The required attr key of the param record. |
 | `val` | [string](#string) |  | The required param value for the param record key. The key and value is used to match to the target param record. |
-| `allowed_subparam_attr_changes` | [string](#string) | repeated | The sub param attrs that are allowed to be changed. Empty if all attrs are allowed. |
+| `allowed_subparam_attr_changes` | [string](#string) | repeated | The sub param attrs that are allowed to be changed. |
 
 
 

--- a/docs/core/proto-docs.md
+++ b/docs/core/proto-docs.md
@@ -141,6 +141,7 @@
     - [GodPermission](#kava.committee.v1beta1.GodPermission)
     - [ParamsChangePermission](#kava.committee.v1beta1.ParamsChangePermission)
     - [SoftwareUpgradePermission](#kava.committee.v1beta1.SoftwareUpgradePermission)
+    - [SubparamRequirement](#kava.committee.v1beta1.SubparamRequirement)
     - [TextPermission](#kava.committee.v1beta1.TextPermission)
   
 - [kava/committee/v1beta1/proposal.proto](#kava/committee/v1beta1/proposal.proto)
@@ -2144,13 +2145,15 @@ VoteType enumerates the valid types of a vote.
 <a name="kava.committee.v1beta1.AllowedParamsChange"></a>
 
 ### AllowedParamsChange
-AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params attrs.
+AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params requirements.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | `subspace` | [string](#string) |  |  |
 | `key` | [string](#string) |  |  |
+| `single_subparam_allowed_attrs` | [string](#string) | repeated | Requirements for when the subparam value is a single record. This contains list of allowed attribute keys that can be changed on the subparam record. |
+| `multi_subparams_requirements` | [SubparamRequirement](#kava.committee.v1beta1.SubparamRequirement) | repeated | Requirements for when the subparam value is a list of records. The requirements contains requirements for each record in the list. |
 
 
 
@@ -2186,6 +2189,23 @@ ParamsChangePermission allows any parameter or sub parameter change proposal.
 
 ### SoftwareUpgradePermission
 SoftwareUpgradePermission permission type for software upgrade proposals
+
+
+
+
+
+
+<a name="kava.committee.v1beta1.SubparamRequirement"></a>
+
+### SubparamRequirement
+SubparamRequirement contains requirements for a single record in a subparam value list
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `key` | [string](#string) |  | The required attr key of the param record. |
+| `val` | [string](#string) |  | The required param value for the param record key. The key and value is used to match to the target param record. |
+| `allowed_subparam_attr_changes` | [string](#string) | repeated | The sub param attrs that are allowed to be changed. Empty if all attrs are allowed. |
 
 
 

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -656,24 +656,114 @@
               {
                 "@type": "/kava.committee.v1beta1.ParamsChangePermission",
                 "allowed_params_changes": [
-                  { "subspace": "auction", "key": "BidDuration" },
-                  { "subspace": "auction", "key": "IncrementSurplus" },
-                  { "subspace": "auction", "key": "IncrementDebt" },
-                  { "subspace": "auction", "key": "IncrementCollateral" },
-                  { "subspace": "bep3", "key": "AssetParams" },
-                  { "subspace": "cdp", "key": "GlobalDebtLimit" },
-                  { "subspace": "cdp", "key": "SurplusThreshold" },
-                  { "subspace": "cdp", "key": "SurplusLot" },
-                  { "subspace": "cdp", "key": "DebtThreshold" },
-                  { "subspace": "cdp", "key": "DebtLot" },
-                  { "subspace": "cdp", "key": "DistributionFrequency" },
-                  { "subspace": "cdp", "key": "CollateralParams" },
-                  { "subspace": "cdp", "key": "DebtParam" },
-                  { "subspace": "incentive", "key": "Active" },
-                  { "subspace": "kavadist", "key": "Active" },
-                  { "subspace": "pricefeed", "key": "Markets" },
-                  { "subspace": "hard", "key": "MoneyMarkets" },
-                  { "subspace": "hard", "key": "MinimumBorrowUSDValue" }
+                  {
+                    "subspace": "auction",
+                    "key": "BidDuration",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementSurplus",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementDebt",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementCollateral",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "bep3",
+                    "key": "AssetParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "GlobalDebtLimit",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DistributionFrequency",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "CollateralParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtParam",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "kavadist",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "pricefeed",
+                    "key": "Markets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  }
                 ]
               },
               { "@type": "/kava.committee.v1beta1.TextPermission" }
@@ -721,13 +811,35 @@
               {
                 "@type": "/kava.committee.v1beta1.ParamsChangePermission",
                 "allowed_params_changes": [
-                  { "subspace": "hard", "key": "MoneyMarkets" },
-                  { "subspace": "hard", "key": "MinimumBorrowUSDValue" },
-                  { "subspace": "incentive", "key": "HardSupplyRewardPeriods" },
-                  { "subspace": "incentive", "key": "HardBorrowRewardPeriods" },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
                   {
                     "subspace": "incentive",
-                    "key": "HardDelegatorRewardPeriods"
+                    "key": "HardSupplyRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardBorrowRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
                   }
                 ]
               }
@@ -749,13 +861,30 @@
               {
                 "@type": "/kava.committee.v1beta1.ParamsChangePermission",
                 "allowed_params_changes": [
-                  { "subspace": "swap", "key": "AllowedPools" },
-                  { "subspace": "swap", "key": "SwapFee" },
+                  {
+                    "subspace": "swap",
+                    "key": "AllowedPools",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "swap",
+                    "key": "SwapFee",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
                   {
                     "subspace": "incentive",
-                    "key": "HardDelegatorRewardPeriods"
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
                   },
-                  { "subspace": "incentive", "key": "SwapRewardPeriods" }
+                  {
+                    "subspace": "incentive",
+                    "key": "SwapRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  }
                 ]
               }
             ],

--- a/proto/kava/committee/v1beta1/permissions.proto
+++ b/proto/kava/committee/v1beta1/permissions.proto
@@ -28,19 +28,28 @@ message ParamsChangePermission {
       [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "AllowedParamsChanges"];
 }
 
-// AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params attrs.
+// AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params requirements.
 message AllowedParamsChange {
   string subspace = 1;
   string key      = 2;
 
-  // TODO: Add supported for sub parameters and required param values
-  // for sub parameter changes.
-  // repeated string               allowed_param_attr_changes = 3;
-  // repeated RequiredSubParamAttr required_sub_param_attrs   = 4;
+  // Requirements for when the subparam value is a single record. This contains list of allowed attribute keys that can
+  // be changed on the subparam record.
+  repeated string single_subparam_allowed_attrs = 3;
+
+  // Requirements for when the subparam value is a list of records. The requirements contains requirements for each
+  // record in the list.
+  repeated SubparamRequirement multi_subparams_requirements = 4 [(gogoproto.nullable) = false];
 }
 
-// TODO: RequiredSubParamAttr contains data on the required sub parameter data needed for param changes.
-// message RequiredSubParamAttr {
-//   string attr_key   = 1;
-//   string attr_value = 2;
-// }
+// SubparamRequirement contains requirements for a single record in a subparam value list
+message SubparamRequirement {
+  // The required attr key of the param record.
+  string key = 1;
+
+  // The required param value for the param record key. The key and value is used to match to the target param record.
+  string val = 2;
+
+  // The sub param attrs that are allowed to be changed. Empty if all attrs are allowed.
+  repeated string allowed_subparam_attr_changes = 3;
+}

--- a/proto/kava/committee/v1beta1/permissions.proto
+++ b/proto/kava/committee/v1beta1/permissions.proto
@@ -50,6 +50,6 @@ message SubparamRequirement {
   // The required param value for the param record key. The key and value is used to match to the target param record.
   string val = 2;
 
-  // The sub param attrs that are allowed to be changed. Empty if all attrs are allowed.
+  // The sub param attrs that are allowed to be changed.
   repeated string allowed_subparam_attr_changes = 3;
 }

--- a/x/committee/legacy/v0_16/testdata/v16-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v16-committee.json
@@ -11,24 +11,114 @@
           {
             "@type": "/kava.committee.v1beta1.ParamsChangePermission",
             "allowed_params_changes": [
-              { "subspace": "auction", "key": "BidDuration" },
-              { "subspace": "auction", "key": "IncrementSurplus" },
-              { "subspace": "auction", "key": "IncrementDebt" },
-              { "subspace": "auction", "key": "IncrementCollateral" },
-              { "subspace": "bep3", "key": "AssetParams" },
-              { "subspace": "cdp", "key": "GlobalDebtLimit" },
-              { "subspace": "cdp", "key": "SurplusThreshold" },
-              { "subspace": "cdp", "key": "SurplusLot" },
-              { "subspace": "cdp", "key": "DebtThreshold" },
-              { "subspace": "cdp", "key": "DebtLot" },
-              { "subspace": "cdp", "key": "DistributionFrequency" },
-              { "subspace": "cdp", "key": "CollateralParams" },
-              { "subspace": "cdp", "key": "DebtParam" },
-              { "subspace": "incentive", "key": "Active" },
-              { "subspace": "kavadist", "key": "Active" },
-              { "subspace": "pricefeed", "key": "Markets" },
-              { "subspace": "hard", "key": "MoneyMarkets" },
-              { "subspace": "hard", "key": "MinimumBorrowUSDValue" }
+              {
+                "subspace": "auction",
+                "key": "BidDuration",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "auction",
+                "key": "IncrementSurplus",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "auction",
+                "key": "IncrementDebt",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "auction",
+                "key": "IncrementCollateral",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "bep3",
+                "key": "AssetParams",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "GlobalDebtLimit",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "SurplusThreshold",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "SurplusLot",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "DebtThreshold",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "DebtLot",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "DistributionFrequency",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "CollateralParams",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "DebtParam",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "Active",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "kavadist",
+                "key": "Active",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "pricefeed",
+                "key": "Markets",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "hard",
+                "key": "MoneyMarkets",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "hard",
+                "key": "MinimumBorrowUSDValue",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              }
             ]
           },
           { "@type": "/kava.committee.v1beta1.TextPermission" }
@@ -74,11 +164,36 @@
           {
             "@type": "/kava.committee.v1beta1.ParamsChangePermission",
             "allowed_params_changes": [
-              { "subspace": "hard", "key": "MoneyMarkets" },
-              { "subspace": "hard", "key": "MinimumBorrowUSDValue" },
-              { "subspace": "incentive", "key": "HardSupplyRewardPeriods" },
-              { "subspace": "incentive", "key": "HardBorrowRewardPeriods" },
-              { "subspace": "incentive", "key": "HardDelegatorRewardPeriods" }
+              {
+                "subspace": "hard",
+                "key": "MoneyMarkets",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "hard",
+                "key": "MinimumBorrowUSDValue",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "HardSupplyRewardPeriods",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "HardBorrowRewardPeriods",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "HardDelegatorRewardPeriods",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              }
             ]
           }
         ],
@@ -99,10 +214,30 @@
           {
             "@type": "/kava.committee.v1beta1.ParamsChangePermission",
             "allowed_params_changes": [
-              { "subspace": "swap", "key": "AllowedPools" },
-              { "subspace": "swap", "key": "SwapFee" },
-              { "subspace": "incentive", "key": "HardDelegatorRewardPeriods" },
-              { "subspace": "incentive", "key": "SwapRewardPeriods" }
+              {
+                "subspace": "swap",
+                "key": "AllowedPools",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "swap",
+                "key": "SwapFee",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "HardDelegatorRewardPeriods",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "incentive",
+                "key": "SwapRewardPeriods",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              }
             ]
           }
         ],

--- a/x/committee/types/committee.go
+++ b/x/committee/types/committee.go
@@ -137,7 +137,7 @@ func (c *BaseCommittee) SetPermissions(permissions []Permission) {
 // As long as one permission allows the proposal then it goes through. Its the OR of all permissions.
 func (c BaseCommittee) HasPermissionsFor(ctx sdk.Context, appCdc codec.Codec, pk ParamKeeper, proposal PubProposal) bool {
 	for _, p := range c.GetPermissions() {
-		if p.Allows(ctx, appCdc, pk, proposal) {
+		if p.Allows(ctx, pk, proposal) {
 			return true
 		}
 	}

--- a/x/committee/types/genesis.go
+++ b/x/committee/types/genesis.go
@@ -96,7 +96,7 @@ func (gs GenesisState) Validate() error {
 
 		// check committee exists
 		if !committeeMap[p.CommitteeID] {
-			return fmt.Errorf("proposal refers to non existent committee; proposal: %+v", p)
+			return fmt.Errorf("proposal refers to non existent committee; committee id: %d", p.CommitteeID)
 		}
 
 		// validate pubProposal

--- a/x/committee/types/genesis_test.go
+++ b/x/committee/types/genesis_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -174,7 +173,6 @@ func TestGenesisState_Validate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fmt.Println(tc.genState)
 			err := tc.genState.Validate()
 
 			if tc.expectPass {

--- a/x/committee/types/param_permissions_test.go
+++ b/x/committee/types/param_permissions_test.go
@@ -1,0 +1,543 @@
+package types_test
+
+import (
+	fmt "fmt"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramsproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	"github.com/stretchr/testify/suite"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
+
+	"github.com/kava-labs/kava/app"
+	cdptypes "github.com/kava-labs/kava/x/cdp/types"
+	types "github.com/kava-labs/kava/x/committee/types"
+)
+
+type ParamsChangeTestSuite struct {
+	suite.Suite
+
+	ctx sdk.Context
+	pk  types.ParamKeeper
+
+	cdpCollateralParams       cdptypes.CollateralParams
+	cdpDebtParam              cdptypes.DebtParam
+	cdpCollateralRequirements []types.SubparamRequirement
+}
+
+func (suite *ParamsChangeTestSuite) SetupTest() {
+	tApp := app.NewTestApp()
+	ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
+
+	suite.ctx = ctx
+	suite.pk = tApp.GetParamsKeeper()
+
+	suite.cdpDebtParam = cdptypes.DebtParam{
+		Denom:            "usdx",
+		ReferenceAsset:   "usd",
+		ConversionFactor: sdk.NewInt(6),
+		DebtFloor:        sdk.NewInt(1000),
+	}
+
+	suite.cdpCollateralParams = cdptypes.CollateralParams{
+		{
+			Denom:                            "bnb",
+			Type:                             "bnb-a",
+			LiquidationRatio:                 sdk.MustNewDecFromStr("2.0"),
+			DebtLimit:                        sdk.NewCoin("usdx", sdk.NewInt(100)),
+			StabilityFee:                     sdk.MustNewDecFromStr("1.02"),
+			LiquidationPenalty:               sdk.MustNewDecFromStr("0.05"),
+			AuctionSize:                      sdk.NewInt(100),
+			ConversionFactor:                 sdk.NewInt(6),
+			SpotMarketID:                     "bnb:usd",
+			LiquidationMarketID:              "bnb:usd",
+			CheckCollateralizationIndexCount: sdk.NewInt(0),
+		},
+		{
+			Denom:                            "btc",
+			Type:                             "btc-a",
+			LiquidationRatio:                 sdk.MustNewDecFromStr("1.5"),
+			DebtLimit:                        sdk.NewCoin("usdx", sdk.NewInt(100)),
+			StabilityFee:                     sdk.MustNewDecFromStr("1.01"),
+			LiquidationPenalty:               sdk.MustNewDecFromStr("0.10"),
+			AuctionSize:                      sdk.NewInt(1000),
+			ConversionFactor:                 sdk.NewInt(8),
+			SpotMarketID:                     "btc:usd",
+			LiquidationMarketID:              "btc:usd",
+			CheckCollateralizationIndexCount: sdk.NewInt(1),
+			KeeperRewardPercentage:           sdk.MustNewDecFromStr("0.12"),
+		},
+	}
+	suite.cdpCollateralRequirements = []types.SubparamRequirement{
+		{
+			Key:                        "type",
+			Val:                        "bnb-a",
+			AllowedSubparamAttrChanges: []string{"conversion_factor", "liquidation_ratio", "spot_market_id"},
+		},
+		{
+			Key:                        "type",
+			Val:                        "btc-a",
+			AllowedSubparamAttrChanges: []string{"stability_fee", "debt_limit", "auction_size", "keeper_reward_percentage"},
+		},
+	}
+}
+
+func (s *ParamsChangeTestSuite) TestSingleSubparams_CdpDeptParams() {
+	testcases := []struct {
+		name        string
+		expected    bool
+		permission  types.AllowedParamsChange
+		paramChange paramsproposal.ParamChange
+	}{
+		{
+			name:     "allow changes to all allowed fields",
+			expected: true,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom", "reference_asset", "conversion_factor", "debt_floor"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "DebtParam",
+				Value: `{
+					"denom": "bnb",
+					"reference_asset": "bnbx",
+					"conversion_factor": "11",
+					"debt_floor": "1200"
+				}`,
+			},
+		},
+		{
+			name:     "allows changes only to certain fields",
+			expected: true,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom", "debt_floor"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "DebtParam",
+				Value: `{
+					"denom": "bnb",
+					"reference_asset": "usd",
+					"conversion_factor": "6",
+					"debt_floor": "1100"
+				}`,
+			},
+		},
+		{
+			name:     "fails if changing attr that is not allowed",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom", "debt_floor"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "DebtParam",
+				Value: `{
+					"denom": "usdx",
+					"reference_asset": "usd",
+					"conversion_factor": "7",
+					"debt_floor": "1000"
+				}`,
+			},
+		},
+		{
+			name:     "fails if there are unexpected param change attrs",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "DebtParam",
+				Value: `{
+					"denom": "usdx",
+					"reference_asset": "usd",
+					"conversion_factor": "6",
+					"debt_floor": "1000",
+					"extra_attr": "123"
+				}`,
+			},
+		},
+		{
+			name:     "fails if there are missing param change attrs",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom", "reference_asset"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "DebtParam",
+				// debt_floor is missing
+				Value: `{
+					"denom": "usdx",
+					"reference_asset": "usd",
+					"conversion_factor": "11.000000000000000000",
+				}`,
+			},
+		},
+		{
+			name:     "fails if subspace does not match",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyDebtParam),
+				SingleSubparamAllowedAttrs: []string{"denom"},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "auction",
+				Key:      "DebtParam",
+				Value: `{
+					"denom": "usdx",
+					"reference_asset": "usd",
+					"conversion_factor": "6",
+					"debt_floor": "1000"
+				}`,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			subspace, found := s.pk.GetSubspace(cdptypes.ModuleName)
+			s.Require().True(found)
+			subspace.Set(s.ctx, cdptypes.KeyDebtParam, s.cdpDebtParam)
+
+			permission := types.ParamsChangePermission{
+				AllowedParamsChanges: types.AllowedParamsChanges{tc.permission},
+			}
+			proposal := paramsproposal.NewParameterChangeProposal(
+				"A Title",
+				"A description of this proposal.",
+				[]paramsproposal.ParamChange{tc.paramChange},
+			)
+			s.Require().Equal(
+				tc.expected,
+				permission.Allows(s.ctx, s.pk, proposal),
+			)
+		})
+	}
+}
+
+func (s *ParamsChangeTestSuite) TestMultiSubparams_CdpCollateralParams() {
+	unchangedBnbValue := `{
+		"denom": "bnb",
+		"type": "bnb-a",
+		"liquidation_ratio": "2.000000000000000000",
+		"debt_limit": { "denom": "usdx", "amount": "100" },
+		"stability_fee": "1.020000000000000000",
+		"auction_size": "100",
+		"liquidation_penalty": "0.050000000000000000",
+		"spot_market_id": "bnb:usd",
+		"liquidation_market_id": "bnb:usd",
+		"keeper_reward_percentage": "0",
+		"check_collateralization_index_count": "0",
+		"conversion_factor": "6"
+	}`
+	unchangedBtcValue := `{
+		"denom": "btc",
+		"type": "btc-a",
+		"liquidation_ratio": "1.500000000000000000",
+		"debt_limit": { "denom": "usdx", "amount": "100" },
+		"stability_fee": "1.010000000000000000",
+		"auction_size": "1000",
+		"liquidation_penalty": "0.100000000000000000",
+		"spot_market_id": "btc:usd",
+		"liquidation_market_id": "btc:usd",
+		"keeper_reward_percentage": "0.12",
+		"check_collateralization_index_count": "1",
+		"conversion_factor": "8"
+	}`
+
+	testcases := []struct {
+		name        string
+		expected    bool
+		permission  types.AllowedParamsChange
+		paramChange paramsproposal.ParamChange
+	}{
+		{
+			name:     "succeeds when changing allowed values and keeping not allowed the same",
+			expected: true,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				Value: `[{
+					"denom": "bnb",
+					"type": "bnb-a",
+					"liquidation_ratio": "2.010000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.020000000000000000",
+					"auction_size": "100",
+					"liquidation_penalty": "0.050000000000000000",
+					"spot_market_id": "bnbc:usd",
+					"liquidation_market_id": "bnb:usd",
+					"keeper_reward_percentage": "0",
+					"check_collateralization_index_count": "0",
+					"conversion_factor": "9"
+				},
+				{
+					"denom": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.500000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "200" },
+					"stability_fee": "2.010000000000000000",
+					"auction_size": "1200",
+					"liquidation_penalty": "0.100000000000000000",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.000000000000000000",
+					"check_collateralization_index_count": "1",
+					"conversion_factor": "8"
+				}]`,
+			},
+		},
+		{
+			name:     "succeeds if nothing is changed",
+			expected: true,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				Value:    fmt.Sprintf("[%s, %s]", unchangedBnbValue, unchangedBtcValue),
+			},
+		},
+		{
+			name:     "fails if changed records are not the same length as existing records",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				Value:    fmt.Sprintf("[%s]", unchangedBnbValue),
+			},
+		},
+		{
+			name:     "fails if incoming records are missing a existing record",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// same length as existing records but missing one with the correct key/value pair
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, unchangedBnbValue),
+			},
+		},
+		{
+			name:     "fails when changing an attribute that is not allowed",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// changed liquidation_ratio, which is not whitelisted
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, `{
+					"denom": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.2",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.01",
+					"auction_size": "1000",
+					"liquidation_penalty": "0.1",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.12",
+					"check_collateralization_index_count": "1",
+					"conversion_factor": "8"
+				}`),
+			},
+		},
+		{
+			name:     "fails when requirements does not include an existing record",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: []types.SubparamRequirement{s.cdpCollateralRequirements[0]},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				Value:    fmt.Sprintf("[%s, %s]", unchangedBnbValue, unchangedBtcValue),
+			},
+		},
+		{
+			name:     "fails when changes has missing key",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: []types.SubparamRequirement{s.cdpCollateralRequirements[0]},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// missing check_collateralization_index_count
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, `{
+					"denom": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.500000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.010000000000000000",
+					"auction_size": "1000",
+					"liquidation_penalty": "0.100000000000000000",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.12",
+					"conversion_factor": "8"
+				}`),
+			},
+		},
+		{
+			name:     "fails when changes has same keys length but an unknown key",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: []types.SubparamRequirement{s.cdpCollateralRequirements[0]},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// missspelled denom key
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, `{
+					"denoms": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.500000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.010000000000000000",
+					"auction_size": "1000",
+					"liquidation_penalty": "0.100000000000000000",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.12",
+					"check_collateralization_index_count": "1",
+					"conversion_factor": "8"
+				}`),
+			},
+		},
+		{
+			name:     "fails when attr is not allowed and has different value",
+			expected: false,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: []types.SubparamRequirement{s.cdpCollateralRequirements[0]},
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// liquidation_ratio changed value but is not allowed
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, `{
+					"denom": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.510000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.010000000000000000",
+					"auction_size": "1000",
+					"liquidation_penalty": "0.100000000000000000",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.12",
+					"check_collateralization_index_count": "1",
+					"conversion_factor": "8"
+				}`),
+			},
+		},
+		{
+			name:     "succeeds when param attr is not allowed but is same",
+			expected: true,
+			permission: types.AllowedParamsChange{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyCollateralParams),
+				MultiSubparamsRequirements: s.cdpCollateralRequirements,
+			},
+			paramChange: paramsproposal.ParamChange{
+				Subspace: "cdp",
+				Key:      "CollateralParams",
+				// liquidation_ratio is not allowed but the same
+				// stability_fee is allowed but changed
+				Value: fmt.Sprintf("[%s, %s]", unchangedBnbValue, `{
+					"denom": "btc",
+					"type": "btc-a",
+					"liquidation_ratio": "1.500000000000000000",
+					"debt_limit": { "denom": "usdx", "amount": "100" },
+					"stability_fee": "1.020000000000000000",
+					"auction_size": "1000",
+					"liquidation_penalty": "0.100000000000000000",
+					"spot_market_id": "btc:usd",
+					"liquidation_market_id": "btc:usd",
+					"keeper_reward_percentage": "0.12",
+					"check_collateralization_index_count": "1",
+					"conversion_factor": "8"
+				}`),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			subspace, found := s.pk.GetSubspace(cdptypes.ModuleName)
+			s.Require().True(found)
+			subspace.Set(s.ctx, cdptypes.KeyCollateralParams, s.cdpCollateralParams)
+
+			permission := types.ParamsChangePermission{
+				AllowedParamsChanges: types.AllowedParamsChanges{tc.permission},
+			}
+			proposal := paramsproposal.NewParameterChangeProposal(
+				"A Title",
+				"A description of this proposal.",
+				[]paramsproposal.ParamChange{tc.paramChange},
+			)
+			s.Require().Equal(
+				tc.expected,
+				permission.Allows(s.ctx, s.pk, proposal),
+			)
+		})
+	}
+}
+
+// Test fail when param change value is invalid json
+// Test fail when param change value is invalid array json
+// Test fail if bad existing data in subspace
+// Test success if permissions does not contain any changes
+// succeeds if one AllowedParamsChange is allowed and the other is not
+// succeeds if changing non cdp subspace data
+// fails if proposal has no corresponding allowed param changes in the permission
+func TestParamsChangeTestSuite(t *testing.T) {
+	suite.Run(t, new(ParamsChangeTestSuite))
+}

--- a/x/committee/types/permissions.go
+++ b/x/committee/types/permissions.go
@@ -227,6 +227,11 @@ func (allowed AllowedParamsChange) allowsParamChange(ctx sdk.Context, paramsChan
 		return false
 	}
 
+	// Allow all param changes if no subparam rules are specified.
+	if len(allowed.SingleSubparamAllowedAttrs) == 0 && len(allowed.MultiSubparamsRequirements) == 0 {
+		return true
+	}
+
 	// Check if param value is an array before unmarshalling to corresponding types
 	tdata := strings.TrimLeft(paramsChange.Value, "\t\r\n")
 	isArray := len(tdata) > 0 && tdata[0] == '['

--- a/x/committee/types/permissions.go
+++ b/x/committee/types/permissions.go
@@ -180,6 +180,9 @@ func validateParamChangesAreAllowed(current SubparamChanges, incoming SubparamCh
 		return false
 	}
 
+	// Warning: ranging over maps iterates through keys in a random order.
+	// All state machine code must be deterministic between validators.
+	// This function's output is deterministic despite the range.
 	for k, v := range current {
 		isAllowed := false
 

--- a/x/committee/types/permissions.pb.go
+++ b/x/committee/types/permissions.pb.go
@@ -259,7 +259,7 @@ type SubparamRequirement struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The required param value for the param record key. The key and value is used to match to the target param record.
 	Val string `protobuf:"bytes,2,opt,name=val,proto3" json:"val,omitempty"`
-	// The sub param attrs that are allowed to be changed. Empty if all attrs are allowed.
+	// The sub param attrs that are allowed to be changed.
 	AllowedSubparamAttrChanges []string `protobuf:"bytes,3,rep,name=allowed_subparam_attr_changes,json=allowedSubparamAttrChanges,proto3" json:"allowed_subparam_attr_changes,omitempty"`
 }
 

--- a/x/committee/types/permissions.pb.go
+++ b/x/committee/types/permissions.pb.go
@@ -180,10 +180,16 @@ func (m *ParamsChangePermission) GetAllowedParamsChanges() AllowedParamsChanges 
 	return nil
 }
 
-// AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params attrs.
+// AllowedParamsChange contains data on the allowed parameter changes for subspace, key, and sub params requirements.
 type AllowedParamsChange struct {
 	Subspace string `protobuf:"bytes,1,opt,name=subspace,proto3" json:"subspace,omitempty"`
 	Key      string `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	// Requirements for when the subparam value is a single record. This contains list of allowed attribute keys that can
+	// be changed on the subparam record.
+	SingleSubparamAllowedAttrs []string `protobuf:"bytes,3,rep,name=single_subparam_allowed_attrs,json=singleSubparamAllowedAttrs,proto3" json:"single_subparam_allowed_attrs,omitempty"`
+	// Requirements for when the subparam value is a list of records. The requirements contains requirements for each
+	// record in the list.
+	MultiSubparamsRequirements []SubparamRequirement `protobuf:"bytes,4,rep,name=multi_subparams_requirements,json=multiSubparamsRequirements,proto3" json:"multi_subparams_requirements"`
 }
 
 func (m *AllowedParamsChange) Reset()         { *m = AllowedParamsChange{} }
@@ -233,12 +239,91 @@ func (m *AllowedParamsChange) GetKey() string {
 	return ""
 }
 
+func (m *AllowedParamsChange) GetSingleSubparamAllowedAttrs() []string {
+	if m != nil {
+		return m.SingleSubparamAllowedAttrs
+	}
+	return nil
+}
+
+func (m *AllowedParamsChange) GetMultiSubparamsRequirements() []SubparamRequirement {
+	if m != nil {
+		return m.MultiSubparamsRequirements
+	}
+	return nil
+}
+
+// SubparamRequirement contains requirements for a single record in a subparam value list
+type SubparamRequirement struct {
+	// The required attr key of the param record.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// The required param value for the param record key. The key and value is used to match to the target param record.
+	Val string `protobuf:"bytes,2,opt,name=val,proto3" json:"val,omitempty"`
+	// The sub param attrs that are allowed to be changed. Empty if all attrs are allowed.
+	AllowedSubparamAttrChanges []string `protobuf:"bytes,3,rep,name=allowed_subparam_attr_changes,json=allowedSubparamAttrChanges,proto3" json:"allowed_subparam_attr_changes,omitempty"`
+}
+
+func (m *SubparamRequirement) Reset()         { *m = SubparamRequirement{} }
+func (m *SubparamRequirement) String() string { return proto.CompactTextString(m) }
+func (*SubparamRequirement) ProtoMessage()    {}
+func (*SubparamRequirement) Descriptor() ([]byte, []int) {
+	return fileDescriptor_bdfaf7be16465ae4, []int{5}
+}
+func (m *SubparamRequirement) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SubparamRequirement) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SubparamRequirement.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SubparamRequirement) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubparamRequirement.Merge(m, src)
+}
+func (m *SubparamRequirement) XXX_Size() int {
+	return m.Size()
+}
+func (m *SubparamRequirement) XXX_DiscardUnknown() {
+	xxx_messageInfo_SubparamRequirement.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SubparamRequirement proto.InternalMessageInfo
+
+func (m *SubparamRequirement) GetKey() string {
+	if m != nil {
+		return m.Key
+	}
+	return ""
+}
+
+func (m *SubparamRequirement) GetVal() string {
+	if m != nil {
+		return m.Val
+	}
+	return ""
+}
+
+func (m *SubparamRequirement) GetAllowedSubparamAttrChanges() []string {
+	if m != nil {
+		return m.AllowedSubparamAttrChanges
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*GodPermission)(nil), "kava.committee.v1beta1.GodPermission")
 	proto.RegisterType((*SoftwareUpgradePermission)(nil), "kava.committee.v1beta1.SoftwareUpgradePermission")
 	proto.RegisterType((*TextPermission)(nil), "kava.committee.v1beta1.TextPermission")
 	proto.RegisterType((*ParamsChangePermission)(nil), "kava.committee.v1beta1.ParamsChangePermission")
 	proto.RegisterType((*AllowedParamsChange)(nil), "kava.committee.v1beta1.AllowedParamsChange")
+	proto.RegisterType((*SubparamRequirement)(nil), "kava.committee.v1beta1.SubparamRequirement")
 }
 
 func init() {
@@ -246,28 +331,36 @@ func init() {
 }
 
 var fileDescriptor_bdfaf7be16465ae4 = []byte{
-	// 330 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xd2, 0xc8, 0x4e, 0x2c, 0x4b,
-	0xd4, 0x4f, 0xce, 0xcf, 0xcd, 0xcd, 0x2c, 0x29, 0x49, 0x4d, 0xd5, 0x2f, 0x33, 0x4c, 0x4a, 0x2d,
-	0x49, 0x34, 0xd4, 0x2f, 0x48, 0x2d, 0xca, 0xcd, 0x2c, 0x2e, 0xce, 0xcc, 0xcf, 0x2b, 0xd6, 0x2b,
-	0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x03, 0xa9, 0xd4, 0x83, 0xab, 0xd4, 0x83, 0xaa, 0x94, 0x92,
-	0x4c, 0xce, 0x2f, 0xce, 0xcd, 0x2f, 0x8e, 0x07, 0xab, 0xd2, 0x87, 0x70, 0x20, 0x5a, 0xa4, 0x44,
-	0xd2, 0xf3, 0xd3, 0xf3, 0x21, 0xe2, 0x20, 0x16, 0x44, 0x54, 0x49, 0x9e, 0x8b, 0xd7, 0x3d, 0x3f,
-	0x25, 0x00, 0x6e, 0x81, 0x15, 0xdf, 0xa9, 0x2d, 0xba, 0x5c, 0x08, 0xbe, 0x92, 0x36, 0x97, 0x64,
-	0x70, 0x7e, 0x5a, 0x49, 0x79, 0x62, 0x51, 0x6a, 0x68, 0x41, 0x7a, 0x51, 0x62, 0x4a, 0x2a, 0x1e,
-	0xc5, 0x0a, 0x5c, 0x7c, 0x21, 0xa9, 0x15, 0x25, 0x78, 0x54, 0xac, 0x64, 0xe4, 0x12, 0x0b, 0x48,
-	0x2c, 0x4a, 0xcc, 0x2d, 0x76, 0xce, 0x48, 0xcc, 0x4b, 0x47, 0x32, 0x4c, 0xa8, 0x9e, 0x4b, 0x2c,
-	0x31, 0x27, 0x27, 0xbf, 0x3c, 0x35, 0x25, 0xbe, 0x00, 0xac, 0x22, 0x3e, 0x19, 0xac, 0xa4, 0x58,
-	0x82, 0x51, 0x81, 0x59, 0x83, 0xdb, 0x48, 0x5b, 0x0f, 0xbb, 0xa7, 0xf5, 0x1c, 0x21, 0xba, 0x90,
-	0x8d, 0x75, 0x92, 0x39, 0x71, 0x4f, 0x9e, 0x61, 0xd5, 0x7d, 0x79, 0x11, 0x2c, 0x92, 0xc5, 0x41,
-	0x22, 0x89, 0x58, 0x44, 0x31, 0xdc, 0xea, 0xcc, 0x25, 0x8c, 0x45, 0xb7, 0x90, 0x14, 0x17, 0x47,
-	0x71, 0x69, 0x52, 0x71, 0x41, 0x62, 0x72, 0xaa, 0x04, 0xa3, 0x02, 0xa3, 0x06, 0x67, 0x10, 0x9c,
-	0x2f, 0x24, 0xc0, 0xc5, 0x9c, 0x9d, 0x5a, 0x29, 0xc1, 0x04, 0x16, 0x06, 0x31, 0x9d, 0x5c, 0x4f,
-	0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5, 0x18,
-	0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e, 0x21, 0x4a, 0x3b, 0x3d, 0xb3, 0x24, 0xa3, 0x34,
-	0x09, 0xe4, 0x21, 0x7d, 0x90, 0xcf, 0x74, 0x73, 0x12, 0x93, 0x8a, 0xc1, 0x2c, 0xfd, 0x0a, 0xa4,
-	0x44, 0x50, 0x52, 0x59, 0x90, 0x5a, 0x9c, 0xc4, 0x06, 0x8e, 0x2e, 0x63, 0x40, 0x00, 0x00, 0x00,
-	0xff, 0xff, 0xab, 0xb1, 0x7a, 0xb4, 0x23, 0x02, 0x00, 0x00,
+	// 451 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x93, 0xcd, 0x6e, 0xd3, 0x40,
+	0x10, 0x80, 0xb3, 0xb8, 0x42, 0x74, 0x11, 0x55, 0xe5, 0x46, 0x91, 0x6b, 0x15, 0x27, 0xca, 0x29,
+	0x52, 0x54, 0x5b, 0x85, 0x1b, 0xb7, 0x04, 0x21, 0xae, 0x95, 0x0b, 0x17, 0x2e, 0xd6, 0x3a, 0x59,
+	0x5c, 0xab, 0x76, 0xd6, 0xec, 0x8c, 0xd3, 0x56, 0x42, 0xe2, 0x15, 0x78, 0x0d, 0x38, 0xf3, 0x10,
+	0x15, 0xa7, 0x1e, 0x39, 0x01, 0x4a, 0x1e, 0x83, 0x0b, 0xda, 0xf5, 0xaf, 0x54, 0x2b, 0xb7, 0x99,
+	0xd9, 0x6f, 0x66, 0xfd, 0xed, 0x7a, 0xe9, 0xe4, 0x8a, 0xad, 0x99, 0xb7, 0x10, 0x69, 0x1a, 0x23,
+	0x72, 0xee, 0xad, 0xcf, 0x42, 0x8e, 0xec, 0xcc, 0xcb, 0xb8, 0x4c, 0x63, 0x80, 0x58, 0xac, 0xc0,
+	0xcd, 0xa4, 0x40, 0x61, 0x0e, 0x14, 0xe9, 0xd6, 0xa4, 0x5b, 0x92, 0xf6, 0xf1, 0x42, 0x40, 0x2a,
+	0x20, 0xd0, 0x94, 0x57, 0x24, 0x45, 0x8b, 0xdd, 0x8f, 0x44, 0x24, 0x8a, 0xba, 0x8a, 0x8a, 0xea,
+	0x78, 0x48, 0x9f, 0xbd, 0x15, 0xcb, 0xf3, 0x7a, 0x83, 0x57, 0x07, 0x3f, 0x7f, 0x9c, 0xd2, 0x26,
+	0x1f, 0x4f, 0xe9, 0xf1, 0x85, 0xf8, 0x88, 0xd7, 0x4c, 0xf2, 0xf7, 0x59, 0x24, 0xd9, 0x92, 0xef,
+	0x80, 0x47, 0xf4, 0xe0, 0x1d, 0xbf, 0xc1, 0x1d, 0xc4, 0x37, 0x42, 0x07, 0xe7, 0x4c, 0xb2, 0x14,
+	0x5e, 0x5f, 0xb2, 0x55, 0xd4, 0x1a, 0x66, 0x7e, 0xa1, 0x03, 0x96, 0x24, 0xe2, 0x9a, 0x2f, 0x83,
+	0x4c, 0x13, 0xc1, 0x42, 0x23, 0x60, 0x91, 0x91, 0x31, 0x79, 0xfa, 0x62, 0xea, 0x76, 0x4b, 0xbb,
+	0xb3, 0xa2, 0xab, 0x3d, 0x76, 0x7e, 0x72, 0xf7, 0x7b, 0xd8, 0xfb, 0xfe, 0x67, 0xd8, 0xef, 0x58,
+	0x04, 0xbf, 0xcf, 0x3a, 0xaa, 0x0f, 0xbe, 0xf5, 0x1f, 0xa1, 0x47, 0x1d, 0xed, 0xa6, 0x4d, 0x9f,
+	0x40, 0x1e, 0x42, 0xc6, 0x16, 0xdc, 0x22, 0x23, 0x32, 0xd9, 0xf7, 0xeb, 0xdc, 0x3c, 0xa4, 0xc6,
+	0x15, 0xbf, 0xb5, 0x1e, 0xe9, 0xb2, 0x0a, 0xcd, 0x19, 0x7d, 0x0e, 0xf1, 0x2a, 0x4a, 0x78, 0x00,
+	0x79, 0xa8, 0xc5, 0x82, 0x4a, 0x93, 0x21, 0x4a, 0xb0, 0x8c, 0x91, 0x31, 0xd9, 0xf7, 0xed, 0x02,
+	0xba, 0x28, 0x99, 0x72, 0xdf, 0x99, 0x22, 0x4c, 0xa0, 0x27, 0x69, 0x9e, 0x60, 0x5c, 0x4f, 0x80,
+	0x40, 0xf2, 0x4f, 0x79, 0x2c, 0x79, 0xca, 0x57, 0x08, 0xd6, 0xde, 0xee, 0xf3, 0xa9, 0x66, 0xfa,
+	0x4d, 0xcf, 0x7c, 0x4f, 0x9d, 0x8f, 0x6f, 0xeb, 0xb1, 0xd5, 0x3a, 0xb4, 0x00, 0x18, 0x7f, 0xa6,
+	0x47, 0x1d, 0x8d, 0x95, 0x20, 0x69, 0x04, 0x0f, 0xa9, 0xb1, 0x66, 0x49, 0xa5, 0xbc, 0x66, 0x89,
+	0x52, 0xae, 0x14, 0x1b, 0x67, 0x44, 0x59, 0x5f, 0x68, 0xa9, 0x5c, 0x42, 0xb5, 0x33, 0xa2, 0x2c,
+	0xef, 0x62, 0xfe, 0xe6, 0x6e, 0xe3, 0x90, 0xfb, 0x8d, 0x43, 0xfe, 0x6e, 0x1c, 0xf2, 0x75, 0xeb,
+	0xf4, 0xee, 0xb7, 0x4e, 0xef, 0xd7, 0xd6, 0xe9, 0x7d, 0x98, 0x46, 0x31, 0x5e, 0xe6, 0xa1, 0xf2,
+	0xf4, 0x94, 0xf0, 0x69, 0xc2, 0x42, 0xd0, 0x91, 0x77, 0xd3, 0x7a, 0x3b, 0x78, 0x9b, 0x71, 0x08,
+	0x1f, 0xeb, 0xbf, 0xfc, 0xe5, 0xff, 0x00, 0x00, 0x00, 0xff, 0xff, 0x78, 0x09, 0x36, 0x56, 0x5a,
+	0x03, 0x00, 0x00,
 }
 
 func (m *GodPermission) Marshal() (dAtA []byte, err error) {
@@ -396,6 +489,29 @@ func (m *AllowedParamsChange) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.MultiSubparamsRequirements) > 0 {
+		for iNdEx := len(m.MultiSubparamsRequirements) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.MultiSubparamsRequirements[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintPermissions(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.SingleSubparamAllowedAttrs) > 0 {
+		for iNdEx := len(m.SingleSubparamAllowedAttrs) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SingleSubparamAllowedAttrs[iNdEx])
+			copy(dAtA[i:], m.SingleSubparamAllowedAttrs[iNdEx])
+			i = encodeVarintPermissions(dAtA, i, uint64(len(m.SingleSubparamAllowedAttrs[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.Key) > 0 {
 		i -= len(m.Key)
 		copy(dAtA[i:], m.Key)
@@ -407,6 +523,52 @@ func (m *AllowedParamsChange) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.Subspace)
 		copy(dAtA[i:], m.Subspace)
 		i = encodeVarintPermissions(dAtA, i, uint64(len(m.Subspace)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SubparamRequirement) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SubparamRequirement) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SubparamRequirement) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.AllowedSubparamAttrChanges) > 0 {
+		for iNdEx := len(m.AllowedSubparamAttrChanges) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.AllowedSubparamAttrChanges[iNdEx])
+			copy(dAtA[i:], m.AllowedSubparamAttrChanges[iNdEx])
+			i = encodeVarintPermissions(dAtA, i, uint64(len(m.AllowedSubparamAttrChanges[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Val) > 0 {
+		i -= len(m.Val)
+		copy(dAtA[i:], m.Val)
+		i = encodeVarintPermissions(dAtA, i, uint64(len(m.Val)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintPermissions(dAtA, i, uint64(len(m.Key)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -479,6 +641,41 @@ func (m *AllowedParamsChange) Size() (n int) {
 	l = len(m.Key)
 	if l > 0 {
 		n += 1 + l + sovPermissions(uint64(l))
+	}
+	if len(m.SingleSubparamAllowedAttrs) > 0 {
+		for _, s := range m.SingleSubparamAllowedAttrs {
+			l = len(s)
+			n += 1 + l + sovPermissions(uint64(l))
+		}
+	}
+	if len(m.MultiSubparamsRequirements) > 0 {
+		for _, e := range m.MultiSubparamsRequirements {
+			l = e.Size()
+			n += 1 + l + sovPermissions(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *SubparamRequirement) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovPermissions(uint64(l))
+	}
+	l = len(m.Val)
+	if l > 0 {
+		n += 1 + l + sovPermissions(uint64(l))
+	}
+	if len(m.AllowedSubparamAttrChanges) > 0 {
+		for _, s := range m.AllowedSubparamAttrChanges {
+			l = len(s)
+			n += 1 + l + sovPermissions(uint64(l))
+		}
 	}
 	return n
 }
@@ -815,6 +1012,218 @@ func (m *AllowedParamsChange) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SingleSubparamAllowedAttrs", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPermissions
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SingleSubparamAllowedAttrs = append(m.SingleSubparamAllowedAttrs, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MultiSubparamsRequirements", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPermissions
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MultiSubparamsRequirements = append(m.MultiSubparamsRequirements, SubparamRequirement{})
+			if err := m.MultiSubparamsRequirements[len(m.MultiSubparamsRequirements)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipPermissions(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SubparamRequirement) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowPermissions
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SubparamRequirement: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SubparamRequirement: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPermissions
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Val", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPermissions
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Val = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AllowedSubparamAttrChanges", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPermissions
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPermissions
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AllowedSubparamAttrChanges = append(m.AllowedSubparamAttrChanges, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/x/committee/types/permissions_test.go
+++ b/x/committee/types/permissions_test.go
@@ -174,7 +174,7 @@ func TestParamsChangePermission_SimpleParamsChange_Allows(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expectAllowed, tc.permission.Allows(sdk.Context{}, nil, nil, tc.pubProposal))
+			require.Equal(t, tc.expectAllowed, tc.permission.Allows(sdk.Context{}, nil, tc.pubProposal))
 		})
 	}
 }


### PR DESCRIPTION
This PR updates `ParamsChangePermission` to match the functionality of `SubParamChangePermission` that allows changes to specific sub-key within module parameter keys, 

In order to create subparam rules in a flexible manner, the idea here is to store rules for sub params in a single object that can work across modules. In this case, the `SubparamRequirement` contains the requirements for subparam key and value so that it can target specific records in subparams and the `allowed_subparam_attr_changes` slice in it contains the rules for which properties can be updated.

Note, since we are no longer unmarsharling the params into its target param struct, we do lose some type validation there. But the proposal handler from cosmos should do some type validation right after our logic so it should be okay.

--

Remaining TODOs:
- [x] A couple of test cases are not written out