### PR TITLE
Fix app module ordering for multi-spend proposal handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -421,6 +421,16 @@ func NewApp(
 		scopedIBCKeeper,
 	)
 
+	app.kavadistKeeper = kavadistkeeper.NewKeeper(
+		appCodec,
+		keys[kavadisttypes.StoreKey],
+		kavadistSubspace,
+		app.bankKeeper,
+		app.accountKeeper,
+		app.distrKeeper,
+		app.ModuleAccountAddrs(),
+	)
+
 	govRouter := govtypes.NewRouter()
 	govRouter.
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
@@ -456,15 +466,6 @@ func NewApp(
 	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
 	app.ibcKeeper.SetRouter(ibcRouter)
 
-	app.kavadistKeeper = kavadistkeeper.NewKeeper(
-		appCodec,
-		keys[kavadisttypes.StoreKey],
-		kavadistSubspace,
-		app.bankKeeper,
-		app.accountKeeper,
-		app.distrKeeper,
-		app.ModuleAccountAddrs(),
-	)
 	app.auctionKeeper = auctionkeeper.NewKeeper(
 		appCodec,
 		keys[auctiontypes.StoreKey],


### PR DESCRIPTION
Instantiates the kavadistkeeper before it's reference in the gov handler.

This fixes an issue where the struct has default values, which leaves the distrkeeper nil.