### PR TITLE
Add evm bank invariants

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -638,7 +638,7 @@ func NewApp(
 		hard.NewAppModule(app.hardKeeper, app.accountKeeper, app.bankKeeper, app.pricefeedKeeper),
 		committee.NewAppModule(app.committeeKeeper, app.accountKeeper),
 		incentive.NewAppModule(app.incentiveKeeper, app.accountKeeper, app.bankKeeper, app.cdpKeeper),
-		evmutil.NewAppModule(app.evmutilKeeper),
+		evmutil.NewAppModule(app.evmutilKeeper, app.bankKeeper),
 	)
 
 	// Warning: Some begin blockers must run before others. Ensure the dependencies are understood before modifying this list.

--- a/x/evmutil/keeper/invariants.go
+++ b/x/evmutil/keeper/invariants.go
@@ -8,14 +8,14 @@ import (
 
 // RegisterInvariants registers the swap module invariants
 func RegisterInvariants(ir sdk.InvariantRegistry, bankK EvmBankKeeper, k Keeper) {
-	ir.RegisterRoute(types.ModuleName, "balances", BalancesInvariant(bankK, k))
+	ir.RegisterRoute(types.ModuleName, "fully-backed", FullyBackedInvariant(bankK, k))
 	ir.RegisterRoute(types.ModuleName, "small-balances", SmallBalancesInvariant(bankK, k))
 }
 
 // AllInvariants runs all invariants of the swap module
 func AllInvariants(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
-		if res, stop := BalancesInvariant(bankK, k)(ctx); stop {
+		if res, stop := FullyBackedInvariant(bankK, k)(ctx); stop {
 			return res, stop
 		}
 		res, stop := SmallBalancesInvariant(bankK, k)(ctx)
@@ -23,10 +23,10 @@ func AllInvariants(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
 	}
 }
 
-// BalancesInvariant ensures all minor balances are backed exactly by the coins in the module account.
-func BalancesInvariant(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
+// FullyBackedInvariant ensures all minor balances are backed exactly by the coins in the module account.
+func FullyBackedInvariant(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
 	broken := false
-	message := sdk.FormatInvariant(types.ModuleName, "balances broken", "minor balances do not match module account")
+	message := sdk.FormatInvariant(types.ModuleName, "fully backed broken", "minor balances do not match module account")
 
 	return func(ctx sdk.Context) (string, bool) {
 

--- a/x/evmutil/keeper/invariants.go
+++ b/x/evmutil/keeper/invariants.go
@@ -14,7 +14,7 @@ func RegisterInvariants(ir sdk.InvariantRegistry, bankK types.BankKeeper, k Keep
 }
 
 // AllInvariants runs all invariants of the swap module
-func AllInvariants(bankK types.BankKeeper, k Keeper) sdk.Invariant { // TODO why?
+func AllInvariants(bankK types.BankKeeper, k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		if res, stop := FullyBackedInvariant(bankK, k)(ctx); stop {
 			return res, stop
@@ -46,6 +46,7 @@ func FullyBackedInvariant(bankK types.BankKeeper, k Keeper) sdk.Invariant {
 	}
 }
 
+// SmallBalancesInvariant ensures all minor balances are less than the overflow amount, beyond this they should be converted to the major denom.
 func SmallBalancesInvariant(_ types.BankKeeper, k Keeper) sdk.Invariant {
 	broken := false
 	message := sdk.FormatInvariant(types.ModuleName, "small balances broken", "minor balances not all less than overflow")

--- a/x/evmutil/keeper/invariants.go
+++ b/x/evmutil/keeper/invariants.go
@@ -9,12 +9,16 @@ import (
 // RegisterInvariants registers the swap module invariants
 func RegisterInvariants(ir sdk.InvariantRegistry, bankK EvmBankKeeper, k Keeper) {
 	ir.RegisterRoute(types.ModuleName, "balances", BalancesInvariant(bankK, k))
+	ir.RegisterRoute(types.ModuleName, "small-balances", SmallBalancesInvariant(bankK, k))
 }
 
 // AllInvariants runs all invariants of the swap module
 func AllInvariants(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
-		res, stop := BalancesInvariant(bankK, k)(ctx)
+		if res, stop := BalancesInvariant(bankK, k)(ctx); stop {
+			return res, stop
+		}
+		res, stop := SmallBalancesInvariant(bankK, k)(ctx)
 		return res, stop
 	}
 }
@@ -37,6 +41,23 @@ func BalancesInvariant(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
 
 		broken = !totalMinorBalances.Equal(bankBalance.Amount)
 
+		return message, broken
+	}
+}
+
+func SmallBalancesInvariant(_ EvmBankKeeper, k Keeper) sdk.Invariant {
+	broken := false
+	message := sdk.FormatInvariant(types.ModuleName, "small balances broken", "minor balances not all less than overflow")
+
+	return func(ctx sdk.Context) (string, bool) {
+
+		k.IterateAllAccounts(ctx, func(account types.Account) bool {
+			if account.Balance.GTE(ConversionMultiplier) {
+				broken = true
+				return true
+			}
+			return false
+		})
 		return message, broken
 	}
 }

--- a/x/evmutil/keeper/invariants.go
+++ b/x/evmutil/keeper/invariants.go
@@ -1,0 +1,42 @@
+package keeper
+
+import (
+	"github.com/kava-labs/kava/x/evmutil/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// RegisterInvariants registers the swap module invariants
+func RegisterInvariants(ir sdk.InvariantRegistry, bankK EvmBankKeeper, k Keeper) {
+	ir.RegisterRoute(types.ModuleName, "balances", BalancesInvariant(bankK, k))
+}
+
+// AllInvariants runs all invariants of the swap module
+func AllInvariants(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		res, stop := BalancesInvariant(bankK, k)(ctx)
+		return res, stop
+	}
+}
+
+// BalancesInvariant ensures all minor balances are backed exactly by the coins in the module account.
+func BalancesInvariant(bankK EvmBankKeeper, k Keeper) sdk.Invariant {
+	broken := false
+	message := sdk.FormatInvariant(types.ModuleName, "balances broken", "minor balances do not match module account")
+
+	return func(ctx sdk.Context) (string, bool) {
+
+		totalMinorBalances := sdk.ZeroInt()
+		k.IterateAllAccounts(ctx, func(acc types.Account) bool {
+			totalMinorBalances = totalMinorBalances.Add(acc.Balance)
+			return false
+		})
+
+		bankAddr := bankK.GetModuleAddress(types.ModuleName)
+		bankBalance := bankK.GetBalance(ctx, bankAddr, EvmDenom)
+
+		broken = !totalMinorBalances.Equal(bankBalance.Amount)
+
+		return message, broken
+	}
+}

--- a/x/evmutil/keeper/invariants_test.go
+++ b/x/evmutil/keeper/invariants_test.go
@@ -1,0 +1,95 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/kava-labs/kava/x/evmutil/keeper"
+	"github.com/kava-labs/kava/x/evmutil/testutil"
+	"github.com/kava-labs/kava/x/evmutil/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type invariantTestSuite struct {
+	testutil.Suite
+	invariants map[string]map[string]sdk.Invariant
+}
+
+func TestInvariantTestSuite(t *testing.T) {
+	suite.Run(t, new(invariantTestSuite))
+}
+
+func (suite *invariantTestSuite) SetupTest() {
+	suite.Suite.SetupTest()
+	suite.invariants = make(map[string]map[string]sdk.Invariant)
+	keeper.RegisterInvariants(suite, suite.EvmBankKeeper, suite.Keeper)
+}
+
+func (suite *invariantTestSuite) SetupValidState() {
+	for i := 0; i < 4; i++ {
+		suite.Keeper.SetAccount(suite.Ctx, *types.NewAccount(
+			suite.Addrs[i],
+			sdk.NewInt(5e11),
+		))
+	}
+	suite.FundModuleAccountWithKava(
+		types.ModuleName,
+		sdk.NewCoins(
+			sdk.NewCoin("ukava", sdk.NewInt(2)),
+		),
+	)
+}
+
+// RegisterRoutes implements sdk.InvariantRegistry
+func (suite *invariantTestSuite) RegisterRoute(moduleName string, route string, invariant sdk.Invariant) {
+	_, exists := suite.invariants[moduleName]
+
+	if !exists {
+		suite.invariants[moduleName] = make(map[string]sdk.Invariant)
+	}
+
+	suite.invariants[moduleName][route] = invariant
+}
+
+func (suite *invariantTestSuite) runInvariant(route string, invariant func(bankKeeper keeper.EvmBankKeeper, k keeper.Keeper) sdk.Invariant) (string, bool) {
+	ctx := suite.Ctx
+	registeredInvariant := suite.invariants[types.ModuleName][route]
+	suite.Require().NotNil(registeredInvariant)
+
+	// direct call
+	dMessage, dBroken := invariant(suite.EvmBankKeeper, suite.Keeper)(ctx)
+	// registered call
+	rMessage, rBroken := registeredInvariant(ctx)
+	// all call
+	aMessage, aBroken := keeper.AllInvariants(suite.EvmBankKeeper, suite.Keeper)(ctx)
+
+	// require matching values for direct call and registered call
+	suite.Require().Equal(dMessage, rMessage, "expected registered invariant message to match")
+	suite.Require().Equal(dBroken, rBroken, "expected registered invariant broken to match")
+	// require matching values for direct call and all invariants call if broken
+	suite.Require().Equal(dBroken, aBroken, "expected all invariant broken to match")
+	if dBroken {
+		suite.Require().Equal(dMessage, aMessage, "expected all invariant message to match")
+	}
+
+	return dMessage, dBroken
+}
+
+func (suite *invariantTestSuite) TestBalancesInvariant() {
+
+	// default state is valid
+	_, broken := suite.runInvariant("balances", keeper.BalancesInvariant)
+	suite.Equal(false, broken)
+
+	suite.SetupValidState()
+	_, broken = suite.runInvariant("balances", keeper.BalancesInvariant)
+	suite.Equal(false, broken)
+
+	// break invariant by decreasing minor balances without decreasing module balance
+	suite.Keeper.RemoveBalance(suite.Ctx, suite.Addrs[0], sdk.OneInt())
+
+	message, broken := suite.runInvariant("balances", keeper.BalancesInvariant)
+	suite.Equal("evmutil: balances broken invariant\nminor balances do not match module account\n", message)
+	suite.Equal(true, broken)
+}

--- a/x/evmutil/keeper/invariants_test.go
+++ b/x/evmutil/keeper/invariants_test.go
@@ -24,7 +24,7 @@ func TestInvariantTestSuite(t *testing.T) {
 func (suite *invariantTestSuite) SetupTest() {
 	suite.Suite.SetupTest()
 	suite.invariants = make(map[string]map[string]sdk.Invariant)
-	keeper.RegisterInvariants(suite, suite.EvmBankKeeper, suite.Keeper)
+	keeper.RegisterInvariants(suite, suite.BankKeeper, suite.Keeper)
 }
 
 func (suite *invariantTestSuite) SetupValidState() {
@@ -53,17 +53,17 @@ func (suite *invariantTestSuite) RegisterRoute(moduleName string, route string, 
 	suite.invariants[moduleName][route] = invariant
 }
 
-func (suite *invariantTestSuite) runInvariant(route string, invariant func(bankKeeper keeper.EvmBankKeeper, k keeper.Keeper) sdk.Invariant) (string, bool) {
+func (suite *invariantTestSuite) runInvariant(route string, invariant func(bankKeeper types.BankKeeper, k keeper.Keeper) sdk.Invariant) (string, bool) {
 	ctx := suite.Ctx
 	registeredInvariant := suite.invariants[types.ModuleName][route]
 	suite.Require().NotNil(registeredInvariant)
 
 	// direct call
-	dMessage, dBroken := invariant(suite.EvmBankKeeper, suite.Keeper)(ctx)
+	dMessage, dBroken := invariant(suite.BankKeeper, suite.Keeper)(ctx)
 	// registered call
 	rMessage, rBroken := registeredInvariant(ctx)
 	// all call
-	aMessage, aBroken := keeper.AllInvariants(suite.EvmBankKeeper, suite.Keeper)(ctx)
+	aMessage, aBroken := keeper.AllInvariants(suite.BankKeeper, suite.Keeper)(ctx)
 
 	// require matching values for direct call and registered call
 	suite.Require().Equal(dMessage, rMessage, "expected registered invariant message to match")

--- a/x/evmutil/keeper/invariants_test.go
+++ b/x/evmutil/keeper/invariants_test.go
@@ -77,21 +77,21 @@ func (suite *invariantTestSuite) runInvariant(route string, invariant func(bankK
 	return dMessage, dBroken
 }
 
-func (suite *invariantTestSuite) TestBalancesInvariant() {
+func (suite *invariantTestSuite) TestFullyBackedInvariant() {
 
 	// default state is valid
-	_, broken := suite.runInvariant("balances", keeper.BalancesInvariant)
+	_, broken := suite.runInvariant("fully-backed", keeper.FullyBackedInvariant)
 	suite.Equal(false, broken)
 
 	suite.SetupValidState()
-	_, broken = suite.runInvariant("balances", keeper.BalancesInvariant)
+	_, broken = suite.runInvariant("fully-backed", keeper.FullyBackedInvariant)
 	suite.Equal(false, broken)
 
 	// break invariant by decreasing minor balances without decreasing module balance
 	suite.Keeper.RemoveBalance(suite.Ctx, suite.Addrs[0], sdk.OneInt())
 
-	message, broken := suite.runInvariant("balances", keeper.BalancesInvariant)
-	suite.Equal("evmutil: balances broken invariant\nminor balances do not match module account\n", message)
+	message, broken := suite.runInvariant("fully-backed", keeper.FullyBackedInvariant)
+	suite.Equal("evmutil: fully backed broken invariant\nminor balances do not match module account\n", message)
 	suite.Equal(true, broken)
 }
 

--- a/x/evmutil/module.go
+++ b/x/evmutil/module.go
@@ -114,7 +114,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 func (am AppModule) RegisterServices(cfg module.Configurator) {}
 
 // RegisterInvariants registers evmutil module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {} // TODO
 
 // InitGenesis performs evmutil module's genesis initialization It returns
 // no validator updates.

--- a/x/evmutil/module.go
+++ b/x/evmutil/module.go
@@ -82,14 +82,16 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command { return nil }
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper     keeper.Keeper
+	bankKeeper types.BankKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(keeper keeper.Keeper) AppModule {
+func NewAppModule(keeper keeper.Keeper, bankKeeper types.BankKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(),
 		keeper:         keeper,
+		bankKeeper:     bankKeeper,
 	}
 }
 
@@ -114,7 +116,9 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 func (am AppModule) RegisterServices(cfg module.Configurator) {}
 
 // RegisterInvariants registers evmutil module's invariants.
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {} // TODO
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
+	keeper.RegisterInvariants(ir, am.bankKeeper, am.keeper)
+}
 
 // InitGenesis performs evmutil module's genesis initialization It returns
 // no validator updates.

--- a/x/evmutil/testutil/suite.go
+++ b/x/evmutil/testutil/suite.go
@@ -2,16 +2,15 @@ package testutil
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/kava-labs/kava/app"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
-
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 
+	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/evmutil/keeper"
-	"github.com/kava-labs/kava/x/evmutil/types"
 )
 
 type Suite struct {
@@ -19,7 +18,7 @@ type Suite struct {
 
 	App           app.TestApp
 	Ctx           sdk.Context
-	BankKeeper    types.BankKeeper
+	BankKeeper    bankkeeper.Keeper
 	AccountKeeper authkeeper.AccountKeeper
 	Keeper        keeper.Keeper
 	EvmBankKeeper keeper.EvmBankKeeper


### PR DESCRIPTION
Ths PR adds a couple of invariants to help lock down bank state.
One detects when akava balances aren't exactly backed by ukava (ie when the evmutil module account's ukava balance (converted to akava) doesn't equal the sum of all akava balances).
Another detects any akava balances greater than one ukava (ie akava balance > `keeper.ConversionMultipler`).

There's a couple of edge cases where these aren't met:
The first can break when coins are burned in the evm (currently only possible via selfdestruct: https://ethereum.stackexchange.com/questions/16188/best-way-to-burn-ethers-and-other-ethereum-tokens)
The second invariant can break when gas fees are taken in the evm antehandler.