### PR TITLE
(Backport) Fix MultiSpend Propsoal With Async Upgrade Time

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -119,7 +119,6 @@ import (
 )
 
 // TODO: set proposed upgrade time
-// TODO: remove in next upgrade
 var MultiSpendPropsalUpgradeTime = time.Date(2022, 1, 27, 16, 0, 0, 0, time.UTC)
 
 const (

--- a/app/app.go
+++ b/app/app.go
@@ -118,8 +118,7 @@ import (
 	validatorvesting "github.com/kava-labs/kava/x/validator-vesting"
 )
 
-// TODO: set proposed upgrade time
-var MultiSpendPropsalUpgradeTime = time.Date(2022, 1, 27, 16, 0, 0, 0, time.UTC)
+var MultiSpendPropsalUpgradeTime = time.Date(2022, 2, 3, 16, 0, 0, 0, time.UTC)
 
 const (
 	appName     = "kava"

--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -116,6 +117,10 @@ import (
 	swaptypes "github.com/kava-labs/kava/x/swap/types"
 	validatorvesting "github.com/kava-labs/kava/x/validator-vesting"
 )
+
+// TODO: set proposed upgrade time
+// TODO: remove in next upgrade
+var MultiSpendPropsalUpgradeTime = time.Date(2022, 1, 27, 16, 0, 0, 0, time.UTC)
 
 const (
 	appName     = "kava"
@@ -421,13 +426,23 @@ func NewApp(
 		scopedIBCKeeper,
 	)
 
+	app.kavadistKeeper = kavadistkeeper.NewKeeper(
+		appCodec,
+		keys[kavadisttypes.StoreKey],
+		kavadistSubspace,
+		app.bankKeeper,
+		app.accountKeeper,
+		app.distrKeeper,
+		app.ModuleAccountAddrs(),
+	)
+
 	govRouter := govtypes.NewRouter()
 	govRouter.
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
 		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
 		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.upgradeKeeper)).
 		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.ibcKeeper.ClientKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).AddRoute(kavadisttypes.RouterKey, kavadist.NewCommunityPoolMultiSpendProposalHandler(app.kavadistKeeper)).
+		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.distrKeeper)).AddRoute(kavadisttypes.RouterKey, kavadist.NewCommunityPoolMultiSpendProposalHandler(app.kavadistKeeper, MultiSpendPropsalUpgradeTime)).
 		AddRoute(committeetypes.RouterKey, committee.NewProposalHandler(app.committeeKeeper))
 	app.govKeeper = govkeeper.NewKeeper(
 		appCodec,
@@ -456,15 +471,6 @@ func NewApp(
 	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
 	app.ibcKeeper.SetRouter(ibcRouter)
 
-	app.kavadistKeeper = kavadistkeeper.NewKeeper(
-		appCodec,
-		keys[kavadisttypes.StoreKey],
-		kavadistSubspace,
-		app.bankKeeper,
-		app.accountKeeper,
-		app.distrKeeper,
-		app.ModuleAccountAddrs(),
-	)
 	app.auctionKeeper = auctionkeeper.NewKeeper(
 		appCodec,
 		keys[auctiontypes.StoreKey],

--- a/x/kavadist/handler.go
+++ b/x/kavadist/handler.go
@@ -1,6 +1,8 @@
 package kavadist
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -10,11 +12,11 @@ import (
 )
 
 // NewCommunityPoolMultiSpendProposalHandler
-func NewCommunityPoolMultiSpendProposalHandler(k keeper.Keeper) govtypes.Handler {
+func NewCommunityPoolMultiSpendProposalHandler(k keeper.Keeper, upgradeTime time.Time) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
 		case *types.CommunityPoolMultiSpendProposal:
-			return keeper.HandleCommunityPoolMultiSpendProposal(ctx, k, c)
+			return keeper.HandleCommunityPoolMultiSpendProposal(ctx, k, c, upgradeTime)
 		default:
 			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized kavadist proposal content type: %T", c)
 		}

--- a/x/kavadist/keeper/proposal_handler_test.go
+++ b/x/kavadist/keeper/proposal_handler_test.go
@@ -1,6 +1,9 @@
 package keeper_test
 
 import (
+	"fmt"
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/x/kavadist/keeper"
@@ -8,8 +11,9 @@ import (
 )
 
 func (suite *keeperTestSuite) TestHandleCommunityPoolMultiSpendProposal() {
-	addr, distrKeeper, ctx := suite.Addrs[0], suite.App.GetDistrKeeper(), suite.Ctx
-	initBalances := suite.BankKeeper.GetAllBalances(ctx, addr)
+	addr1, addr2, distrKeeper, ctx := suite.Addrs[0], suite.Addrs[1], suite.App.GetDistrKeeper(), suite.Ctx
+
+	upgradeTime := ctx.BlockTime().Add(24 * time.Hour)
 
 	// add coins to the module account and fund fee pool
 	macc := distrKeeper.GetDistributionAccount(ctx)
@@ -23,18 +27,65 @@ func (suite *keeperTestSuite) TestHandleCommunityPoolMultiSpendProposal() {
 	proposalAmount2 := int64(1200)
 	proposal := types.NewCommunityPoolMultiSpendProposal("test title", "description", []types.MultiSpendRecipient{
 		{
-			Address: addr.String(),
+			Address: addr1.String(),
 			Amount:  sdk.NewCoins(sdk.NewInt64Coin("ukava", proposalAmount1)),
 		},
 		{
-			Address: addr.String(),
+			Address: addr1.String(),
+			Amount:  sdk.NewCoins(sdk.NewInt64Coin("ukava", proposalAmount2)),
+		},
+		{
+			Address: addr2.String(),
+			Amount:  sdk.NewCoins(sdk.NewInt64Coin("ukava", proposalAmount1)),
+		},
+		{
+			Address: addr2.String(),
 			Amount:  sdk.NewCoins(sdk.NewInt64Coin("ukava", proposalAmount2)),
 		},
 	})
-	err := keeper.HandleCommunityPoolMultiSpendProposal(ctx, suite.Keeper, proposal)
-	suite.Require().Nil(err)
 
-	balances := suite.BankKeeper.GetAllBalances(ctx, addr)
-	expected := initBalances.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2))
-	suite.Require().Equal(expected, balances.AmountOf("ukava"))
+	suite.Suite.Run("it panics before upgrade time", func() {
+		handler := func() { keeper.HandleCommunityPoolMultiSpendProposal(ctx, suite.Keeper, proposal, upgradeTime) }
+		suite.Require().PanicsWithValue(fmt.Sprintf("cannot submit multi-spend proposal before %s", upgradeTime.UTC().String()), handler)
+	})
+
+	suite.Suite.Run("it sends funds to all recipients at or after upgrade time", func() {
+		ctx = ctx.WithBlockTime(upgradeTime)
+		initBalances1 := suite.BankKeeper.GetAllBalances(ctx, addr1)
+		initBalances2 := suite.BankKeeper.GetAllBalances(ctx, addr2)
+
+		err := keeper.HandleCommunityPoolMultiSpendProposal(ctx, suite.Keeper, proposal, upgradeTime)
+		suite.Require().Nil(err)
+
+		balances := suite.BankKeeper.GetAllBalances(ctx, addr1)
+		expected := initBalances1.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2))
+		suite.Require().Equal(expected, balances.AmountOf("ukava"))
+
+		balances = suite.BankKeeper.GetAllBalances(ctx, addr2)
+		expected = initBalances2.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2))
+		suite.Require().Equal(expected, balances.AmountOf("ukava"))
+
+		ctx = ctx.WithBlockTime(upgradeTime.Add(24 * time.Hour))
+		err = keeper.HandleCommunityPoolMultiSpendProposal(ctx, suite.Keeper, proposal, upgradeTime)
+		suite.Require().Nil(err)
+
+		balances = suite.BankKeeper.GetAllBalances(ctx, addr1)
+		expected = initBalances1.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2).Mul(sdk.NewInt(2)))
+		suite.Require().Equal(expected, balances.AmountOf("ukava"))
+
+		balances = suite.BankKeeper.GetAllBalances(ctx, addr2)
+		expected = initBalances2.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2).Mul(sdk.NewInt(2)))
+		suite.Require().Equal(expected, balances.AmountOf("ukava"))
+	})
+
+	suite.Suite.Run("it errors if pool doesn't have enough funds", func() {
+		feePool := distrKeeper.GetFeePool(ctx)
+		feePool.CommunityPool = sdk.DecCoins{}
+		distrKeeper.SetFeePool(ctx, feePool)
+
+		ctx = ctx.WithBlockTime(upgradeTime)
+		err := keeper.HandleCommunityPoolMultiSpendProposal(ctx, suite.Keeper, proposal, upgradeTime)
+
+		suite.Require().Error(err)
+	})
 }

--- a/x/kavadist/testutil/suite.go
+++ b/x/kavadist/testutil/suite.go
@@ -39,7 +39,7 @@ func (suite *Suite) SetupTest() {
 	config := sdk.GetConfig()
 	app.SetBech32AddressPrefixes(config)
 	tApp := app.NewTestApp()
-	_, addrs := app.GeneratePrivKeyAddressPairs(1)
+	_, addrs := app.GeneratePrivKeyAddressPairs(2)
 	coins := sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000000000000)))
 	authGS := app.NewFundedGenStateWithSameCoins(tApp.AppCodec(), coins, addrs)
 


### PR DESCRIPTION
Backports https://github.com/Kava-Labs/kava/pull/1153

Sets an upgrade time in app.go when multi spend proposals will be allowed to be submitted.

Before this time, multi-spend proposals will be continued to be rejects with a panic in order to preserve existing state.