### PR TITLE
Fix: register msgs on legacy codec

### DIFF
--- a/x/savings/types/codec.go
+++ b/x/savings/types/codec.go
@@ -13,6 +13,8 @@ import (
 // RegisterLegacyAminoCodec registers all the necessary types and interfaces for the
 // savings module.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgDeposit{}, "savings/MsgDeposit", nil)
+	cdc.RegisterConcrete(&MsgWithdraw{}, "savings/MsgWithdraw", nil)
 }
 
 func RegisterInterfaces(registry types.InterfaceRegistry) {


### PR DESCRIPTION
noticed the legacy codec registration didn't have the msg types registered.