### PR TITLE
CircleCI: Enable Docker Build Kit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           version: 20.10.11
       - run:
           name: Build Docker image
-          command: docker build -t $IMAGE_NAME:$CIRCLE_BRANCH .
+          command: DOCKER_BUILDKIT=1 docker build -t $IMAGE_NAME:$CIRCLE_BRANCH .
       - run:
           name: Publish Docker Image to Docker Hub
           command: |


### PR DESCRIPTION
Allow usage of build cache in circleci