### PR TITLE
Make module json param queries consistent 

### DIFF
--- a/x/auction/client/cli/query.go
+++ b/x/auction/client/cli/query.go
@@ -58,7 +58,7 @@ func GetCmdQueryParams() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/bep3/client/cli/query.go
+++ b/x/bep3/client/cli/query.go
@@ -329,7 +329,8 @@ func QueryParamsCmd(queryRoute string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return clientCtx.PrintProto(res)
+
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/cdp/client/cli/query.go
+++ b/x/cdp/client/cli/query.go
@@ -241,7 +241,7 @@ func QueryParamsCmd() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/hard/client/cli/query.go
+++ b/x/hard/client/cli/query.go
@@ -73,7 +73,7 @@ func queryParamsCmd() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/issuance/client/cli/query.go
+++ b/x/issuance/client/cli/query.go
@@ -53,7 +53,7 @@ func GetCmdQueryParams() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/kavadist/client/cli/query.go
+++ b/x/kavadist/client/cli/query.go
@@ -48,7 +48,7 @@ func queryParamsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return cliCtx.PrintProto(res)
+			return cliCtx.PrintProto(&res.Params)
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)

--- a/x/pricefeed/client/cli/query.go
+++ b/x/pricefeed/client/cli/query.go
@@ -198,7 +198,7 @@ func GetCmdQueryParams() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }

--- a/x/swap/client/cli/query.go
+++ b/x/swap/client/cli/query.go
@@ -62,7 +62,7 @@ func queryParamsCmd(queryRoute string) *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			return clientCtx.PrintProto(&res.Params)
 		},
 	}
 }


### PR DESCRIPTION
Updates output to remove the extra outer `"params"` wrapping field for all modules, e.g `{ "collateral_params": [], ... }` instead of `{"params": { "collateral_params": [], ... } }`

Incentive module is unchanged as it uses legacy querying.