### PR TITLE
feat: convert base accounts with ethsecp256k1 pubkey to EthAccount in ante handler

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -114,6 +114,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper), // innermost AnteDecorator
+		NewSetEthAccountDecorator(options.AccountKeeper),              // only update account type if sig verification has passed
 		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
 	)
 	return sdk.ChainAnteDecorators(decorators...)
@@ -130,6 +131,7 @@ func newEthAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		evmante.NewEthGasConsumeDecorator(options.EvmKeeper),
 		evmante.NewCanTransferDecorator(options.EvmKeeper, options.FeeMarketKeeper),
 		evmante.NewEthIncrementSenderSequenceDecorator(options.AccountKeeper), // innermost AnteDecorator.
+		NewSetEthAccountDecoratorEVM(options.AccountKeeper),
 	)
 }
 

--- a/app/ante/ethaccount.go
+++ b/app/ante/ethaccount.go
@@ -1,0 +1,98 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/tharsis/ethermint/crypto/ethsecp256k1"
+	evmtypes "github.com/tharsis/ethermint/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	emptyCodeHash = crypto.Keccak256(nil)
+)
+
+// SetEthAccountDecorator converts base accounts with pubkey type ethsecp256k1 to EthAccount when they transact on the cosmos-sdk
+type SetEthAccountDecorator struct {
+	ak authante.AccountKeeper
+}
+
+func NewSetEthAccountDecorator(ak authante.AccountKeeper) SetEthAccountDecorator {
+	return SetEthAccountDecorator{
+		ak: ak,
+	}
+}
+
+// AnteHandle checks if each signer has a base account with pubkey type ethsecp256k1 and converts the account to EthAccount if so
+func (sead SetEthAccountDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+	pubkeys, err := sigTx.GetPubKeys()
+	if err != nil {
+		return ctx, err
+	}
+	signers := sigTx.GetSigners()
+
+	for i := range pubkeys {
+		acc, err := authante.GetSignerAcc(ctx, sead.ak, signers[i])
+		if err != nil {
+			return ctx, err
+		}
+		pk := acc.GetPubKey()
+		_, isEthPubkey := pk.(*ethsecp256k1.PubKey)
+		bacc, isBaseAcc := acc.(*authtypes.BaseAccount)
+		if isEthPubkey && isBaseAcc {
+			ethAcc := &evmtypes.EthAccount{
+				BaseAccount: bacc,
+				CodeHash:    common.BytesToHash(emptyCodeHash).String(),
+			}
+			sead.ak.SetAccount(ctx, ethAcc)
+		}
+	}
+	return next(ctx, tx, simulate)
+}
+
+// SetEthAccountDecorator converts base accounts to EthAccount when they transact on the evm
+type SetEthAccountDecoratorEVM struct {
+	ak authante.AccountKeeper
+}
+
+func NewSetEthAccountDecoratorEVM(ak authante.AccountKeeper) SetEthAccountDecoratorEVM {
+	return SetEthAccountDecoratorEVM{
+		ak: ak,
+	}
+}
+
+// AnteHandle checks if each signer has a base account and converts the account to EthAccount if so
+func (sead SetEthAccountDecoratorEVM) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	for _, msg := range tx.GetMsgs() {
+		// increment sequence of all signers
+		for _, addr := range msg.GetSigners() {
+			acc := sead.ak.GetAccount(ctx, addr)
+
+			if acc == nil {
+				return ctx, sdkerrors.Wrapf(
+					sdkerrors.ErrUnknownAddress,
+					"account %s (%s) is nil", common.BytesToAddress(addr.Bytes()), addr,
+				)
+			}
+			bacc, isBaseAcc := acc.(*authtypes.BaseAccount)
+			if isBaseAcc {
+				ethAcc := &evmtypes.EthAccount{
+					BaseAccount: bacc,
+					CodeHash:    common.BytesToHash(emptyCodeHash).String(),
+				}
+				sead.ak.SetAccount(ctx, ethAcc)
+			}
+		}
+	}
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/ethaccount.go
+++ b/app/ante/ethaccount.go
@@ -74,7 +74,7 @@ func NewSetEthAccountDecoratorEVM(ak authante.AccountKeeper) SetEthAccountDecora
 // AnteHandle checks if each signer has a base account and converts the account to EthAccount if so
 func (sead SetEthAccountDecoratorEVM) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	for _, msg := range tx.GetMsgs() {
-		// increment sequence of all signers
+		// for all signers, convert BaseAccount to EthAccount
 		for _, addr := range msg.GetSigners() {
 			acc := sead.ak.GetAccount(ctx, addr)
 

--- a/app/app.go
+++ b/app/app.go
@@ -81,7 +81,6 @@ import (
 	dbm "github.com/tendermint/tm-db"
 	evmante "github.com/tharsis/ethermint/app/ante"
 	srvflags "github.com/tharsis/ethermint/server/flags"
-	ethermint "github.com/tharsis/ethermint/types"
 	"github.com/tharsis/ethermint/x/evm"
 	evmrest "github.com/tharsis/ethermint/x/evm/client/rest"
 	evmkeeper "github.com/tharsis/ethermint/x/evm/keeper"
@@ -370,7 +369,7 @@ func NewApp(
 		appCodec,
 		keys[authtypes.StoreKey],
 		authSubspace,
-		ethermint.ProtoAccount,
+		authtypes.ProtoBaseAccount,
 		mAccPerms,
 	)
 	app.bankKeeper = bankkeeper.NewBaseKeeper(

--- a/x/swap/testutil/suite.go
+++ b/x/swap/testutil/suite.go
@@ -20,7 +20,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
-	ethermint "github.com/tharsis/ethermint/types"
 )
 
 var defaultSwapFee = sdk.MustNewDecFromStr("0.003")
@@ -104,7 +103,7 @@ func (suite *Suite) NewAccountFromAddr(addr sdk.AccAddress, balance sdk.Coins) a
 // CreateVestingAccount creates a new vesting account from the provided balance and vesting balance
 func (suite *Suite) CreateVestingAccount(initialBalance sdk.Coins, vestingBalance sdk.Coins) authtypes.AccountI {
 	acc := suite.CreateAccount(initialBalance)
-	bacc := acc.(*ethermint.EthAccount)
+	bacc := acc.(*authtypes.BaseAccount)
 
 	periods := vestingtypes.Periods{
 		vestingtypes.Period{
@@ -112,7 +111,7 @@ func (suite *Suite) CreateVestingAccount(initialBalance sdk.Coins, vestingBalanc
 			Amount: vestingBalance,
 		},
 	}
-	vacc := vestingtypes.NewPeriodicVestingAccount(bacc.BaseAccount, initialBalance, time.Now().Unix(), periods) // TODO is initialBalance correct for originalVesting?
+	vacc := vestingtypes.NewPeriodicVestingAccount(bacc, initialBalance, time.Now().Unix(), periods) // TODO is initialBalance correct for originalVesting?
 
 	return vacc
 }


### PR DESCRIPTION
Changes default account type back to base account

Implements two new antehandlers:
 * `SetEthAccountDecorator`, which is run for cosmos-sdk transactions, and converts `BaseAccount` with pubkey type `ethsecp256k1` to `EthAccount`
 * `SetEthAccountDecoratorEVM`, which is run for EVM transactions, and converts `BaseAccount` to `EthAccount` - note that because EVM txs don't implement `authsigning.SigVerifiableTx` - we can't do the additional pubkey type check. However, for accounts which only ever interact with the EVM, the pubkey doesn't ever get set (nor need to be set). 