### PR TITLE
Validate module genesis states after migration

### DIFF
--- a/migrate/v0_16/cosmos.go
+++ b/migrate/v0_16/cosmos.go
@@ -8,6 +8,7 @@ import (
 
 	v039auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v039"
 	v040auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v040"
+	v040authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	v036supply "github.com/cosmos/cosmos-sdk/x/bank/legacy/v036"
 	v038bank "github.com/cosmos/cosmos-sdk/x/bank/legacy/v038"
 	v040bank "github.com/cosmos/cosmos-sdk/x/bank/legacy/v040"
@@ -118,8 +119,13 @@ func migrateV040(appState genutiltypes.AppMap, clientCtx client.Context, genesis
 		// delete deprecated x/auth genesis state
 		delete(appState, v039auth.ModuleName)
 
+		migratedGenState := MigrateAuthV040(authGenState, genesisTime)
+		if err := v040authtypes.ValidateGenesis(*migratedGenState); err != nil {
+			panic(err)
+		}
+
 		// Run our custom auth v40 migration on the v039 auth gen state
-		appState[v040auth.ModuleName] = v040Codec.MustMarshalJSON(MigrateAuthV040(authGenState, genesisTime))
+		appState[v040auth.ModuleName] = v040Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/crisis.

--- a/migrate/v0_16/kava.go
+++ b/migrate/v0_16/kava.go
@@ -49,8 +49,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015auction.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015auction.ModuleName], &genState)
 
+		migratedGenState := v016auction.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015auction.ModuleName] = v16Codec.MustMarshalJSON(v016auction.Migrate(genState))
+		appState[v015auction.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/committee
@@ -59,8 +64,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015committee.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015committee.ModuleName], &genState)
 
+		migratedGenState := v016committee.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015committee.ModuleName] = v16Codec.MustMarshalJSON(v016committee.Migrate(genState))
+		appState[v015committee.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/bep3
@@ -69,8 +79,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015bep3.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015bep3.ModuleName], &genState)
 
+		migratedGenState := v016bep3.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015bep3.ModuleName] = v16Codec.MustMarshalJSON(v016bep3.Migrate(genState))
+		appState[v015bep3.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/swap
@@ -79,8 +94,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015swap.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015swap.ModuleName], &genState)
 
+		migratedGenState := v016swap.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015swap.ModuleName] = v16Codec.MustMarshalJSON(v016swap.Migrate(genState))
+		appState[v015swap.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/kavadist
@@ -89,8 +109,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015kavadist.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015kavadist.ModuleName], &genState)
 
+		migratedGenState := v016kavadist.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015kavadist.ModuleName] = v16Codec.MustMarshalJSON(v016kavadist.Migrate(genState))
+		appState[v015kavadist.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/cdp
@@ -99,8 +124,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015cdp.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015cdp.ModuleName], &genState)
 
+		migratedGenState := v016cdp.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015cdp.ModuleName] = v16Codec.MustMarshalJSON(v016cdp.Migrate(genState))
+		appState[v015cdp.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/issuance
@@ -109,8 +139,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015issuance.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015issuance.ModuleName], &genState)
 
+		migratedGenState := v016issuance.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015issuance.ModuleName] = v16Codec.MustMarshalJSON(v016issuance.Migrate(genState))
+		appState[v015issuance.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/pricefeed
@@ -119,8 +154,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015pricefeed.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015pricefeed.ModuleName], &genState)
 
+		migratedGenState := v016pricefeed.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015pricefeed.ModuleName] = v16Codec.MustMarshalJSON(v016pricefeed.Migrate(genState))
+		appState[v015pricefeed.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/hard
@@ -129,8 +169,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015hard.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015hard.ModuleName], &genState)
 
+		migratedGenState := v016hard.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015hard.ModuleName] = v16Codec.MustMarshalJSON(v016hard.Migrate(genState))
+		appState[v015hard.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Migrate x/incentive
@@ -139,8 +184,13 @@ func migrateKavaAppState(appState genutiltypes.AppMap, clientCtx client.Context)
 		var genState v015incentive.GenesisState
 		v15Codec.MustUnmarshalJSON(appState[v015incentive.ModuleName], &genState)
 
+		migratedGenState := v016incentive.Migrate(genState)
+		if err := migratedGenState.Validate(); err != nil {
+			panic(err)
+		}
+
 		// replace migrated genstate with previous genstate
-		appState[v015incentive.ModuleName] = v16Codec.MustMarshalJSON(v016incentive.Migrate(genState))
+		appState[v015incentive.ModuleName] = v16Codec.MustMarshalJSON(migratedGenState)
 	}
 
 	// Remove x/validator-vesting

--- a/migrate/v0_16/testdata/appstate-bank-v15.json
+++ b/migrate/v0_16/testdata/appstate-bank-v15.json
@@ -98,7 +98,7 @@
         "type": "cosmos-sdk/Account",
         "value": {
           "account_number": "0",
-          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
           "coins": [
             {
               "amount": "100000000000000",
@@ -109,10 +109,7 @@
               "denom": "ukava"
             }
           ],
-          "public_key": {
-            "type": "tendermint/PubKeySecp256k1",
-            "value": "A7WkS5eJAiPE/gl7n4I5qa5JsREvQM5fkdgCEPhNfj0h"
-          },
+          "public_key": null,
           "sequence": "0"
         }
       },

--- a/migrate/v0_16/testdata/appstate-bank-v16.json
+++ b/migrate/v0_16/testdata/appstate-bank-v16.json
@@ -57,11 +57,8 @@
       },
       {
         "@type": "/cosmos.auth.v1beta1.BaseAccount",
-        "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
-        "pub_key": {
-          "@type": "/cosmos.crypto.secp256k1.PubKey",
-          "key": "A7WkS5eJAiPE/gl7n4I5qa5JsREvQM5fkdgCEPhNfj0h"
-        },
+        "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
+        "pub_key": null,
         "account_number": "0",
         "sequence": "0"
       },
@@ -238,7 +235,7 @@
         "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
       },
       {
-        "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+        "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
         "coins": [
           { "denom": "bnb", "amount": "100000000000000" },
           { "denom": "ukava", "amount": "1000000000000" }

--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -837,6 +837,23 @@
         {
           "type": "cosmos-sdk/ModuleAccount",
           "value": {
+            "address": "kava1j4yzhgjm00ch3h0p9kel7g8sp6g045qf8kzmmd",
+            "coins": [
+              {
+                "denom": "bnb",
+                "amount": "2"
+              }
+            ],
+            "public_key": null,
+            "account_number": "0",
+            "sequence": "0",
+            "name": "auction",
+            "permissions": ["minter", "burner"]
+          }
+        },
+        {
+          "type": "cosmos-sdk/ModuleAccount",
+          "value": {
             "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
             "coins": [
               {

--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -948,7 +948,10 @@
                 "denom": "ukava"
               }
             ],
-            "public_key": null,
+            "public_key": {
+              "type": "tendermint/PubKeySecp256k1",
+              "value": "A64VRmYpsMHDcT5tRBSiwCmdAogT0lsx6i/lEqUx8BUF"
+            },
             "sequence": "0"
           }
         },

--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -798,7 +798,7 @@
           }
         }
       ],
-      "next_auction_id": "12",
+      "next_auction_id": "3896",
       "params": {
         "bid_duration": "600000000000",
         "increment_collateral": "0.010000000000000000",
@@ -2080,7 +2080,7 @@
           }
         }
       ],
-      "next_proposal_id": "1",
+      "next_proposal_id": "4",
       "proposals": [
         {
           "pub_proposal": {
@@ -2110,7 +2110,7 @@
               "amount": [{ "denom": "ukava", "amount": "10" }]
             }
           },
-          "id": "1",
+          "id": "2",
           "committee_id": "2",
           "deadline": "2021-11-24T18:49:44.219341Z"
         },
@@ -2127,7 +2127,7 @@
               }
             }
           },
-          "id": "1",
+          "id": "3",
           "committee_id": "2",
           "deadline": "2021-11-24T18:49:44.219693Z"
         }
@@ -2221,6 +2221,30 @@
           "total_shares": "1398497336200"
         },
         {
+          "pool_id": "busd:usdx",
+          "reserves_a": {
+            "amount": "7038291919",
+            "denom": "busd"
+          },
+          "reserves_b": {
+            "amount": "72606256",
+            "denom": "usdx"
+          },
+          "total_shares": "699359418"
+        },
+        {
+          "pool_id": "hard:usdx",
+          "reserves_a": {
+            "amount": "11935938",
+            "denom": "hard"
+          },
+          "reserves_b": {
+            "amount": "8688979",
+            "denom": "usdx"
+          },
+          "total_shares": "9918771"
+        },
+        {
           "pool_id": "usdx:xrpb",
           "reserves_a": {
             "amount": "843639517257",
@@ -2237,22 +2261,22 @@
         {
           "depositor": "kava1l77xymdt2ya0rl2mludkny5aqmr67u88ymgdje",
           "pool_id": "usdx:xrpb",
-          "shares_owned": "29034728969"
+          "shares_owned": "7739661881008"
         },
         {
           "depositor": "kava1llqkrdr69wc76cuxpx6j06x9pt63f52f7mlcye",
           "pool_id": "busd:usdx",
-          "shares_owned": "24905307583"
+          "shares_owned": "699359418"
         },
         {
           "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
           "pool_id": "hard:usdx",
-          "shares_owned": "708138421"
+          "shares_owned": "9918771"
         },
         {
           "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
           "pool_id": "ukava:usdx",
-          "shares_owned": "3427014047"
+          "shares_owned": "1398497336200"
         }
       ]
     },

--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -844,7 +844,7 @@
                 "amount": "2"
               }
             ],
-            "public_key": null,
+            "public_key": "",
             "account_number": "0",
             "sequence": "0",
             "name": "auction",
@@ -923,7 +923,7 @@
           "type": "cosmos-sdk/Account",
           "value": {
             "account_number": "0",
-            "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+            "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
             "coins": [
               {
                 "amount": "100000000000000",
@@ -1477,7 +1477,7 @@
               "time_based_limit": "0"
             },
             "active": true,
-            "deputy_address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+            "deputy_address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
             "fixed_fee": "1000",
             "min_swap_amount": "1001",
             "max_swap_amount": "500000000000",

--- a/migrate/v0_16/testdata/genesis-v15.json
+++ b/migrate/v0_16/testdata/genesis-v15.json
@@ -535,6 +535,20 @@
             "market_id": "bnb:usd:30",
             "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
             "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "btc",
+            "market_id": "btc:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "btc",
+            "market_id": "btc:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
           }
         ]
       },

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -593,7 +593,7 @@
       ]
     },
     "auction": {
-      "next_auction_id": "12",
+      "next_auction_id": "3896",
       "params": {
         "max_auction_duration": "172800s",
         "bid_duration": "600s",
@@ -1088,7 +1088,7 @@
       "previous_block_time": "1970-01-01T00:00:00Z"
     },
     "committee": {
-      "next_proposal_id": "1",
+      "next_proposal_id": "4",
       "committees": [
         {
           "@type": "/kava.committee.v1beta1.MemberCommittee",
@@ -1707,7 +1707,7 @@
             "recipient": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
             "amount": [{ "denom": "ukava", "amount": "10" }]
           },
-          "id": "1",
+          "id": "2",
           "committee_id": "2",
           "deadline": "2021-11-24T18:49:44.219341Z"
         },
@@ -1724,7 +1724,7 @@
               "upgraded_client_state": null
             }
           },
-          "id": "1",
+          "id": "3",
           "committee_id": "2",
           "deadline": "2021-11-24T18:49:44.219693Z"
         }
@@ -1939,6 +1939,30 @@
           "total_shares": "1398497336200"
         },
         {
+          "pool_id": "busd:usdx",
+          "reserves_a": {
+            "amount": "7038291919",
+            "denom": "busd"
+          },
+          "reserves_b": {
+            "amount": "72606256",
+            "denom": "usdx"
+          },
+          "total_shares": "699359418"
+        },
+        {
+          "pool_id": "hard:usdx",
+          "reserves_a": {
+            "amount": "11935938",
+            "denom": "hard"
+          },
+          "reserves_b": {
+            "amount": "8688979",
+            "denom": "usdx"
+          },
+          "total_shares": "9918771"
+        },
+        {
           "pool_id": "usdx:xrpb",
           "reserves_a": {
             "amount": "843639517257",
@@ -1955,22 +1979,22 @@
         {
           "depositor": "kava1l77xymdt2ya0rl2mludkny5aqmr67u88ymgdje",
           "pool_id": "usdx:xrpb",
-          "shares_owned": "29034728969"
+          "shares_owned": "7739661881008"
         },
         {
           "depositor": "kava1llqkrdr69wc76cuxpx6j06x9pt63f52f7mlcye",
           "pool_id": "busd:usdx",
-          "shares_owned": "24905307583"
+          "shares_owned": "699359418"
         },
         {
           "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
           "pool_id": "hard:usdx",
-          "shares_owned": "708138421"
+          "shares_owned": "9918771"
         },
         {
           "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
           "pool_id": "ukava:usdx",
-          "shares_owned": "3427014047"
+          "shares_owned": "1398497336200"
         }
       ]
     },

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -453,6 +453,20 @@
             "market_id": "bnb:usd:30",
             "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
             "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "btc",
+            "market_id": "btc:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "btc",
+            "market_id": "btc:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
           }
         ]
       },

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -719,7 +719,7 @@
         },
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
-          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
           "pub_key": null,
           "account_number": "0",
           "sequence": "0"
@@ -900,7 +900,7 @@
           "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
         },
         {
-          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
           "coins": [
             { "denom": "bnb", "amount": "100000000000000" },
             { "denom": "ukava", "amount": "1000000000000" }
@@ -1037,7 +1037,7 @@
               "time_based_limit": "0"
             },
             "active": true,
-            "deputy_address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+            "deputy_address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
             "fixed_fee": "1000",
             "min_swap_amount": "1001",
             "max_swap_amount": "500000000000",

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -734,7 +734,10 @@
         {
           "@type": "/cosmos.auth.v1beta1.BaseAccount",
           "address": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
-          "pub_key": null,
+          "pub_key": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "A64VRmYpsMHDcT5tRBSiwCmdAogT0lsx6i/lEqUx8BUF"
+          },
           "account_number": "0",
           "sequence": "0"
         },

--- a/migrate/v0_16/testdata/genesis-v16.json
+++ b/migrate/v0_16/testdata/genesis-v16.json
@@ -673,6 +673,17 @@
         {
           "@type": "/cosmos.auth.v1beta1.ModuleAccount",
           "base_account": {
+            "address": "kava1j4yzhgjm00ch3h0p9kel7g8sp6g045qf8kzmmd",
+            "pub_key": null,
+            "account_number": "0",
+            "sequence": "0"
+          },
+          "name": "auction",
+          "permissions": ["minter", "burner"]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
             "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
             "pub_key": null,
             "account_number": "0",
@@ -861,6 +872,12 @@
             { "denom": "hard", "amount": "1000000000000" },
             { "denom": "swp", "amount": "1000000000000" },
             { "denom": "ukava", "amount": "1000000000000" }
+          ]
+        },
+        {
+          "address": "kava1j4yzhgjm00ch3h0p9kel7g8sp6g045qf8kzmmd",
+          "coins": [
+            { "denom": "bnb", "amount": "2" }
           ]
         },
         {


### PR DESCRIPTION
This catches some possible invalid module genesis states, but does not catch everything -- invalid migration state could still be emitted as there's still some validation in module `InitGenesis` functions.