### PR TITLE
Fix json for cli status query

### DIFF
--- a/cmd/kava/cmd/status.go
+++ b/cmd/kava/cmd/status.go
@@ -31,7 +31,7 @@ type validatorInfo struct {
 type resultStatus struct {
 	NodeInfo      p2p.DefaultNodeInfo `json:"node_info"`
 	SyncInfo      ctypes.SyncInfo     `json:"sync_info"`
-	ValidatorInfo validatorInfo       `json:"validator_info`
+	ValidatorInfo validatorInfo       `json:"validator_info"`
 }
 
 // StatusCommand returns the command to return the status of the network.


### PR DESCRIPTION
There was a missing `"` in a struct tag so the json field name wasn't being used.

I tested manually against current mainnet.