### PR TITLE
feat: convert base accounts with ethsecp256k1 pubkey to EthAccount in ante handler

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -109,7 +109,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		authante.NewValidateMemoDecorator(options.AccountKeeper),
 		authante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		authante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
-		authante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
 		authante.NewValidateSigCountDecorator(options.AccountKeeper),
 		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),

--- a/app/ante/pubkey.go
+++ b/app/ante/pubkey.go
@@ -1,0 +1,169 @@
+package ante
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/tharsis/ethermint/crypto/ethsecp256k1"
+	evmtypes "github.com/tharsis/ethermint/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	// simulation signature values used to estimate gas consumption
+	key                = make([]byte, secp256k1.PubKeySize)
+	simSecp256k1Pubkey = &secp256k1.PubKey{Key: key}
+	emptyCodeHash      = crypto.Keccak256(nil)
+)
+
+// SetPubKeyDecorator sets PubKeys in context for any signer which does not already have pubkey set
+// PubKeys must be set in context for all signers before any other sigverify decorators run
+// CONTRACT: Tx must implement SigVerifiableTx interface
+type SetPubKeyDecorator struct {
+	ak authante.AccountKeeper
+}
+
+func NewSetPubKeyDecorator(ak authante.AccountKeeper) SetPubKeyDecorator {
+	return SetPubKeyDecorator{
+		ak: ak,
+	}
+}
+
+func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+
+	pubkeys, err := sigTx.GetPubKeys()
+	if err != nil {
+		return ctx, err
+	}
+	signers := sigTx.GetSigners()
+
+	for i, pk := range pubkeys {
+		// PublicKey was omitted from slice since it has already been set in context
+		if pk == nil {
+			if !simulate {
+				continue
+			}
+			pk = simSecp256k1Pubkey
+		}
+		// Only make check if simulate=false
+		if !simulate && !bytes.Equal(pk.Address(), signers[i]) {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey,
+				"pubKey does not match signer address %s with signer index: %d", signers[i], i)
+		}
+
+		acc, err := authante.GetSignerAcc(ctx, spkd.ak, signers[i])
+		if err != nil {
+			return ctx, err
+		}
+		// account already has pubkey set,no need to reset
+		if acc.GetPubKey() != nil {
+			continue
+		}
+		err = acc.SetPubKey(pk)
+		if err != nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, err.Error())
+		}
+		pk := acc.GetPubKey()
+		_, isEthPubkey := pk.(*ethsecp256k1.PubKey)
+		bacc, isBaseAcc := acc.(*authtypes.BaseAccount)
+		// pubkey is ethsecp256k1 and account is base account - convert to eth account
+		if isEthPubkey && isBaseAcc {
+
+			ethAcc := &evmtypes.EthAccount{
+				BaseAccount: bacc,
+				CodeHash:    common.BytesToHash(emptyCodeHash).String(),
+			}
+			spkd.ak.SetAccount(ctx, ethAcc)
+		} else
+		// for other account types (vesting accounts), even if the pubkey is eth pubkey,
+		// we can't convert to eth account, because we would lose vesting data
+		{
+			spkd.ak.SetAccount(ctx, acc)
+		}
+	}
+
+	// Also emit the following events, so that txs can be indexed by these
+	// indices:
+	// - signature (via `tx.signature='<sig_as_base64>'`),
+	// - concat(address,"/",sequence) (via `tx.acc_seq='cosmos1abc...def/42'`).
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	var events sdk.Events
+	for i, sig := range sigs {
+		events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+			sdk.NewAttribute(sdk.AttributeKeyAccountSequence, fmt.Sprintf("%s/%d", signers[i], sig.Sequence)),
+		))
+
+		sigBzs, err := signatureDataToBz(sig.Data)
+		if err != nil {
+			return ctx, err
+		}
+		for _, sigBz := range sigBzs {
+			events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+				sdk.NewAttribute(sdk.AttributeKeySignature, base64.StdEncoding.EncodeToString(sigBz)),
+			))
+		}
+	}
+
+	ctx.EventManager().EmitEvents(events)
+
+	return next(ctx, tx, simulate)
+}
+
+// signatureDataToBz converts a SignatureData into raw bytes signature.
+// For SingleSignatureData, it returns the signature raw bytes.
+// For MultiSignatureData, it returns an array of all individual signatures,
+// as well as the aggregated signature.
+func signatureDataToBz(data signing.SignatureData) ([][]byte, error) {
+	if data == nil {
+		return nil, fmt.Errorf("got empty SignatureData")
+	}
+
+	switch data := data.(type) {
+	case *signing.SingleSignatureData:
+		return [][]byte{data.Signature}, nil
+	case *signing.MultiSignatureData:
+		sigs := [][]byte{}
+		var err error
+
+		for _, d := range data.Signatures {
+			nestedSigs, err := signatureDataToBz(d)
+			if err != nil {
+				return nil, err
+			}
+			sigs = append(sigs, nestedSigs...)
+		}
+
+		multisig := cryptotypes.MultiSignature{
+			Signatures: sigs,
+		}
+		aggregatedSig, err := multisig.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, aggregatedSig)
+
+		return sigs, nil
+	default:
+		return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", data)
+	}
+}

--- a/app/app.go
+++ b/app/app.go
@@ -81,7 +81,6 @@ import (
 	dbm "github.com/tendermint/tm-db"
 	evmante "github.com/tharsis/ethermint/app/ante"
 	srvflags "github.com/tharsis/ethermint/server/flags"
-	ethermint "github.com/tharsis/ethermint/types"
 	"github.com/tharsis/ethermint/x/evm"
 	evmrest "github.com/tharsis/ethermint/x/evm/client/rest"
 	evmkeeper "github.com/tharsis/ethermint/x/evm/keeper"
@@ -370,7 +369,7 @@ func NewApp(
 		appCodec,
 		keys[authtypes.StoreKey],
 		authSubspace,
-		ethermint.ProtoAccount,
+		authtypes.ProtoBaseAccount,
 		mAccPerms,
 	)
 	app.bankKeeper = bankkeeper.NewBaseKeeper(

--- a/x/swap/testutil/suite.go
+++ b/x/swap/testutil/suite.go
@@ -20,7 +20,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
-	ethermint "github.com/tharsis/ethermint/types"
 )
 
 var defaultSwapFee = sdk.MustNewDecFromStr("0.003")
@@ -104,7 +103,7 @@ func (suite *Suite) NewAccountFromAddr(addr sdk.AccAddress, balance sdk.Coins) a
 // CreateVestingAccount creates a new vesting account from the provided balance and vesting balance
 func (suite *Suite) CreateVestingAccount(initialBalance sdk.Coins, vestingBalance sdk.Coins) authtypes.AccountI {
 	acc := suite.CreateAccount(initialBalance)
-	bacc := acc.(*ethermint.EthAccount)
+	bacc := acc.(*authtypes.BaseAccount)
 
 	periods := vestingtypes.Periods{
 		vestingtypes.Period{
@@ -112,7 +111,7 @@ func (suite *Suite) CreateVestingAccount(initialBalance sdk.Coins, vestingBalanc
 			Amount: vestingBalance,
 		},
 	}
-	vacc := vestingtypes.NewPeriodicVestingAccount(bacc.BaseAccount, initialBalance, time.Now().Unix(), periods) // TODO is initialBalance correct for originalVesting?
+	vacc := vestingtypes.NewPeriodicVestingAccount(bacc, initialBalance, time.Now().Unix(), periods) // TODO is initialBalance correct for originalVesting?
 
 	return vacc
 }


### PR DESCRIPTION
Changes default account type back to base account

Implements custom `NewSetPubKeyDecorator`, which is mostly copied over from https://github.com/cosmos/cosmos-sdk/blob/b6c77e6c819f8a51166649eaef125d1bfb276f04/x/auth/ante/sigverify.go#L57. Relevant changes are on L83-100