### PR TITLE
Migrate v15 SubParamPermission to v16 ParamsChangePermission

### DIFF
--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -1270,6 +1270,17 @@
                           "keeper_reward_percentage",
                           "stability_fee"
                         ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "swp-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
                       }
                     ]
                   },
@@ -1442,6 +1453,16 @@
                       {
                         "key": "denom",
                         "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
                         "allowed_subparam_attr_changes": [
                           "borrow_limit",
                           "interest_rate_model",

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -1125,12 +1125,6 @@
                     "multi_subparams_requirements": []
                   },
                   {
-                    "subspace": "bep3",
-                    "key": "AssetParams",
-                    "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
-                  },
-                  {
                     "subspace": "cdp",
                     "key": "GlobalDebtLimit",
                     "single_subparam_allowed_attrs": [],
@@ -1167,18 +1161,6 @@
                     "multi_subparams_requirements": []
                   },
                   {
-                    "subspace": "cdp",
-                    "key": "CollateralParams",
-                    "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
-                  },
-                  {
-                    "subspace": "cdp",
-                    "key": "DebtParam",
-                    "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
-                  },
-                  {
                     "subspace": "incentive",
                     "key": "Active",
                     "single_subparam_allowed_attrs": [],
@@ -1191,22 +1173,283 @@
                     "multi_subparams_requirements": []
                   },
                   {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "CollateralParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "type",
+                        "val": "bnb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-b",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "btcb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "xrpb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "ukava-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hard-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hbtc-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtParam",
+                    "single_subparam_allowed_attrs": ["debt_floor"],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "bep3",
+                    "key": "AssetParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "coin_id",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "subspace": "pricefeed",
                     "key": "Markets",
                     "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      }
+                    ]
                   },
                   {
                     "subspace": "hard",
                     "key": "MoneyMarkets",
                     "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
-                  },
-                  {
-                    "subspace": "hard",
-                    "key": "MinimumBorrowUSDValue",
-                    "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      }
+                    ]
                   }
                 ]
               },
@@ -1257,12 +1500,6 @@
                 "allowed_params_changes": [
                   {
                     "subspace": "hard",
-                    "key": "MoneyMarkets",
-                    "single_subparam_allowed_attrs": [],
-                    "multi_subparams_requirements": []
-                  },
-                  {
-                    "subspace": "hard",
                     "key": "MinimumBorrowUSDValue",
                     "single_subparam_allowed_attrs": [],
                     "multi_subparams_requirements": []
@@ -1284,6 +1521,90 @@
                     "key": "HardDelegatorRewardPeriods",
                     "single_subparam_allowed_attrs": [],
                     "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      }
+                    ]
                   }
                 ]
               }

--- a/x/committee/legacy/v0_16/migrate.go
+++ b/x/committee/legacy/v0_16/migrate.go
@@ -2,6 +2,8 @@ package v0_16
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 
 	proto "github.com/gogo/protobuf/proto"
 
@@ -15,11 +17,175 @@ import (
 	v038upgrade "github.com/cosmos/cosmos-sdk/x/upgrade/legacy/v038"
 	v040upgrade "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	v016bep3types "github.com/kava-labs/kava/x/bep3/types"
+	v016cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	v015committee "github.com/kava-labs/kava/x/committee/legacy/v0_15"
 	v016committee "github.com/kava-labs/kava/x/committee/types"
+	v016hardtypes "github.com/kava-labs/kava/x/hard/types"
 	v015kavadist "github.com/kava-labs/kava/x/kavadist/legacy/v0_15"
 	v016kavadist "github.com/kava-labs/kava/x/kavadist/types"
+	v016pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 )
+
+// migrateWhitelist returns an string slice of json keys that should be whitelisted on the whitelist interface
+func migrateWhitelist(whitelist interface{}, ignoredTag string) []string {
+	allowed := []string{}
+	v := reflect.ValueOf(whitelist)
+	typeOfS := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		tag := typeOfS.Field(i).Tag.Get("json")
+		if tag != ignoredTag && tag != "" {
+			val, ok := v.Field(i).Interface().(bool)
+			if ok && val {
+				allowed = append(allowed, tag)
+			}
+		}
+	}
+	sort.Strings(allowed)
+	return allowed
+}
+
+// isSubparamAllowed returns true if the subspace and key is allowed in the v15 permissions
+func isSubparamAllowed(permission v015committee.SubParamChangePermission, subspace string, key string) bool {
+	for _, allowed := range permission.AllowedParams {
+		if allowed.Key == key && allowed.Subspace == subspace {
+			return true
+		}
+	}
+	return false
+}
+
+type subspaceKeyPair struct {
+	key      []byte
+	subspace string
+}
+
+// migrateSubParamPermissions converts v15 SubParamChangePermissions to v16 ParamsChangePermission
+func migrateSubParamPermissions(permission v015committee.SubParamChangePermission) *v016committee.ParamsChangePermission {
+	changes := v016committee.AllowedParamsChanges{}
+
+	// migrate allowed params
+	pairsToAvoid := []subspaceKeyPair{
+		{key: v016cdptypes.KeyCollateralParams, subspace: v016cdptypes.ModuleName},
+		{key: v016cdptypes.KeyDebtParam, subspace: v016cdptypes.ModuleName},
+		{key: v016bep3types.KeyAssetParams, subspace: v016bep3types.ModuleName},
+		{key: v016pricefeedtypes.KeyMarkets, subspace: v016pricefeedtypes.ModuleName},
+		{key: v016hardtypes.KeyMoneyMarkets, subspace: v016hardtypes.ModuleName},
+	}
+	for _, allowed := range permission.AllowedParams {
+		shouldAvoid := false
+		for _, pair := range pairsToAvoid {
+			if string(pair.key) == allowed.Key && pair.subspace == allowed.Subspace {
+				shouldAvoid = true
+				break
+			}
+		}
+		if !shouldAvoid {
+			changes = append(changes, v016committee.AllowedParamsChange{
+				Subspace: allowed.Subspace,
+				Key:      allowed.Key,
+			})
+		}
+	}
+
+	// migrate collateral params
+	if isSubparamAllowed(permission, v016cdptypes.ModuleName, string(v016cdptypes.KeyCollateralParams)) {
+		change := v016committee.AllowedParamsChange{
+			Key:      string(v016cdptypes.KeyCollateralParams),
+			Subspace: string(v016cdptypes.ModuleName),
+		}
+		requirements := []v016committee.SubparamRequirement{}
+		for _, param := range permission.AllowedCollateralParams {
+			requirement := v016committee.SubparamRequirement{
+				Key:                        "type",
+				Val:                        param.Type,
+				AllowedSubparamAttrChanges: []string{},
+			}
+			allowed := migrateWhitelist(param, "type")
+			requirement.AllowedSubparamAttrChanges = allowed
+			requirements = append(requirements, requirement)
+		}
+		change.MultiSubparamsRequirements = requirements
+		changes = append(changes, change)
+	}
+
+	// migrate debt params
+	if isSubparamAllowed(permission, string(v016cdptypes.ModuleName), string(v016cdptypes.KeyDebtParam)) {
+		change := v016committee.AllowedParamsChange{
+			Subspace:                   v016cdptypes.ModuleName,
+			Key:                        string(v016cdptypes.KeyDebtParam),
+			SingleSubparamAllowedAttrs: migrateWhitelist(permission.AllowedDebtParam, ""),
+		}
+		changes = append(changes, change)
+	}
+
+	// migrate asset params
+	if isSubparamAllowed(permission, string(v016bep3types.ModuleName), string(v016bep3types.KeyAssetParams)) {
+		change := v016committee.AllowedParamsChange{
+			Key:      string(v016bep3types.KeyAssetParams),
+			Subspace: string(v016bep3types.ModuleName),
+		}
+		requirements := []v016committee.SubparamRequirement{}
+		for _, param := range permission.AllowedAssetParams {
+			requirement := v016committee.SubparamRequirement{
+				Key:                        "denom",
+				Val:                        param.Denom,
+				AllowedSubparamAttrChanges: []string{},
+			}
+			allowed := migrateWhitelist(param, "denom")
+			requirement.AllowedSubparamAttrChanges = allowed
+			requirements = append(requirements, requirement)
+		}
+		change.MultiSubparamsRequirements = requirements
+		changes = append(changes, change)
+	}
+
+	// migrate markets
+	if isSubparamAllowed(permission, string(v016pricefeedtypes.ModuleName), string(v016pricefeedtypes.KeyMarkets)) {
+		change := v016committee.AllowedParamsChange{
+			Key:      string(v016pricefeedtypes.KeyMarkets),
+			Subspace: string(v016pricefeedtypes.ModuleName),
+		}
+		requirements := []v016committee.SubparamRequirement{}
+		for _, param := range permission.AllowedMarkets {
+			requirement := v016committee.SubparamRequirement{
+				Key:                        "market_id",
+				Val:                        param.MarketID,
+				AllowedSubparamAttrChanges: []string{},
+			}
+			allowed := migrateWhitelist(param, "market_id")
+			requirement.AllowedSubparamAttrChanges = allowed
+			requirements = append(requirements, requirement)
+		}
+		change.MultiSubparamsRequirements = requirements
+		changes = append(changes, change)
+	}
+
+	// migrate money markets
+	if isSubparamAllowed(permission, string(v016hardtypes.ModuleName), string(v016hardtypes.KeyMoneyMarkets)) {
+		change := v016committee.AllowedParamsChange{
+			Key:      string(v016hardtypes.KeyMoneyMarkets),
+			Subspace: string(v016hardtypes.ModuleName),
+		}
+		requirements := []v016committee.SubparamRequirement{}
+		for _, param := range permission.AllowedMoneyMarkets {
+			requirement := v016committee.SubparamRequirement{
+				Key:                        "denom",
+				Val:                        param.Denom,
+				AllowedSubparamAttrChanges: []string{},
+			}
+			allowed := migrateWhitelist(param, "denom")
+			requirement.AllowedSubparamAttrChanges = allowed
+			requirements = append(requirements, requirement)
+		}
+		change.MultiSubparamsRequirements = requirements
+		changes = append(changes, change)
+	}
+
+	return &v016committee.ParamsChangePermission{
+		AllowedParamsChanges: changes,
+	}
+}
 
 func migratePermission(v015permission v015committee.Permission) *codectypes.Any {
 	var protoProposal proto.Message
@@ -52,18 +218,7 @@ func migratePermission(v015permission v015committee.Permission) *codectypes.Any 
 		}
 	case v015committee.SubParamChangePermission:
 		{
-			// TODO: Not implemented
-			// for now just convert these params change permission without sub param restrictions
-			changes := make(v016committee.AllowedParamsChanges, len(v015permission.AllowedParams))
-			for i, param := range v015permission.AllowedParams {
-				changes[i] = v016committee.AllowedParamsChange{
-					Subspace: param.Subspace,
-					Key:      param.Key,
-				}
-			}
-			protoProposal = &v016committee.ParamsChangePermission{
-				AllowedParamsChanges: changes,
-			}
+			protoProposal = migrateSubParamPermissions(v015permission)
 		}
 	default:
 		panic(fmt.Errorf("'%s' is not a valid permission", v015permission))

--- a/x/committee/legacy/v0_16/migrate_subparam_test.go
+++ b/x/committee/legacy/v0_16/migrate_subparam_test.go
@@ -1,0 +1,365 @@
+package v0_16
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	v016bep3types "github.com/kava-labs/kava/x/bep3/types"
+	v016cdptypes "github.com/kava-labs/kava/x/cdp/types"
+	v015committee "github.com/kava-labs/kava/x/committee/legacy/v0_15"
+	v016committee "github.com/kava-labs/kava/x/committee/types"
+	v016hardtypes "github.com/kava-labs/kava/x/hard/types"
+	v016pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
+)
+
+func (s *migrateTestSuite) TestMigrate_Committee_SubparamPermissions() {
+	testcases := []struct {
+		name           string
+		v015permission v015committee.Permission
+		v016permission v016committee.Permission
+	}{
+		{
+			name: "allowed collateral params",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016cdptypes.ModuleName,
+					Key:      string(v016cdptypes.KeyCollateralParams),
+				}},
+				AllowedCollateralParams: v015committee.AllowedCollateralParams{
+					{
+						Type:                   "bnb",
+						Denom:                  true,
+						LiquidationRatio:       false,
+						DebtLimit:              true,
+						KeeperRewardPercentage: true,
+					},
+					{
+						Type:                             "btc",
+						Prefix:                           true,
+						SpotMarketID:                     false,
+						DebtLimit:                        true,
+						CheckCollateralizationIndexCount: true,
+					},
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace: v016cdptypes.ModuleName,
+						Key:      string(v016cdptypes.KeyCollateralParams),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{
+							{
+								Key:                        "type",
+								Val:                        "bnb",
+								AllowedSubparamAttrChanges: []string{"debt_limit", "denom", "keeper_reward_percentage"},
+							},
+							{
+								Key:                        "type",
+								Val:                        "btc",
+								AllowedSubparamAttrChanges: []string{"check_collateralization_index_count", "debt_limit", "prefix"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed collateral params - no requirements",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016cdptypes.ModuleName,
+					Key:      string(v016cdptypes.KeyCollateralParams),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016cdptypes.ModuleName,
+						Key:                        string(v016cdptypes.KeyCollateralParams),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed debt params",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016cdptypes.ModuleName,
+					Key:      string(v016cdptypes.KeyDebtParam),
+				}},
+				AllowedDebtParam: v015committee.AllowedDebtParam{
+					Denom:            true,
+					ReferenceAsset:   false,
+					ConversionFactor: true,
+					DebtFloor:        true,
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016cdptypes.ModuleName,
+						Key:                        string(v016cdptypes.KeyDebtParam),
+						SingleSubparamAllowedAttrs: []string{"conversion_factor", "debt_floor", "denom"},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed debt params - no requirements",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016cdptypes.ModuleName,
+					Key:      string(v016cdptypes.KeyDebtParam),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016cdptypes.ModuleName,
+						Key:                        string(v016cdptypes.KeyDebtParam),
+						SingleSubparamAllowedAttrs: []string{},
+					},
+				},
+			},
+		},
+		{
+			name: "param not allowed",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedDebtParam: v015committee.AllowedDebtParam{
+					Denom:            true,
+					ReferenceAsset:   false,
+					ConversionFactor: true,
+					DebtFloor:        true,
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{},
+			},
+		},
+		{
+			name: "allowed asset params",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016bep3types.ModuleName,
+					Key:      string(v016bep3types.KeyAssetParams),
+				}},
+				AllowedAssetParams: v015committee.AllowedAssetParams{
+					{
+						Denom:         "bnb",
+						CoinID:        true,
+						MaxSwapAmount: true,
+						Active:        true,
+					},
+					{
+						Denom:        "btc",
+						Limit:        true,
+						MinBlockLock: true,
+						Active:       true,
+					},
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace: v016bep3types.ModuleName,
+						Key:      string(v016bep3types.KeyAssetParams),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{
+							{
+								Key:                        "denom",
+								Val:                        "bnb",
+								AllowedSubparamAttrChanges: []string{"active", "coin_id", "max_swap_amount"},
+							},
+							{
+								Key:                        "denom",
+								Val:                        "btc",
+								AllowedSubparamAttrChanges: []string{"active", "limit", "min_block_lock"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed asset params - no requirements",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016bep3types.ModuleName,
+					Key:      string(v016bep3types.KeyAssetParams),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016bep3types.ModuleName,
+						Key:                        string(v016bep3types.KeyAssetParams),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed markets",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016pricefeedtypes.ModuleName,
+					Key:      string(v016pricefeedtypes.KeyMarkets),
+				}},
+				AllowedMarkets: v015committee.AllowedMarkets{
+					{
+						MarketID:   "bnb-btc",
+						BaseAsset:  false,
+						QuoteAsset: true,
+						Active:     true,
+					},
+					{
+						MarketID:  "btc-usd",
+						BaseAsset: true,
+						Oracles:   true,
+						Active:    true,
+					},
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace: v016pricefeedtypes.ModuleName,
+						Key:      string(v016pricefeedtypes.KeyMarkets),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{
+							{
+								Key:                        "market_id",
+								Val:                        "bnb-btc",
+								AllowedSubparamAttrChanges: []string{"active", "quote_asset"},
+							},
+							{
+								Key:                        "market_id",
+								Val:                        "btc-usd",
+								AllowedSubparamAttrChanges: []string{"active", "base_asset", "oracles"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed markets - no requirements",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016pricefeedtypes.ModuleName,
+					Key:      string(v016pricefeedtypes.KeyMarkets),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016pricefeedtypes.ModuleName,
+						Key:                        string(v016pricefeedtypes.KeyMarkets),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed money markets",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016hardtypes.ModuleName,
+					Key:      string(v016hardtypes.KeyMoneyMarkets),
+				}},
+				AllowedMoneyMarkets: v015committee.AllowedMoneyMarkets{
+					{
+						Denom:                  "bnb",
+						BorrowLimit:            true,
+						ConversionFactor:       false,
+						ReserveFactor:          true,
+						KeeperRewardPercentage: true,
+					},
+					{
+						Denom:             "btc",
+						BorrowLimit:       false,
+						SpotMarketID:      true,
+						InterestRateModel: true,
+					},
+				},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace: v016hardtypes.ModuleName,
+						Key:      string(v016hardtypes.KeyMoneyMarkets),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{
+							{
+								Key:                        "denom",
+								Val:                        "bnb",
+								AllowedSubparamAttrChanges: []string{"borrow_limit", "keeper_reward_percentage", "reserve_factor"},
+							},
+							{
+								Key:                        "denom",
+								Val:                        "btc",
+								AllowedSubparamAttrChanges: []string{"interest_rate_model", "spot_market_id"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed money markets - no requirements",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016hardtypes.ModuleName,
+					Key:      string(v016hardtypes.KeyMoneyMarkets),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace:                   v016hardtypes.ModuleName,
+						Key:                        string(v016hardtypes.KeyMoneyMarkets),
+						MultiSubparamsRequirements: []v016committee.SubparamRequirement{},
+					},
+				},
+			},
+		},
+		{
+			name: "allowed params",
+			v015permission: v015committee.SubParamChangePermission{
+				AllowedParams: v015committee.AllowedParams{{
+					Subspace: v016hardtypes.ModuleName,
+					Key:      string(v016hardtypes.KeyMinimumBorrowUSDValue),
+				}},
+			},
+			v016permission: &v016committee.ParamsChangePermission{
+				AllowedParamsChanges: v016committee.AllowedParamsChanges{
+					{
+						Subspace: v016hardtypes.ModuleName,
+						Key:      string(v016hardtypes.KeyMinimumBorrowUSDValue),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		s.Run(tc.name, func() {
+			oldCommittee := v015committee.MemberCommittee{
+				BaseCommittee: v015committee.BaseCommittee{
+					ID:               1,
+					Description:      "test",
+					Members:          s.addresses,
+					Permissions:      []v015committee.Permission{tc.v015permission},
+					VoteThreshold:    sdk.NewDec(40),
+					ProposalDuration: time.Hour * 24 * 7,
+					TallyOption:      v015committee.FirstPastThePost,
+				},
+			}
+			expectedProposal, err := v016committee.NewMemberCommittee(1, "test", s.addresses, []v016committee.Permission{tc.v016permission}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, v016committee.TALLY_OPTION_FIRST_PAST_THE_POST)
+			s.Require().NoError(err)
+			s.v15genstate.Committees = []v015committee.Committee{oldCommittee}
+			genState := Migrate(s.v15genstate)
+			s.Require().Len(genState.Committees, 1)
+			s.Equal(expectedProposal, genState.GetCommittees()[0])
+		})
+	}
+}

--- a/x/committee/legacy/v0_16/migrate_subparam_test.go
+++ b/x/committee/legacy/v0_16/migrate_subparam_test.go
@@ -345,7 +345,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_SubparamPermissions() {
 		s.Run(tc.name, func() {
 			oldCommittee := v015committee.MemberCommittee{
 				BaseCommittee: v015committee.BaseCommittee{
-					ID:               1,
+					ID:               2,
 					Description:      "test",
 					Members:          s.addresses,
 					Permissions:      []v015committee.Permission{tc.v015permission},
@@ -354,7 +354,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_SubparamPermissions() {
 					TallyOption:      v015committee.FirstPastThePost,
 				},
 			}
-			expectedProposal, err := v016committee.NewMemberCommittee(1, "test", s.addresses, []v016committee.Permission{tc.v016permission}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, v016committee.TALLY_OPTION_FIRST_PAST_THE_POST)
+			expectedProposal, err := v016committee.NewMemberCommittee(2, "test", s.addresses, []v016committee.Permission{tc.v016permission}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, v016committee.TALLY_OPTION_FIRST_PAST_THE_POST)
 			s.Require().NoError(err)
 			s.v15genstate.Committees = []v015committee.Committee{oldCommittee}
 			genState := Migrate(s.v15genstate)

--- a/x/committee/legacy/v0_16/migrate_test.go
+++ b/x/committee/legacy/v0_16/migrate_test.go
@@ -124,7 +124,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_TallyOption() {
 		s.Run(tc.name, func() {
 			oldCommittee := v015committee.MemberCommittee{
 				BaseCommittee: v015committee.BaseCommittee{
-					ID:               1,
+					ID:               2,
 					Description:      "test",
 					Members:          s.addresses,
 					Permissions:      []v015committee.Permission{},
@@ -133,7 +133,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_TallyOption() {
 					TallyOption:      tc.v015tallyOption,
 				},
 			}
-			expectedProposal, err := v016committee.NewMemberCommittee(1, "test", s.addresses, []v016committee.Permission{}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, tc.v016tallyOption)
+			expectedProposal, err := v016committee.NewMemberCommittee(2, "test", s.addresses, []v016committee.Permission{}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, tc.v016tallyOption)
 			s.Require().NoError(err)
 			s.v15genstate.Committees = []v015committee.Committee{oldCommittee}
 			genState := Migrate(s.v15genstate)
@@ -200,7 +200,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_Permissions() {
 		s.Run(tc.name, func() {
 			oldCommittee := v015committee.MemberCommittee{
 				BaseCommittee: v015committee.BaseCommittee{
-					ID:               1,
+					ID:               2,
 					Description:      "test",
 					Members:          s.addresses,
 					Permissions:      []v015committee.Permission{tc.v015permission},
@@ -209,7 +209,7 @@ func (s *migrateTestSuite) TestMigrate_Committee_Permissions() {
 					TallyOption:      v015committee.FirstPastThePost,
 				},
 			}
-			expectedProposal, err := v016committee.NewMemberCommittee(1, "test", s.addresses, []v016committee.Permission{tc.v016permission}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, v016committee.TALLY_OPTION_FIRST_PAST_THE_POST)
+			expectedProposal, err := v016committee.NewMemberCommittee(2, "test", s.addresses, []v016committee.Permission{tc.v016permission}, oldCommittee.VoteThreshold, oldCommittee.ProposalDuration, v016committee.TALLY_OPTION_FIRST_PAST_THE_POST)
 			s.Require().NoError(err)
 			s.v15genstate.Committees = []v015committee.Committee{oldCommittee}
 			genState := Migrate(s.v15genstate)

--- a/x/committee/legacy/v0_16/testdata/v16-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v16-committee.json
@@ -36,12 +36,6 @@
                 "multi_subparams_requirements": []
               },
               {
-                "subspace": "bep3",
-                "key": "AssetParams",
-                "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
-              },
-              {
                 "subspace": "cdp",
                 "key": "GlobalDebtLimit",
                 "single_subparam_allowed_attrs": [],
@@ -78,18 +72,6 @@
                 "multi_subparams_requirements": []
               },
               {
-                "subspace": "cdp",
-                "key": "CollateralParams",
-                "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
-              },
-              {
-                "subspace": "cdp",
-                "key": "DebtParam",
-                "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
-              },
-              {
                 "subspace": "incentive",
                 "key": "Active",
                 "single_subparam_allowed_attrs": [],
@@ -102,22 +84,283 @@
                 "multi_subparams_requirements": []
               },
               {
+                "subspace": "hard",
+                "key": "MinimumBorrowUSDValue",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "cdp",
+                "key": "CollateralParams",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": [
+                  {
+                    "key": "type",
+                    "val": "bnb-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "busd-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "busd-b",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "btcb-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "xrpb-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "ukava-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "hard-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "hbtc-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
+                  }
+                ]
+              },
+              {
+                "subspace": "cdp",
+                "key": "DebtParam",
+                "single_subparam_allowed_attrs": ["debt_floor"],
+                "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "bep3",
+                "key": "AssetParams",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": [
+                  {
+                    "key": "denom",
+                    "val": "bnb",
+                    "allowed_subparam_attr_changes": [
+                      "active",
+                      "limit",
+                      "max_swap_amount",
+                      "min_block_lock"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "busd",
+                    "allowed_subparam_attr_changes": [
+                      "active",
+                      "coin_id",
+                      "limit",
+                      "max_swap_amount",
+                      "min_block_lock"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "btcb",
+                    "allowed_subparam_attr_changes": [
+                      "active",
+                      "limit",
+                      "max_swap_amount",
+                      "min_block_lock"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "xrpb",
+                    "allowed_subparam_attr_changes": [
+                      "active",
+                      "limit",
+                      "max_swap_amount",
+                      "min_block_lock"
+                    ]
+                  }
+                ]
+              },
+              {
                 "subspace": "pricefeed",
                 "key": "Markets",
                 "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
+                "multi_subparams_requirements": [
+                  {
+                    "key": "market_id",
+                    "val": "bnb:usd",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "bnb:usd:30",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "btc:usd",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "btc:usd:30",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "xrp:usd",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "xrp:usd:30",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "busd:usd",
+                    "allowed_subparam_attr_changes": ["active"]
+                  },
+                  {
+                    "key": "market_id",
+                    "val": "busd:usd:30",
+                    "allowed_subparam_attr_changes": ["active"]
+                  }
+                ]
               },
               {
                 "subspace": "hard",
                 "key": "MoneyMarkets",
                 "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
-              },
-              {
-                "subspace": "hard",
-                "key": "MinimumBorrowUSDValue",
-                "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
+                "multi_subparams_requirements": [
+                  {
+                    "key": "denom",
+                    "val": "bnb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "busd",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "btcb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "xrpb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "usdx",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "ukava",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "hard",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -166,12 +409,6 @@
             "allowed_params_changes": [
               {
                 "subspace": "hard",
-                "key": "MoneyMarkets",
-                "single_subparam_allowed_attrs": [],
-                "multi_subparams_requirements": []
-              },
-              {
-                "subspace": "hard",
                 "key": "MinimumBorrowUSDValue",
                 "single_subparam_allowed_attrs": [],
                 "multi_subparams_requirements": []
@@ -193,6 +430,90 @@
                 "key": "HardDelegatorRewardPeriods",
                 "single_subparam_allowed_attrs": [],
                 "multi_subparams_requirements": []
+              },
+              {
+                "subspace": "hard",
+                "key": "MoneyMarkets",
+                "single_subparam_allowed_attrs": [],
+                "multi_subparams_requirements": [
+                  {
+                    "key": "denom",
+                    "val": "bnb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "busd",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "btcb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "xrpb",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "usdx",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "ukava",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "hard",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/x/committee/legacy/v0_16/testdata/v16-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v16-committee.json
@@ -181,6 +181,17 @@
                       "keeper_reward_percentage",
                       "stability_fee"
                     ]
+                  },
+                  {
+                    "key": "type",
+                    "val": "swp-a",
+                    "allowed_subparam_attr_changes": [
+                      "auction_size",
+                      "check_collateralization_index_count",
+                      "debt_limit",
+                      "keeper_reward_percentage",
+                      "stability_fee"
+                    ]
                   }
                 ]
               },
@@ -353,6 +364,16 @@
                   {
                     "key": "denom",
                     "val": "hard",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "swp",
                     "allowed_subparam_attr_changes": [
                       "borrow_limit",
                       "interest_rate_model",

--- a/x/committee/types/codec.go
+++ b/x/committee/types/codec.go
@@ -81,7 +81,6 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"kava.committee.v1beta1.Committee",
 		(*Committee)(nil),
-		// TODO: Might not need the base one since we just use token and member, add some tests to test this out.
 		&BaseCommittee{},
 		&TokenCommittee{},
 		&MemberCommittee{},


### PR DESCRIPTION
Migrate v15 `SubParamPermission` with requires for different module params to the v16 format. All functionalities and intentions of the original restrictions should be preserved. 