### PR TITLE
Remove support for MsgCreateVestingAccount

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -45,6 +45,7 @@ func NewAnteHandler(
 	}
 	decorators = append(decorators,
 		ante.NewMempoolFeeDecorator(),
+		NewVestingAccountDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(accountKeeper),

--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -18,7 +18,6 @@ func (vad VestingAccountDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	for _, msg := range msgs {
 		_, ok := msg.(*vesting.MsgCreateVestingAccount)
 		if ok {
-			// return ctx, fmt.Errorf("MsgCreateVestingAccount not supported")
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "MsgCreateVestingAccount not supported")
 
 		}

--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -14,13 +14,11 @@ func NewVestingAccountDecorator() VestingAccountDecorator {
 }
 
 func (vad VestingAccountDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	msgs := tx.GetMsgs()
-	for _, msg := range msgs {
-		_, ok := msg.(*vesting.MsgCreateVestingAccount)
-		if ok {
+	for _, msg := range tx.GetMsgs() {
+		if _, ok := msg.(*vesting.MsgCreateVestingAccount); ok {
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "MsgCreateVestingAccount not supported")
-
 		}
 	}
+
 	return next(ctx, tx, simulate)
 }

--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -1,0 +1,27 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+// VestingAccountDecorator blocks MsgCreateVestingAccount from reaching the mempool
+type VestingAccountDecorator struct{}
+
+func NewVestingAccountDecorator() VestingAccountDecorator {
+	return VestingAccountDecorator{}
+}
+
+func (vad VestingAccountDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	msgs := tx.GetMsgs()
+	for _, msg := range msgs {
+		_, ok := msg.(*vesting.MsgCreateVestingAccount)
+		if ok {
+			// return ctx, fmt.Errorf("MsgCreateVestingAccount not supported")
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "MsgCreateVestingAccount not supported")
+
+		}
+	}
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/vesting_test.go
+++ b/app/ante/vesting_test.go
@@ -1,0 +1,45 @@
+package ante_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/simapp/helpers"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/app/ante"
+)
+
+func TestVestingMempoolDecorator_MsgCreateVestingAccount_Unauthorized(t *testing.T) {
+	txConfig := app.MakeEncodingConfig().TxConfig
+
+	testPrivKeys, testAddresses := app.GeneratePrivKeyAddressPairs(5)
+
+	decorator := ante.NewVestingAccountDecorator()
+
+	tx, err := helpers.GenTx(
+		txConfig,
+		[]sdk.Msg{
+			vesting.NewMsgCreateVestingAccount(
+				testAddresses[0], testAddresses[1],
+				sdk.NewCoins(sdk.NewInt64Coin("ukava", 100_000_000)),
+				time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC).Unix(), false),
+		},
+		sdk.NewCoins(),
+		helpers.DefaultGenTxGas,
+		"testing-chain-id",
+		[]uint64{0},
+		[]uint64{0},
+		testPrivKeys[0],
+	)
+	require.NoError(t, err)
+	mmd := MockAnteHandler{}
+	ctx := sdk.Context{}.WithIsCheckTx(true)
+	_, err = decorator.AnteHandle(ctx, tx, false, mmd.AnteHandle)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MsgCreateVestingAccount not supported")
+}


### PR DESCRIPTION
Implements a new ante handler which blocks msgs that contain `MsgCreateVestingAccount`