### PR TITLE
Pricefeed query fix

### DIFF
--- a/x/pricefeed/keeper/grpc_query.go
+++ b/x/pricefeed/keeper/grpc_query.go
@@ -56,7 +56,9 @@ func (s queryServer) Prices(c context.Context, req *types.QueryPricesRequest) (*
 
 	var currentPrices types.CurrentPriceResponses
 	for _, cp := range s.keeper.GetCurrentPrices(ctx) {
-		currentPrices = append(currentPrices, types.CurrentPriceResponse(cp))
+		if cp.MarketID != "" {
+			currentPrices = append(currentPrices, types.CurrentPriceResponse(cp))
+		}
 	}
 
 	return &types.QueryPricesResponse{

--- a/x/pricefeed/keeper/querier.go
+++ b/x/pricefeed/keeper/querier.go
@@ -57,7 +57,16 @@ func queryPrice(ctx sdk.Context, req abci.RequestQuery, keeper Keeper, legacyQue
 
 func queryPrices(ctx sdk.Context, req abci.RequestQuery, keeper Keeper, legacyQuerierCdc *codec.LegacyAmino) (res []byte, sdkErr error) {
 	currentPrices := keeper.GetCurrentPrices(ctx)
-	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, currentPrices)
+
+	// Filter out invalid markets without a price
+	var validCurrentPrices types.CurrentPrices
+	for _, cp := range currentPrices {
+		if cp.MarketID != "" {
+			validCurrentPrices = append(validCurrentPrices, types.CurrentPrice(cp))
+		}
+	}
+
+	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, validCurrentPrices)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}


### PR DESCRIPTION
Fix so that pricefeed module's prices endpoint doesn't return markets without a posted price.

Before:
```
[
{"0.00000000"},
{"bnb:usd", "474.3045"},
...
]
```

After:
```
[
{"bnb:usd", "474.3045"},
...
]
```