### PR TITLE
Update migrations to include uatom IBC denom money market

### DIFF
--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -1893,29 +1893,10 @@
           }
         },
         {
-          "type": "kava/MemberCommittee",
-          "value": {
-            "base_committee": {
-              "id": "3",
-              "description": "Kava God Committee (testing only)",
-              "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
-              "permissions": [
-                {
-                  "type": "kava/GodPermission",
-                  "value": {}
-                }
-              ],
-              "vote_threshold": "0.500000000000000000",
-              "proposal_duration": "604800000000000",
-              "tally_option": "FirstPastThePost"
-            }
-          }
-        },
-        {
           "type": "kava/TokenCommittee",
           "value": {
             "base_committee": {
-              "id": "4",
+              "id": "3",
               "description": "Hard Governance Committee",
               "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
               "permissions": [
@@ -2033,7 +2014,7 @@
           "type": "kava/TokenCommittee",
           "value": {
             "base_committee": {
-              "id": "5",
+              "id": "4",
               "description": "Swp Governance Committee",
               "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
               "permissions": [
@@ -2077,6 +2058,25 @@
             },
             "quorum": "0.330000000000000000",
             "tally_denom": "swp"
+          }
+        },
+        {
+          "type": "kava/MemberCommittee",
+          "value": {
+            "base_committee": {
+              "id": "5",
+              "description": "Kava God Committee (testing only)",
+              "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+              "permissions": [
+                {
+                  "type": "kava/GodPermission",
+                  "value": {}
+                }
+              ],
+              "vote_threshold": "0.500000000000000000",
+              "proposal_duration": "604800000000000",
+              "tally_option": "FirstPastThePost"
+            }
           }
         }
       ],

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -398,6 +398,24 @@
             },
             "reserve_factor": "0.100000000000000000",
             "keeper_reward_percentage": "0.010000000000000000"
+          },
+          {
+            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "25000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "atom:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
           }
         ],
         "minimum_borrow_usd_value": "10.000000000000000000"
@@ -1469,6 +1487,16 @@
                           "keeper_reward_percentage",
                           "reserve_factor"
                         ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
                       }
                     ]
                   }
@@ -2004,10 +2032,7 @@
         "create_localhost": false,
         "next_client_sequence": "0",
         "params": {
-          "allowed_clients": [
-            "06-solomachine",
-            "07-tendermint"
-          ]
+          "allowed_clients": ["06-solomachine", "07-tendermint"]
         }
       },
       "connection_genesis": {

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -1524,23 +1524,9 @@
           }
         },
         {
-          "@type": "/kava.committee.v1beta1.MemberCommittee",
-          "base_committee": {
-            "id": "3",
-            "description": "Kava God Committee (testing only)",
-            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
-            "permissions": [
-              { "@type": "/kava.committee.v1beta1.GodPermission" }
-            ],
-            "vote_threshold": "0.500000000000000000",
-            "proposal_duration": "604800s",
-            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
-          }
-        },
-        {
           "@type": "/kava.committee.v1beta1.TokenCommittee",
           "base_committee": {
-            "id": "4",
+            "id": "3",
             "description": "Hard Governance Committee",
             "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
             "permissions": [
@@ -1652,6 +1638,28 @@
                           "reserve_factor",
                           "spot_market_id"
                         ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
                       }
                     ]
                   }
@@ -1668,7 +1676,7 @@
         {
           "@type": "/kava.committee.v1beta1.TokenCommittee",
           "base_committee": {
-            "id": "5",
+            "id": "4",
             "description": "Swp Governance Committee",
             "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
             "permissions": [
@@ -1708,6 +1716,20 @@
           },
           "quorum": "0.330000000000000000",
           "tally_denom": "swp"
+        },
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "5",
+            "description": "Kava God Committee (testing only)",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              { "@type": "/kava.committee.v1beta1.GodPermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "604800s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
         }
       ],
       "proposals": [

--- a/x/committee/legacy/v0_16/migrate.go
+++ b/x/committee/legacy/v0_16/migrate.go
@@ -184,7 +184,7 @@ func migrateSubParamPermissions(
 			requirements = append(requirements, requirement)
 		}
 
-		if isStabilityCommittee {
+		if committeeID == KavaStabilityCommitteeID {
 			// Add permissions for existing pricefeed markets that are missing in allowed_markets
 		outer:
 			for _, oldPricefeedMarket := range oldPricefeedState.Params.Markets {

--- a/x/committee/legacy/v0_16/migrate.go
+++ b/x/committee/legacy/v0_16/migrate.go
@@ -28,6 +28,11 @@ import (
 	v016pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 )
 
+const (
+	KavaStabilityCommitteeID  = 1
+	HardGovernanceCommitteeID = 3
+)
+
 // migrateWhitelist returns an string slice of json keys that should be whitelisted on the whitelist interface
 func migrateWhitelist(whitelist interface{}, ignoredTag string) []string {
 	allowed := []string{}
@@ -108,7 +113,7 @@ func migrateSubParamPermissions(permission v015committee.SubParamChangePermissio
 		}
 
 		// add new requirement for stability committee
-		if committeeID == 1 {
+		if committeeID == KavaStabilityCommitteeID {
 			requirement := v016committee.SubparamRequirement{
 				Key: "type",
 				Val: "swp-a",
@@ -195,7 +200,7 @@ func migrateSubParamPermissions(permission v015committee.SubParamChangePermissio
 		}
 
 		// add new requirement for stability committee
-		if committeeID == 1 {
+		if committeeID == KavaStabilityCommitteeID {
 			requirement := v016committee.SubparamRequirement{
 				Key: "denom",
 				Val: "swp",
@@ -215,7 +220,7 @@ func migrateSubParamPermissions(permission v015committee.SubParamChangePermissio
 				},
 			}
 			requirements = append(requirements, requirementAtom)
-		} else if committeeID == 3 {
+		} else if committeeID == HardGovernanceCommitteeID {
 			// add new requirement for Hard Governance committee
 			requirementSwp := v016committee.SubparamRequirement{
 				Key: "denom",

--- a/x/committee/legacy/v0_16/migrate.go
+++ b/x/committee/legacy/v0_16/migrate.go
@@ -21,6 +21,7 @@ import (
 	v016cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	v015committee "github.com/kava-labs/kava/x/committee/legacy/v0_15"
 	v016committee "github.com/kava-labs/kava/x/committee/types"
+	v016hardMigration "github.com/kava-labs/kava/x/hard/legacy/v0_16"
 	v016hardtypes "github.com/kava-labs/kava/x/hard/types"
 	v015kavadist "github.com/kava-labs/kava/x/kavadist/legacy/v0_15"
 	v016kavadist "github.com/kava-labs/kava/x/kavadist/types"
@@ -204,6 +205,16 @@ func migrateSubParamPermissions(permission v015committee.SubParamChangePermissio
 				},
 			}
 			requirements = append(requirements, requirement)
+
+			requirementAtom := v016committee.SubparamRequirement{
+				Key: "denom",
+				Val: v016hardMigration.UATOM_IBC_DENOM,
+				AllowedSubparamAttrChanges: []string{
+					"borrow_limit", "interest_rate_model",
+					"keeper_reward_percentage", "reserve_factor",
+				},
+			}
+			requirements = append(requirements, requirementAtom)
 		}
 
 		change.MultiSubparamsRequirements = requirements

--- a/x/committee/legacy/v0_16/testdata/v15-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v15-committee.json
@@ -404,29 +404,10 @@
       }
     },
     {
-      "type": "kava/MemberCommittee",
-      "value": {
-        "base_committee": {
-          "id": "3",
-          "description": "Kava God Committee (testing only)",
-          "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
-          "permissions": [
-            {
-              "type": "kava/GodPermission",
-              "value": {}
-            }
-          ],
-          "vote_threshold": "0.500000000000000000",
-          "proposal_duration": "604800000000000",
-          "tally_option": "FirstPastThePost"
-        }
-      }
-    },
-    {
       "type": "kava/TokenCommittee",
       "value": {
         "base_committee": {
-          "id": "4",
+          "id": "3",
           "description": "Hard Governance Committee",
           "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
           "permissions": [
@@ -544,7 +525,7 @@
       "type": "kava/TokenCommittee",
       "value": {
         "base_committee": {
-          "id": "5",
+          "id": "4",
           "description": "Swp Governance Committee",
           "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
           "permissions": [
@@ -588,6 +569,25 @@
         },
         "quorum": "0.330000000000000000",
         "tally_denom": "swp"
+      }
+    },
+    {
+      "type": "kava/MemberCommittee",
+      "value": {
+        "base_committee": {
+          "id": "5",
+          "description": "Kava God Committee (testing only)",
+          "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+          "permissions": [
+            {
+              "type": "kava/GodPermission",
+              "value": {}
+            }
+          ],
+          "vote_threshold": "0.500000000000000000",
+          "proposal_duration": "604800000000000",
+          "tally_option": "FirstPastThePost"
+        }
       }
     }
   ],

--- a/x/committee/legacy/v0_16/testdata/v16-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v16-committee.json
@@ -417,21 +417,9 @@
       }
     },
     {
-      "@type": "/kava.committee.v1beta1.MemberCommittee",
-      "base_committee": {
-        "id": "3",
-        "description": "Kava God Committee (testing only)",
-        "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
-        "permissions": [{ "@type": "/kava.committee.v1beta1.GodPermission" }],
-        "vote_threshold": "0.500000000000000000",
-        "proposal_duration": "604800s",
-        "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
-      }
-    },
-    {
       "@type": "/kava.committee.v1beta1.TokenCommittee",
       "base_committee": {
-        "id": "4",
+        "id": "3",
         "description": "Hard Governance Committee",
         "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
         "permissions": [
@@ -543,6 +531,28 @@
                       "reserve_factor",
                       "spot_market_id"
                     ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "swp",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor",
+                      "spot_market_id"
+                    ]
                   }
                 ]
               }
@@ -559,7 +569,7 @@
     {
       "@type": "/kava.committee.v1beta1.TokenCommittee",
       "base_committee": {
-        "id": "5",
+        "id": "4",
         "description": "Swp Governance Committee",
         "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
         "permissions": [
@@ -599,6 +609,18 @@
       },
       "quorum": "0.330000000000000000",
       "tally_denom": "swp"
+    },
+    {
+      "@type": "/kava.committee.v1beta1.MemberCommittee",
+      "base_committee": {
+        "id": "5",
+        "description": "Kava God Committee (testing only)",
+        "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+        "permissions": [{ "@type": "/kava.committee.v1beta1.GodPermission" }],
+        "vote_threshold": "0.500000000000000000",
+        "proposal_duration": "604800s",
+        "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+      }
     }
   ],
   "proposals": [

--- a/x/committee/legacy/v0_16/testdata/v16-committee.json
+++ b/x/committee/legacy/v0_16/testdata/v16-committee.json
@@ -380,6 +380,16 @@
                       "keeper_reward_percentage",
                       "reserve_factor"
                     ]
+                  },
+                  {
+                    "key": "denom",
+                    "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                    "allowed_subparam_attr_changes": [
+                      "borrow_limit",
+                      "interest_rate_model",
+                      "keeper_reward_percentage",
+                      "reserve_factor"
+                    ]
                   }
                 ]
               }

--- a/x/hard/legacy/v0_16/migrate.go
+++ b/x/hard/legacy/v0_16/migrate.go
@@ -11,7 +11,6 @@ import (
 const UATOM_IBC_DENOM = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 
 func migrateParams(params v015hard.Params) v016hard.Params {
-	// moneyMarkets := make([]v016hard.MoneyMarket, len(params.MoneyMarkets)+1)
 	var moneyMarkets []v016hard.MoneyMarket
 	for _, mm := range params.MoneyMarkets {
 		moneyMarket := v016hard.MoneyMarket{
@@ -92,7 +91,6 @@ func migratePrevAccTimes(oldPrevAccTimes v015hard.GenesisAccumulationTimes) v016
 			BorrowInterestFactor:     prevAccTime.BorrowInterestFactor,
 		}
 	}
-
 	return prevAccTimes
 }
 

--- a/x/hard/legacy/v0_16/migrate.go
+++ b/x/hard/legacy/v0_16/migrate.go
@@ -1,14 +1,20 @@
 package v0_16
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	v015hard "github.com/kava-labs/kava/x/hard/legacy/v0_15"
 	v016hard "github.com/kava-labs/kava/x/hard/types"
 )
 
+// Denom generated via: echo -n transfer/channel-0/uatom | shasum -a 256 | awk '{printf "ibc/%s",toupper($1)}'
+const UATOM_IBC_DENOM = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+
 func migrateParams(params v015hard.Params) v016hard.Params {
-	moneyMarkets := make([]v016hard.MoneyMarket, len(params.MoneyMarkets))
-	for i, mm := range params.MoneyMarkets {
-		moneyMarkets[i] = v016hard.MoneyMarket{
+	// moneyMarkets := make([]v016hard.MoneyMarket, len(params.MoneyMarkets)+1)
+	var moneyMarkets []v016hard.MoneyMarket
+	for _, mm := range params.MoneyMarkets {
+		moneyMarket := v016hard.MoneyMarket{
 			Denom: mm.Denom,
 			BorrowLimit: v016hard.BorrowLimit{
 				HasMaxLimit:  mm.BorrowLimit.HasMaxLimit,
@@ -26,7 +32,28 @@ func migrateParams(params v015hard.Params) v016hard.Params {
 			ReserveFactor:          mm.ReserveFactor,
 			KeeperRewardPercentage: mm.KeeperRewardPercentage,
 		}
+		moneyMarkets = append(moneyMarkets, moneyMarket)
 	}
+
+	atomMoneyMarket := v016hard.MoneyMarket{
+		Denom: UATOM_IBC_DENOM,
+		BorrowLimit: v016hard.BorrowLimit{
+			HasMaxLimit:  true,
+			MaximumLimit: sdk.NewDec(25000000000),
+			LoanToValue:  sdk.MustNewDecFromStr("0.5"),
+		},
+		SpotMarketID:     "atom:usd:30",
+		ConversionFactor: sdk.NewInt(1000000),
+		InterestRateModel: v016hard.InterestRateModel{
+			BaseRateAPY:    sdk.ZeroDec(),
+			BaseMultiplier: sdk.MustNewDecFromStr("0.05"),
+			Kink:           sdk.MustNewDecFromStr("0.8"),
+			JumpMultiplier: sdk.NewDec(5),
+		},
+		ReserveFactor:          sdk.MustNewDecFromStr("0.025"),
+		KeeperRewardPercentage: sdk.MustNewDecFromStr("0.02"),
+	}
+	moneyMarkets = append(moneyMarkets, atomMoneyMarket)
 
 	return v016hard.Params{
 		MoneyMarkets:          moneyMarkets,
@@ -65,6 +92,7 @@ func migratePrevAccTimes(oldPrevAccTimes v015hard.GenesisAccumulationTimes) v016
 			BorrowInterestFactor:     prevAccTime.BorrowInterestFactor,
 		}
 	}
+
 	return prevAccTimes
 }
 

--- a/x/hard/legacy/v0_16/migrate_test.go
+++ b/x/hard/legacy/v0_16/migrate_test.go
@@ -132,6 +132,24 @@ func (s *migrateTestSuite) TestMigrate_GenState() {
 					ReserveFactor:          sdk.MustNewDecFromStr("0.5"),
 					KeeperRewardPercentage: sdk.MustNewDecFromStr("0.6"),
 				},
+				{
+					Denom: UATOM_IBC_DENOM,
+					BorrowLimit: v016hard.BorrowLimit{
+						HasMaxLimit:  true,
+						MaximumLimit: sdk.NewDec(25000000000),
+						LoanToValue:  sdk.MustNewDecFromStr("0.5"),
+					},
+					SpotMarketID:     "atom:usd:30",
+					ConversionFactor: sdk.NewInt(1000000),
+					InterestRateModel: v016hard.InterestRateModel{
+						BaseRateAPY:    sdk.ZeroDec(),
+						BaseMultiplier: sdk.MustNewDecFromStr("0.05"),
+						Kink:           sdk.MustNewDecFromStr("0.8"),
+						JumpMultiplier: sdk.NewDec(5),
+					},
+					ReserveFactor:          sdk.MustNewDecFromStr("0.025"),
+					KeeperRewardPercentage: sdk.MustNewDecFromStr("0.02"),
+				},
 			},
 		},
 		PreviousAccumulationTimes: v016hard.GenesisAccumulationTimes{

--- a/x/hard/legacy/v0_16/testdata/v16-hard.json
+++ b/x/hard/legacy/v0_16/testdata/v16-hard.json
@@ -36,6 +36,24 @@
         },
         "reserve_factor": "0.100000000000000000",
         "keeper_reward_percentage": "0.010000000000000000"
+      },
+      {
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+        "borrow_limit": {
+          "has_max_limit": true,
+          "maximum_limit": "25000000000.000000000000000000",
+          "loan_to_value": "0.500000000000000000"
+        },
+        "spot_market_id": "atom:usd:30",
+        "conversion_factor": "1000000",
+        "interest_rate_model": {
+          "base_rate_apy": "0.000000000000000000",
+          "base_multiplier": "0.050000000000000000",
+          "kink": "0.800000000000000000",
+          "jump_multiplier": "5.000000000000000000"
+        },
+        "reserve_factor": "0.025000000000000000",
+        "keeper_reward_percentage": "0.020000000000000000"
       }
     ],
     "minimum_borrow_usd_value": "10.000000000000000000"


### PR DESCRIPTION
Update hard and committee module migrations to include uatom's IBC denom. I set the initial limit is set to ~$1m.