### PR TITLE
fix: only set config in migration if unsealed

### DIFF
--- a/migrate/v0_16/cosmos.go
+++ b/migrate/v0_16/cosmos.go
@@ -38,7 +38,6 @@ import (
 	ibchost "github.com/cosmos/ibc-go/modules/core/24-host"
 	ibctypes "github.com/cosmos/ibc-go/modules/core/types"
 
-	"github.com/kava-labs/kava/app"
 	v015kavadist "github.com/kava-labs/kava/x/kavadist/legacy/v0_15"
 	v015validatorvesting "github.com/kava-labs/kava/x/validator-vesting/legacy/v0_15"
 )
@@ -71,7 +70,7 @@ func migrateV043(appState genutiltypes.AppMap, clientCtx client.Context) genutil
 // migrateV040 migrates cosmos modules from v0.39 to a v0.40 genesis state.
 // This is based on the genutil/legacy/v40 migration logic but adapted to handle custom types from the kava module.
 func migrateV040(appState genutiltypes.AppMap, clientCtx client.Context, genesisTime time.Time) genutiltypes.AppMap {
-	app.SetSDKConfig()
+	setConfigIfUnsealed()
 	v039Codec := codec.NewLegacyAmino()
 	v039auth.RegisterLegacyAminoCodec(v039Codec)
 	v036gov.RegisterLegacyAminoCodec(v039Codec)

--- a/migrate/v0_16/migrate.go
+++ b/migrate/v0_16/migrate.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	tmtypes "github.com/tendermint/tendermint/types"
-
 	"github.com/kava-labs/kava/app"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 var (
@@ -17,9 +17,17 @@ var (
 	ChainID     = "kava-9"
 )
 
+func setConfigIfUnsealed() {
+	config := sdk.GetConfig()
+	if config.GetBech32AccountAddrPrefix() == "kava" {
+		return
+	}
+	app.SetSDKConfig()
+}
+
 // Migrate converts v15 genesis doc to v16 genesis doc
 func Migrate(genDoc *tmtypes.GenesisDoc, ctx client.Context) (*tmtypes.GenesisDoc, error) {
-	app.SetSDKConfig()
+	setConfigIfUnsealed()
 
 	var appState genutiltypes.AppMap
 	var err error

--- a/migrate/v0_16/migrate_test.go
+++ b/migrate/v0_16/migrate_test.go
@@ -63,7 +63,7 @@ func TestMigrateFull(t *testing.T) {
 
 func TestAccountBalances(t *testing.T) {
 	t.Skip() // avoid committing test data
-	app.SetSDKConfig()
+	setConfigIfUnsealed()
 
 	// load auth state from kava-8 with empty accounts removed (keeps size down)
 	authbz, err := ioutil.ReadFile(filepath.Join("testdata", "kava-8-test-auth-state.json"))


### PR DESCRIPTION
Couldn't think of a way to check if config is sealed other than implicitly via checking one of the account prefixes, lmk if there's a more direct solution. 