### PR TITLE
Fix EvmBankKeeper akava handling issues

### DIFF
--- a/x/evmutil/types/expected_keepers.go
+++ b/x/evmutil/types/expected_keepers.go
@@ -15,4 +15,5 @@ type BankKeeper interface {
 	evmtypes.BankKeeper
 
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 }


### PR DESCRIPTION
The `EvmBankKeeper` currently only handles `ukava` -> `akava` swap on account to module transfer and `akava` to `ukava` swap on module to account transfers. 

This works fine in most cases but might fail if `x/evm` changes how it uses the BankKeeper in the future. This PR makes sure we are correctly handling swap between these two denoms for all supported transactions.