### PR TITLE
v17 migrations setup + evm modules migration

### DIFF
--- a/migrate/cmd.go
+++ b/migrate/cmd.go
@@ -14,15 +14,15 @@ import (
 
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/app/params"
-	"github.com/kava-labs/kava/migrate/v0_16"
+	"github.com/kava-labs/kava/migrate/v0_17"
 )
 
 // MigrateGenesisCmd returns a command to execute genesis state migration.
 func MigrateGenesisCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "migrate [genesis-file]",
-		Short:   "Migrate genesis from v0.15 to v0.16",
-		Long:    "Migrate the source genesis into v0.16 and print to STDOUT.",
+		Short:   "Migrate genesis from v0.16 to v0.17",
+		Long:    "Migrate the source genesis into v0.17 and print to STDOUT.",
 		Example: fmt.Sprintf(`%s migrate /path/to/genesis.json`, version.AppName),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -34,7 +34,7 @@ func MigrateGenesisCmd() *cobra.Command {
 				return fmt.Errorf("failed to read genesis document from file %s: %w", importGenesis, err)
 			}
 
-			newGenDoc, err := v0_16.Migrate(oldGenDoc, clientCtx)
+			newGenDoc, err := v0_17.Migrate(oldGenDoc, clientCtx)
 			if err != nil {
 				return fmt.Errorf("failed to run migration: %w", err)
 			}

--- a/migrate/cmd_test.go
+++ b/migrate/cmd_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMigrateGenesisCmd_V16_Success(t *testing.T) {
+func TestMigrateGenesisCmd_V17_Success(t *testing.T) {
 	ctx := newCmdContext()
 	cmd := migrate.MigrateGenesisCmd()
-	file := filepath.Join("v0_16", "testdata", "genesis-v15.json")
+	file := filepath.Join("v0_17", "testdata", "genesis-v16.json")
 	cmd.SetArgs([]string{file})
 	err := cmd.ExecuteContext(ctx)
 	require.NoError(t, err)

--- a/migrate/v0_17/kava.go
+++ b/migrate/v0_17/kava.go
@@ -1,0 +1,31 @@
+package v0_17
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
+
+	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
+)
+
+func migrateAppState(appState genutiltypes.AppMap, clientCtx client.Context) {
+	codec := clientCtx.Codec
+
+	// x/emvutil
+	evmUtilGenState := evmutiltypes.NewGenesisState([]evmutiltypes.Account{})
+	appState[evmutiltypes.ModuleName] = codec.MustMarshalJSON(evmUtilGenState)
+
+	// x/evm
+	evmGenState := &evmtypes.GenesisState{
+		Accounts: []evmtypes.GenesisAccount{},
+		Params: evmtypes.Params{
+			EvmDenom:     "akava",
+			EnableCreate: true,
+			EnableCall:   true,
+			ChainConfig:  evmtypes.DefaultChainConfig(),
+			ExtraEIPs:    nil,
+		},
+	}
+	appState[evmtypes.ModuleName] = codec.MustMarshalJSON(evmGenState)
+}

--- a/migrate/v0_17/migrate.go
+++ b/migrate/v0_17/migrate.go
@@ -1,0 +1,72 @@
+package v0_17
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/kava-labs/kava/app"
+	tmtypes "github.com/tendermint/tendermint/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
+
+	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
+)
+
+var (
+	GenesisTime = time.Date(2022, 5, 10, 16, 0, 0, 0, time.UTC)
+	ChainID     = "kava-2222-10"
+)
+
+func setConfigIfUnsealed() {
+	config := sdk.GetConfig()
+	if config.GetBech32AccountAddrPrefix() == "kava" {
+		return
+	}
+	app.SetSDKConfig()
+}
+
+// Migrate converts v16 genesis doc to v17 genesis doc
+func Migrate(genDoc *tmtypes.GenesisDoc, ctx client.Context) (*tmtypes.GenesisDoc, error) {
+	setConfigIfUnsealed()
+
+	var appState genutiltypes.AppMap
+	var err error
+	if err := json.Unmarshal(genDoc.AppState, &appState); err != nil {
+		return nil, fmt.Errorf("failed to marchal app state from genesis doc:  %w", err)
+	}
+
+	migrateNewModules(appState, ctx)
+
+	genDoc.AppState, err = json.Marshal(appState)
+	if err != nil {
+		return nil, err
+	}
+
+	genDoc.GenesisTime = GenesisTime
+	genDoc.ChainID = ChainID
+	genDoc.InitialHeight = 1
+
+	return genDoc, nil
+}
+
+func migrateNewModules(appState genutiltypes.AppMap, clientCtx client.Context) {
+	// x/emvutil
+	evmUtilGenState := evmutiltypes.NewGenesisState([]evmutiltypes.Account{})
+	appState[evmutiltypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(evmUtilGenState)
+
+	// x/evm
+	evmGenState := &evmtypes.GenesisState{
+		Accounts: []evmtypes.GenesisAccount{},
+		Params: evmtypes.Params{
+			EvmDenom:     "akava",
+			EnableCreate: true,
+			EnableCall:   true,
+			ChainConfig:  evmtypes.DefaultChainConfig(),
+			ExtraEIPs:    nil,
+		},
+	}
+	appState[evmtypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(evmGenState)
+}

--- a/migrate/v0_17/migrate.go
+++ b/migrate/v0_17/migrate.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	GenesisTime = time.Date(2022, 5, 10, 16, 0, 0, 0, time.UTC)
+	// TODO: needs verification before release
+	GenesisTime = time.Date(2022, 5, 10, 17, 0, 0, 0, time.UTC)
 	ChainID     = "kava-2222-10"
 )
 

--- a/migrate/v0_17/migrate.go
+++ b/migrate/v0_17/migrate.go
@@ -10,9 +10,6 @@ import (
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/kava-labs/kava/app"
 	tmtypes "github.com/tendermint/tendermint/types"
-	evmtypes "github.com/tharsis/ethermint/x/evm/types"
-
-	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
 )
 
 var (
@@ -38,7 +35,7 @@ func Migrate(genDoc *tmtypes.GenesisDoc, ctx client.Context) (*tmtypes.GenesisDo
 		return nil, fmt.Errorf("failed to marchal app state from genesis doc:  %w", err)
 	}
 
-	migrateNewModules(appState, ctx)
+	migrateAppState(appState, ctx)
 
 	genDoc.AppState, err = json.Marshal(appState)
 	if err != nil {
@@ -50,23 +47,4 @@ func Migrate(genDoc *tmtypes.GenesisDoc, ctx client.Context) (*tmtypes.GenesisDo
 	genDoc.InitialHeight = 1
 
 	return genDoc, nil
-}
-
-func migrateNewModules(appState genutiltypes.AppMap, clientCtx client.Context) {
-	// x/emvutil
-	evmUtilGenState := evmutiltypes.NewGenesisState([]evmutiltypes.Account{})
-	appState[evmutiltypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(evmUtilGenState)
-
-	// x/evm
-	evmGenState := &evmtypes.GenesisState{
-		Accounts: []evmtypes.GenesisAccount{},
-		Params: evmtypes.Params{
-			EvmDenom:     "akava",
-			EnableCreate: true,
-			EnableCall:   true,
-			ChainConfig:  evmtypes.DefaultChainConfig(),
-			ExtraEIPs:    nil,
-		},
-	}
-	appState[evmtypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(evmGenState)
 }

--- a/migrate/v0_17/migrate_test.go
+++ b/migrate/v0_17/migrate_test.go
@@ -1,0 +1,87 @@
+package v0_17
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmtypes "github.com/tendermint/tendermint/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
+
+	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
+)
+
+func TestMigrateGenesisDoc(t *testing.T) {
+	expected := getTestDataJSON("genesis-v17.json")
+	genDoc, err := tmtypes.GenesisDocFromFile(filepath.Join("testdata", "genesis-v16.json"))
+	assert.NoError(t, err)
+
+	actualGenDoc, err := Migrate(genDoc, newClientContext())
+	assert.NoError(t, err)
+
+	actualJson, err := tmjson.Marshal(actualGenDoc)
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, expected, string(actualJson))
+}
+
+func TestMigrateEvmUtil(t *testing.T) {
+	appMap, ctx := migrateToV16AndGetAppMap(t)
+	var genstate evmutiltypes.GenesisState
+	err := ctx.Codec.UnmarshalJSON(appMap[evmutiltypes.ModuleName], &genstate)
+	assert.NoError(t, err)
+	assert.Len(t, genstate.Accounts, 0)
+}
+
+func TestMigrateEvm(t *testing.T) {
+	appMap, ctx := migrateToV16AndGetAppMap(t)
+	var genstate evmtypes.GenesisState
+	err := ctx.Codec.UnmarshalJSON(appMap[evmtypes.ModuleName], &genstate)
+	assert.NoError(t, err)
+	assert.Len(t, genstate.Accounts, 0)
+	assert.Equal(t, genstate.Params, evmtypes.Params{
+		EvmDenom:     "akava",
+		EnableCreate: true,
+		EnableCall:   true,
+		ChainConfig:  evmtypes.DefaultChainConfig(),
+		ExtraEIPs:    []int64{},
+	})
+}
+
+func migrateToV16AndGetAppMap(t *testing.T) (genutiltypes.AppMap, client.Context) {
+	genDoc, err := tmtypes.GenesisDocFromFile(filepath.Join("testdata", "genesis-v16.json"))
+	assert.NoError(t, err)
+
+	ctx := newClientContext()
+	actualGenDoc, err := Migrate(genDoc, ctx)
+	assert.NoError(t, err)
+
+	var appMap genutiltypes.AppMap
+	err = tmjson.Unmarshal(actualGenDoc.AppState, &appMap)
+	assert.NoError(t, err)
+
+	return appMap, ctx
+}
+
+func getTestDataJSON(filename string) string {
+	file := filepath.Join("testdata", filename)
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func newClientContext() client.Context {
+	config := app.MakeEncodingConfig()
+	return client.Context{}.
+		WithCodec(config.Marshaler).
+		WithLegacyAmino(config.Amino).
+		WithInterfaceRegistry(config.InterfaceRegistry)
+}

--- a/migrate/v0_17/testdata/genesis-v16.json
+++ b/migrate/v0_17/testdata/genesis-v16.json
@@ -1,0 +1,2280 @@
+{
+  "genesis_time": "2022-01-19T16:00:00Z",
+  "chain_id": "kava-9",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "200000",
+      "max_gas": "20000000",
+      "time_iota_ms": "1000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "50000"
+    },
+    "validator": { "pub_key_types": ["ed25519"] },
+    "version": {
+      "app_version": "1"
+    }
+  },
+  "app_hash": "",
+  "app_state": {
+    "incentive": {
+      "params": {
+        "usdx_minting_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb-a",
+            "start": "2021-07-20T14:00:00Z",
+            "end": "2024-10-16T14:00:00Z",
+            "rewards_per_second": { "denom": "ukava", "amount": "122354" }
+          },
+          {
+            "active": true,
+            "collateral_type": "hard-a",
+            "start": "2021-07-20T14:00:00Z",
+            "end": "2024-10-16T14:00:00Z",
+            "rewards_per_second": { "denom": "ukava", "amount": "23809" }
+          }
+        ],
+        "hard_supply_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb",
+            "start": "2021-07-20T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "123455" }]
+          },
+          {
+            "active": true,
+            "collateral_type": "hard",
+            "start": "2021-07-20T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "123455" }]
+          }
+        ],
+        "hard_borrow_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "12345" }]
+          },
+          {
+            "active": true,
+            "collateral_type": "btcb",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "12345" }]
+          }
+        ],
+        "delegator_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "ukava",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "hard", "amount": "316880" },
+              { "denom": "swp", "amount": "316880" }
+            ]
+          }
+        ],
+        "swap_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "ukava:usdx",
+            "start": "2021-07-14T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "swp", "amount": "316880" },
+              { "denom": "ukava", "amount": "31688" }
+            ]
+          },
+          {
+            "active": true,
+            "collateral_type": "swp:usdx",
+            "start": "2021-07-14T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "swp", "amount": "616880" },
+              { "denom": "ukava", "amount": "31688" }
+            ]
+          }
+        ],
+        "claim_multipliers": [
+          {
+            "denom": "hard",
+            "multipliers": [
+              {
+                "name": "small",
+                "months_lockup": "1",
+                "factor": "0.200000000000000000"
+              },
+              {
+                "name": "large",
+                "months_lockup": "12",
+                "factor": "1.000000000000000000"
+              }
+            ]
+          },
+          {
+            "denom": "swp",
+            "multipliers": [
+              {
+                "name": "small",
+                "months_lockup": "1",
+                "factor": "0.100000000000000000"
+              },
+              {
+                "name": "large",
+                "months_lockup": "12",
+                "factor": "1.000000000000000000"
+              }
+            ]
+          }
+        ],
+        "claim_end": "2025-01-01T00:00:00Z"
+      },
+      "usdx_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "bnb-a",
+            "previous_accumulation_time": "2021-06-10T16:43:11.679705Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "bnb-a",
+            "reward_indexes": [
+              {
+                "collateral_type": "ukava",
+                "reward_factor": "0.043949244534927716"
+              }
+            ]
+          }
+        ]
+      },
+      "hard_supply_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "bnb",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          },
+          {
+            "collateral_type": "hard",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "bnb",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "32.458112657412585027"
+              }
+            ]
+          },
+          {
+            "collateral_type": "hard",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "35.000000000000000000"
+              }
+            ]
+          }
+        ]
+      },
+      "hard_borrow_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "btcb",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "btcb",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "88.582200355378048199"
+              }
+            ]
+          }
+        ]
+      },
+      "delegator_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "ukava",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "ukava",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "0.078380843036861815"
+              },
+              {
+                "collateral_type": "swp",
+                "reward_factor": "0.013629025935176301"
+              }
+            ]
+          }
+        ]
+      },
+      "swap_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "btcb-a",
+            "previous_accumulation_time": "2021-06-10T16:43:11.679705Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "btcb:usdx",
+            "reward_indexes": [
+              {
+                "collateral_type": "swp",
+                "reward_factor": "6.145396761233172901"
+              }
+            ]
+          }
+        ]
+      },
+      "usdx_minting_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qptt5vu26cmxpmv0hf2tnnmf293x266pjcsjar",
+            "reward": { "denom": "ukava", "amount": "550" }
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "bnb-a",
+              "reward_factor": "0.043949244534927716"
+            },
+            {
+              "collateral_type": "btcb-a",
+              "reward_factor": "0.046551281526135881"
+            }
+          ]
+        }
+      ],
+      "hard_liquidity_provider_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
+            "reward": [{ "denom": "hard", "amount": "1747514" }]
+          },
+          "supply_reward_indexes": [
+            {
+              "collateral_type": "bnb",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "22.000000000000000000"
+                }
+              ]
+            },
+            {
+              "collateral_type": "hard",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "30.000000000000000000"
+                }
+              ]
+            }
+          ],
+          "borrow_reward_indexes": [
+            {
+              "collateral_type": "btc",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "88.582200355378048199"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "base_claim": {
+            "owner": "kava1w2uj6rpejrma47vjx4rcghh3fndhmrvs6pmxph",
+            "reward": [
+              {
+                "amount": "1747514",
+                "denom": "hard"
+              }
+            ]
+          },
+          "borrow_reward_indexes": [],
+          "supply_reward_indexes": []
+        }
+      ],
+      "delegator_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
+            "reward": []
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "ukava",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "0.000000000000000000"
+                },
+                {
+                  "collateral_type": "swp",
+                  "reward_factor": "0.000000100000000000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "swap_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qzease8mre5adak7wcc2twh6ryh9evnxpr6caj",
+            "reward": [{ "denom": "swp", "amount": "1960368" }]
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "busd:usdx",
+              "reward_indexes": [
+                {
+                  "collateral_type": "swp",
+                  "reward_factor": "0.018083281889996318"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "hard": {
+      "params": {
+        "money_markets": [
+          {
+            "denom": "usdx",
+            "borrow_limit": {
+              "has_max_limit": false,
+              "maximum_limit": "20000000.000000000000000000",
+              "loan_to_value": "0.800000000000000000"
+            },
+            "spot_market_id": "usdx:usd",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.050000000000000000",
+              "base_multiplier": "0.100000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "0.500000000000000000"
+            },
+            "reserve_factor": "0.000000000000000000",
+            "keeper_reward_percentage": "0.050000000000000000"
+          },
+          {
+            "denom": "ukava",
+            "borrow_limit": {
+              "has_max_limit": false,
+              "maximum_limit": "100000000000.000000000000000000",
+              "loan_to_value": "0.800000000000000000"
+            },
+            "spot_market_id": "kava:usd",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.050000000000000000",
+              "base_multiplier": "2.000000000000000000",
+              "kink": "0.850000000000000000",
+              "jump_multiplier": "10.000000000000000000"
+            },
+            "reserve_factor": "0.100000000000000000",
+            "keeper_reward_percentage": "0.010000000000000000"
+          },
+          {
+            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "25000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "atom:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          }
+        ],
+        "minimum_borrow_usd_value": "10.000000000000000000"
+      },
+      "previous_accumulation_times": [
+        {
+          "collateral_type": "btcb",
+          "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z",
+          "supply_interest_factor": "1.000205165357775358",
+          "borrow_interest_factor": "1.002233592784895182"
+        }
+      ],
+      "deposits": [
+        {
+          "depositor": "kava1qq9ustlc0nv4aew275w93g4qy5zahqgxf5mwv9",
+          "amount": [
+            { "denom": "bnb", "amount": "162103943" },
+            { "denom": "btcb", "amount": "19428483" }
+          ],
+          "index": [{ "denom": "bnb", "value": "1.001740185031830285" }]
+        }
+      ],
+      "borrows": [
+        {
+          "borrower": "kava1qq9ustlc0nv4aew275w93g4qy5zahqgxf5mwv9",
+          "amount": [
+            { "denom": "usdx", "amount": "146724966" },
+            { "denom": "xrpb", "amount": "541061835659" }
+          ],
+          "index": [
+            { "denom": "usdx", "value": "1.000156840239586720" },
+            { "denom": "xrpb", "value": "1.002063063678030789" }
+          ]
+        }
+      ],
+      "total_supplied": [{ "denom": "bnb", "amount": "1246173151758" }],
+      "total_borrowed": [{ "denom": "busd", "amount": "704609324351367" }],
+      "total_reserves": [{ "denom": "xrpb", "amount": "711656301126744" }]
+    },
+    "pricefeed": {
+      "params": {
+        "markets": [
+          {
+            "active": true,
+            "base_asset": "bnb",
+            "market_id": "bnb:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "bnb",
+            "market_id": "bnb:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "atom",
+            "market_id": "atom:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "atom",
+            "market_id": "atom:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "akt",
+            "market_id": "akt:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "akt",
+            "market_id": "akt:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "luna",
+            "market_id": "luna:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "luna",
+            "market_id": "luna:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "osmo",
+            "market_id": "osmo:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "osmo",
+            "market_id": "osmo:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "ust",
+            "market_id": "ust:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "ust",
+            "market_id": "ust:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          }
+        ]
+      },
+      "posted_prices": [
+        {
+          "expiry": "2022-07-20T00:00:00Z",
+          "market_id": "bnb:usd",
+          "oracle_address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "price": "215.962650000000001782"
+        },
+        {
+          "expiry": "2022-07-20T00:00:00Z",
+          "market_id": "bnb:usd:30",
+          "oracle_address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "price": "217.962650000000001782"
+        }
+      ]
+    },
+    "issuance": {
+      "params": {
+        "assets": [
+          {
+            "blockable": true,
+            "blocked_addresses": [],
+            "denom": "hbtc",
+            "owner": "kava1dmm9zpdnm6mfhywzt9sstm4p33y0cnsd0m673z",
+            "paused": false,
+            "rate_limit": {
+              "active": false,
+              "limit": "0",
+              "time_period": "0s"
+            }
+          }
+        ]
+      },
+      "supplies": [
+        {
+          "current_supply": { "denom": "ukava", "amount": "100" },
+          "time_elapsed": "3600s"
+        },
+        {
+          "current_supply": { "denom": "bnb", "amount": "300" },
+          "time_elapsed": "300s"
+        }
+      ]
+    },
+    "cdp": {
+      "params": {
+        "collateral_params": [
+          {
+            "denom": "bnb",
+            "type": "bnb-a",
+            "liquidation_ratio": "1.500000000000000000",
+            "debt_limit": { "denom": "usdx", "amount": "20000000000000" },
+            "stability_fee": "1.000000000782997700",
+            "auction_size": "50000000000",
+            "liquidation_penalty": "0.050000000000000000",
+            "spot_market_id": "bnb:usd",
+            "liquidation_market_id": "bnb:usd:30",
+            "keeper_reward_percentage": "0.010000000000000000",
+            "check_collateralization_index_count": "10",
+            "conversion_factor": "8"
+          },
+          {
+            "denom": "hbtc",
+            "type": "hbtc-a",
+            "liquidation_ratio": "1.500000000000000000",
+            "debt_limit": { "denom": "usdx", "amount": "10000000000000" },
+            "stability_fee": "1.000000001547125958",
+            "auction_size": "1000000000000",
+            "liquidation_penalty": "0.075000000000000000",
+            "spot_market_id": "btc:usd",
+            "liquidation_market_id": "btc:usd:30",
+            "keeper_reward_percentage": "0.010000000000000000",
+            "check_collateralization_index_count": "10",
+            "conversion_factor": "8"
+          }
+        ],
+        "debt_param": {
+          "denom": "usdx",
+          "reference_asset": "usd",
+          "conversion_factor": "6",
+          "debt_floor": "10000000"
+        },
+        "global_debt_limit": { "denom": "usdx", "amount": "43000000000000" },
+        "surplus_auction_threshold": "500000000000",
+        "surplus_auction_lot": "10000000000",
+        "debt_auction_threshold": "100000000000",
+        "debt_auction_lot": "10000000000",
+        "circuit_breaker": false
+      },
+      "cdps": [
+        {
+          "id": "19",
+          "owner": "kava1u4p6a2yse66ewfndw4j7ppsa777vdcex3m4n9s",
+          "type": "bnb-a",
+          "collateral": { "denom": "bnb", "amount": "40911876" },
+          "principal": { "denom": "usdx", "amount": "10016831" },
+          "accumulated_fees": { "denom": "usdx", "amount": "36088" },
+          "fees_updated": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        },
+        {
+          "id": "22",
+          "owner": "kava1e8xjfylam4nvugcmkxwvuxh22uvvad5vknu4yh",
+          "type": "bnb-a",
+          "collateral": { "denom": "bnb", "amount": "88268546" },
+          "principal": { "denom": "usdx", "amount": "10000000" },
+          "accumulated_fees": { "denom": "usdx", "amount": "156662" },
+          "fees_updated": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        }
+      ],
+      "deposits": [
+        {
+          "cdp_id": "19",
+          "depositor": "kava1u4p6a2yse66ewfndw4j7ppsa777vdcex3m4n9s",
+          "amount": { "denom": "bnb", "amount": "40911876" }
+        },
+        {
+          "cdp_id": "22",
+          "depositor": "kava1e8xjfylam4nvugcmkxwvuxh22uvvad5vknu4yh",
+          "amount": { "denom": "bnb", "amount": "88268546" }
+        }
+      ],
+      "starting_cdp_id": "1",
+      "debt_denom": "debt",
+      "gov_denom": "ukava",
+      "previous_accumulation_times": [
+        {
+          "collateral_type": "bnb-a",
+          "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        }
+      ],
+      "total_principals": [
+        { "collateral_type": "bnb-a", "total_principal": "9285009581820" }
+      ]
+    },
+    "auction": {
+      "next_auction_id": "12",
+      "params": {
+        "max_auction_duration": "172800s",
+        "bid_duration": "600s",
+        "increment_surplus": "0.010000000000000000",
+        "increment_debt": "0.010000000000000000",
+        "increment_collateral": "0.010000000000000000"
+      },
+      "auctions": [
+        {
+          "@type": "/kava.auction.v1beta1.CollateralAuction",
+          "base_auction": {
+            "id": "3795",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          },
+          "corresponding_debt": { "denom": "debt", "amount": "0" },
+          "max_bid": { "denom": "bnb", "amount": "1" },
+          "lot_returns": {
+            "addresses": ["kava1eevfnzkf2mt6feyttyzh6ektclauq7zlayefwf"],
+            "weights": ["100"]
+          }
+        },
+        {
+          "@type": "/kava.auction.v1beta1.SurplusAuction",
+          "base_auction": {
+            "id": "3796",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          }
+        },
+        {
+          "@type": "/kava.auction.v1beta1.DebtAuction",
+          "base_auction": {
+            "id": "3895",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          },
+          "corresponding_debt": { "denom": "debt", "amount": "0" }
+        }
+      ]
+    },
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1cj7njkw2g9fqx4e768zc75dp9sks8u9znxrf0w",
+            "pub_key": null,
+            "account_number": "0",
+            "sequence": "0"
+          },
+          "name": "kavadist",
+          "permissions": ["minter"]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
+            "pub_key": null,
+            "account_number": "0",
+            "sequence": "0"
+          },
+          "name": "hard",
+          "permissions": ["minter", "burner"]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1mfru9azs5nua2wxcd4sq64g5nt7nn4n8s2w8cu",
+            "pub_key": null,
+            "account_number": "32",
+            "sequence": "0"
+          },
+          "name": "swap",
+          "permissions": []
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1z3ytjpr6ancl8gw80z6f47z9smug7986x29vtj",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.vesting.v1beta1.PeriodicVestingAccount",
+          "base_vesting_account": {
+            "base_account": {
+              "address": "kava1jun8w7meyvgxl68fsjrsdhnv87zursv7dwlgee",
+              "pub_key": null,
+              "account_number": "0",
+              "sequence": "0"
+            },
+            "original_vesting": [
+              {
+                "denom": "swp",
+                "amount": "14791312"
+              }
+            ],
+            "delegated_free": [],
+            "delegated_vesting": [],
+            "end_time": "1665767828"
+          },
+          "start_time": "1642608000",
+          "vesting_periods": [
+            {
+              "length": "23159828",
+              "amount": [
+                {
+                  "denom": "swp",
+                  "amount": "14791312"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1h932rkxxhwf0gz3gq23qsnedgax5vwuxw4ufhy",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1tfvn5t8qwngqd2q427za2mel48pcus3z9u73fl",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ektgdyy0z23qqnd67ns3qvfzgfgjd5xe82lf5c",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ynf22ap74j6znl503a56y23x5stfr0aw5kntp8",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava173w2zz287s36ewnnkf4mjansnthnnsz7rtrxqc",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1fwfwmt6vupf3m9uvpdsuuc4dga8p5dtl4npcqz",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1sw54s6gq76acm35ls6m5c0kr93dstgrh6eftld",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1t4dvu32e309pzhmdn3aqcjlj79h9876plynrfm",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1wuzhkn2f8nqe2aprnwt3jkjvvr9m7dlkpumtz2",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        }
+      ]
+    },
+    "bank": {
+      "params": { "send_enabled": [], "default_send_enabled": true },
+      "balances": [
+        {
+          "address": "kava1cj7njkw2g9fqx4e768zc75dp9sks8u9znxrf0w",
+          "coins": [
+            { "denom": "hard", "amount": "1000000000000" },
+            { "denom": "swp", "amount": "1000000000000" },
+            { "denom": "ukava", "amount": "1000000000000" }
+          ]
+        },
+        {
+          "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
+          "coins": [{ "denom": "usdx", "amount": "1000000000" }]
+        },
+        {
+          "address": "kava1mfru9azs5nua2wxcd4sq64g5nt7nn4n8s2w8cu",
+          "coins": [
+            { "denom": "ukava", "amount": "1000000000000" },
+            { "denom": "usdx", "amount": "4100000000000" }
+          ]
+        },
+        {
+          "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "coins": [
+            { "denom": "bnb", "amount": "100000000000000" },
+            { "denom": "ukava", "amount": "1000000000000" }
+          ]
+        },
+        {
+          "address": "kava1z3ytjpr6ancl8gw80z6f47z9smug7986x29vtj",
+          "coins": [
+            { "denom": "ukava", "amount": "565077579" },
+            { "denom": "usdx", "amount": "1363200" }
+          ]
+        },
+        {
+          "address": "kava1jun8w7meyvgxl68fsjrsdhnv87zursv7dwlgee",
+          "coins": [
+            { "denom": "swp", "amount": "15915874" },
+            { "denom": "ukava", "amount": "1000000" }
+          ]
+        },
+        {
+          "address": "kava1h932rkxxhwf0gz3gq23qsnedgax5vwuxw4ufhy",
+          "coins": [{ "denom": "ukava", "amount": "2499984990625" }]
+        },
+        {
+          "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1tfvn5t8qwngqd2q427za2mel48pcus3z9u73fl",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1ektgdyy0z23qqnd67ns3qvfzgfgjd5xe82lf5c",
+          "coins": [
+            { "denom": "bnb", "amount": "10000000000000000" },
+            { "denom": "btcb", "amount": "10000000000000000" },
+            { "denom": "busd", "amount": "10000000000000000" },
+            { "denom": "hard", "amount": "1000000000000000000" },
+            { "denom": "hbtc", "amount": "10000000000000000" },
+            { "denom": "swp", "amount": "1000000000000000000" },
+            { "denom": "ukava", "amount": "10000000000000000" },
+            { "denom": "usdx", "amount": "100000000000000000" },
+            { "denom": "xrpb", "amount": "10000000000000000" }
+          ]
+        },
+        {
+          "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1ynf22ap74j6znl503a56y23x5stfr0aw5kntp8",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava173w2zz287s36ewnnkf4mjansnthnnsz7rtrxqc",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1fwfwmt6vupf3m9uvpdsuuc4dga8p5dtl4npcqz",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1sw54s6gq76acm35ls6m5c0kr93dstgrh6eftld",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1t4dvu32e309pzhmdn3aqcjlj79h9876plynrfm",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1wuzhkn2f8nqe2aprnwt3jkjvvr9m7dlkpumtz2",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        }
+      ],
+      "supply": [],
+      "denom_metadata": []
+    },
+    "bep3": {
+      "params": {
+        "asset_params": [
+          {
+            "denom": "btcb",
+            "coin_id": "0",
+            "supply_limit": {
+              "limit": "100000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+            "fixed_fee": "2",
+            "min_swap_amount": "3",
+            "max_swap_amount": "2000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "xrpb",
+            "coin_id": "144",
+            "supply_limit": {
+              "limit": "2000000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+            "fixed_fee": "100000",
+            "min_swap_amount": "100001",
+            "max_swap_amount": "250000000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "bnb",
+            "coin_id": "714",
+            "supply_limit": {
+              "limit": "100000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+            "fixed_fee": "1000",
+            "min_swap_amount": "1001",
+            "max_swap_amount": "500000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "busd",
+            "coin_id": "727",
+            "supply_limit": {
+              "limit": "2000000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+            "fixed_fee": "20000",
+            "min_swap_amount": "20001",
+            "max_swap_amount": "100000000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          }
+        ]
+      },
+      "atomic_swaps": [
+        {
+          "amount": [
+            {
+              "amount": "1999955998",
+              "denom": "btcb"
+            }
+          ],
+          "closed_block": "1",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "838627",
+          "random_number_hash": "6F1CF8F2E13A0C0F0A359F54E47E4E265D766B8E006D2F00BDF994ABDEF1E9E4",
+          "recipient": "kava1fl2hs6y9vz986g5v52pdan9ga923n9mn5cxxkw",
+          "recipient_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "sender": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "sender_other_chain": "bnb19k9wuv2j7c7ck8tmc7kav0r0cnt3esmkrpf25x",
+          "status": "SWAP_STATUS_COMPLETED",
+          "timestamp": "1636034914"
+        },
+        {
+          "amount": [
+            {
+              "amount": "19000000000",
+              "denom": "bnb"
+            }
+          ],
+          "closed_block": "1",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "1736797",
+          "random_number_hash": "280EB832A37F2265CC82F3957CE603AAD57BAD7038B876A1F28953AFA29FA1C3",
+          "recipient": "kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6",
+          "recipient_other_chain": "bnb18nsgj50zvc4uq93w4j0ltz5gaxhwv7aq4qnq0p",
+          "sender": "kava1zw6gg4ztvly7zf25pa33mclav3spvj3ympxxna",
+          "sender_other_chain": "bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn",
+          "status": "SWAP_STATUS_COMPLETED",
+          "timestamp": "1641976566"
+        },
+        {
+          "amount": [
+            {
+              "amount": "999595462080",
+              "denom": "busd"
+            }
+          ],
+          "closed_block": "787122",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "1",
+          "random_number_hash": "BFB7CC82DA0E0C8556AC37843F5AB136B9A7A066054368F5948944282B414D83",
+          "recipient": "kava1eufgf0w9d7hf5mgtek4zr2upkxag9stmzx6unl",
+          "recipient_other_chain": "bnb10zq89008gmedc6rrwzdfukjk94swynd7dl97w8",
+          "sender": "kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu",
+          "sender_other_chain": "bnb1vl3wn4x8kqajg2j9wxa5y5amgzdxchutkxr6at",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1635694492"
+        },
+        {
+          "amount": [
+            {
+              "amount": "999595462080",
+              "denom": "busd"
+            }
+          ],
+          "closed_block": "787122",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "1",
+          "random_number_hash": "BFB7CC82DA0E0C8556AC37843F5AB136B9A7A066054368F5948944282B414D83",
+          "recipient": "kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu",
+          "recipient_other_chain": "bnb1vl3wn4x8kqajg2j9wxa5y5amgzdxchutkxr6at",
+          "sender": "kava1eufgf0w9d7hf5mgtek4zr2upkxag9stmzx6unl",
+          "sender_other_chain": "bnb10zq89008gmedc6rrwzdfukjk94swynd7dl97w8",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1635694492"
+        },
+        {
+          "amount": [
+            {
+              "amount": "1000000",
+              "denom": "btcb"
+            }
+          ],
+          "closed_block": "0",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "24687",
+          "random_number_hash": "A74EA1AB58D312FDF1E872D18583CACCF294E639DDA4F303939E9ADCEC081D93",
+          "recipient": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "recipient_other_chain": "bnb1lhk5ndlgf5wz55t8k35cqj6h9l3m4l5ek2w7q6",
+          "sender": "kava1d2u28azje7rhqyjtxc2ex8q0cxxpw7dfm7ltq5",
+          "sender_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "status": "SWAP_STATUS_OPEN",
+          "timestamp": "1641934114"
+        },
+        {
+          "amount": [
+            {
+              "amount": "1000000",
+              "denom": "btcb"
+            }
+          ],
+          "closed_block": "0",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "1",
+          "random_number_hash": "39E9ADCEC081D93A74EA1A83CACCF294E639DDA4F3039B58D312FDF1E872D185",
+          "recipient": "kava1d2u28azje7rhqyjtxc2ex8q0cxxpw7dfm7ltq5",
+          "recipient_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "sender": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "sender_other_chain": "bnb1lhk5ndlgf5wz55t8k35cqj6h9l3m4l5ek2w7q6",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1641934114"
+        }
+      ],
+      "supplies": [
+        {
+          "incoming_supply": { "denom": "bnb", "amount": "0" },
+          "outgoing_supply": { "denom": "bnb", "amount": "0" },
+          "current_supply": { "denom": "bnb", "amount": "30467559434006" },
+          "time_limited_current_supply": { "denom": "bnb", "amount": "0" },
+          "time_elapsed": "0s"
+        }
+      ],
+      "previous_block_time": "1970-01-01T00:00:00Z"
+    },
+    "committee": {
+      "next_proposal_id": "1",
+      "committees": [
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "1",
+            "description": "Kava Stability Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "auction",
+                    "key": "BidDuration",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementSurplus",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementDebt",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementCollateral",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "GlobalDebtLimit",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DistributionFrequency",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "kavadist",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "CollateralParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "type",
+                        "val": "bnb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-b",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "btcb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "xrpb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "ukava-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hard-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hbtc-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "swp-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtParam",
+                    "single_subparam_allowed_attrs": ["debt_floor"],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "bep3",
+                    "key": "AssetParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "coin_id",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "pricefeed",
+                    "key": "Markets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "atom:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "atom:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "akt:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "akt:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "luna:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "luna:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "osmo:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "osmo:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "ust:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "ust:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              { "@type": "/kava.committee.v1beta1.TextPermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        },
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "2",
+            "description": "Kava Safety Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              { "@type": "/kava.committee.v1beta1.SoftwareUpgradePermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "604800s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        },
+        {
+          "@type": "/kava.committee.v1beta1.TokenCommittee",
+          "base_committee": {
+            "id": "3",
+            "description": "Hard Governance Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardSupplyRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardBorrowRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_DEADLINE"
+          },
+          "quorum": "0.330000000000000000",
+          "tally_denom": "hard"
+        },
+        {
+          "@type": "/kava.committee.v1beta1.TokenCommittee",
+          "base_committee": {
+            "id": "4",
+            "description": "Swp Governance Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "swap",
+                    "key": "AllowedPools",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "swap",
+                    "key": "SwapFee",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "SwapRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  }
+                ]
+              }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_DEADLINE"
+          },
+          "quorum": "0.330000000000000000",
+          "tally_denom": "swp"
+        },
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "5",
+            "description": "Kava God Committee (testing only)",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              { "@type": "/kava.committee.v1beta1.GodPermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "604800s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        }
+      ],
+      "proposals": [
+        {
+          "content": {
+            "@type": "/kava.kavadist.v1beta1.CommunityPoolMultiSpendProposal",
+            "title": "Test",
+            "description": "Test",
+            "recipient_list": [
+              {
+                "address": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+                "amount": [{ "denom": "ukava", "amount": "10" }]
+              }
+            ]
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:48:08.693415Z"
+        },
+        {
+          "content": {
+            "@type": "/cosmos.distribution.v1beta1.CommunityPoolSpendProposal",
+            "title": "Community Pool Spend",
+            "description": "Fund the community pool.",
+            "recipient": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+            "amount": [{ "denom": "ukava", "amount": "10" }]
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:49:44.219341Z"
+        },
+        {
+          "content": {
+            "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
+            "title": "Test",
+            "description": "Test",
+            "plan": {
+              "name": "Test",
+              "time": "0001-01-01T00:00:00Z",
+              "height": "100",
+              "info": "",
+              "upgraded_client_state": null
+            }
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:49:44.219693Z"
+        }
+      ],
+      "votes": [
+        {
+          "proposal_id": "1",
+          "voter": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+          "vote_type": "VOTE_TYPE_YES"
+        },
+        {
+          "proposal_id": "1",
+          "voter": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+          "vote_type": "VOTE_TYPE_ABSTAIN"
+        }
+      ]
+    },
+    "crisis": { "constant_fee": { "denom": "ukava", "amount": "1333000000" } },
+    "distribution": {
+      "params": {
+        "community_tax": "0.000000000000000000",
+        "base_proposer_reward": "0.010000000000000000",
+        "bonus_proposer_reward": "0.040000000000000000",
+        "withdraw_addr_enabled": true
+      },
+      "fee_pool": { "community_pool": [] },
+      "delegator_withdraw_infos": [],
+      "previous_proposer": "",
+      "outstanding_rewards": [],
+      "validator_accumulated_commissions": [],
+      "validator_historical_rewards": [],
+      "validator_current_rewards": [],
+      "delegator_starting_infos": [],
+      "validator_slash_events": []
+    },
+    "evidence": { "evidence": [] },
+    "genutil": {
+      "gen_txs": [
+        {
+          "type": "cosmos-sdk/StdTx",
+          "value": {
+            "fee": { "amount": [], "gas": "200000" },
+            "memo": "23a5601684fa065ce9d953af5fc7d4347050ad14@192.168.0.14:26656",
+            "msg": [
+              {
+                "type": "cosmos-sdk/MsgCreateValidator",
+                "value": {
+                  "commission": {
+                    "max_change_rate": "0.010000000000000000",
+                    "max_rate": "0.200000000000000000",
+                    "rate": "0.100000000000000000"
+                  },
+                  "delegator_address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+                  "description": {
+                    "details": "",
+                    "identity": "",
+                    "moniker": "validator",
+                    "security_contact": "",
+                    "website": ""
+                  },
+                  "min_self_delegation": "1",
+                  "pubkey": "kavavalconspub1zcjduepqvfq6egzgfmdkd6k7cqhsvsfr4lhsp6adh4uurxgkhec8h7amxcjq7gjum4",
+                  "validator_address": "kavavaloper1ypjp0m04pyp73hwgtc0dgkx0e9rrydeckewa42",
+                  "value": { "amount": "1000000000", "denom": "ukava" }
+                }
+              }
+            ],
+            "signatures": [
+              {
+                "pub_key": {
+                  "type": "tendermint/PubKeySecp256k1",
+                  "value": "AgIWiZpdEVb69gfaqyNjbA0b3oe+nRS9BZ9gH/I6oGz+"
+                },
+                "signature": "K9ZA2OYWrX2WSanMnbMHIaFIABWxhcrFjAnyF1U83nlFsVuEmUyGYMOmwo4vac54nkY4pfSzNreu5EnJxniUHA=="
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "gov": {
+      "starting_proposal_id": "1",
+      "deposits": [],
+      "votes": [],
+      "proposals": [],
+      "deposit_params": {
+        "min_deposit": [{ "denom": "ukava", "amount": "200000000" }],
+        "max_deposit_period": "600s"
+      },
+      "voting_params": { "voting_period": "600s" },
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto_threshold": "0.334000000000000000"
+      }
+    },
+    "mint": {
+      "minter": {
+        "inflation": "0.020000000000000000",
+        "annual_provisions": "0.000000000000000000"
+      },
+      "params": {
+        "mint_denom": "ukava",
+        "inflation_rate_change": "0.130000000000000000",
+        "inflation_max": "0.130000000000000000",
+        "inflation_min": "0.010000000000000000",
+        "goal_bonded": "0.670000000000000000",
+        "blocks_per_year": "6311520"
+      }
+    },
+    "params": null,
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.010000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.000100000000000000"
+      },
+      "signing_infos": [],
+      "missed_blocks": []
+    },
+    "staking": {
+      "params": {
+        "unbonding_time": "3600s",
+        "max_validators": 100,
+        "max_entries": 7,
+        "historical_entries": 10000,
+        "bond_denom": "ukava"
+      },
+      "last_total_power": "0",
+      "last_validator_powers": [],
+      "validators": [],
+      "delegations": [],
+      "unbonding_delegations": [],
+      "redelegations": [],
+      "exported": false
+    },
+    "kavadist": {
+      "params": {
+        "active": true,
+        "periods": [
+          {
+            "end": "2021-06-01T14:00:00Z",
+            "inflation": "1.000000000000000000",
+            "start": "2020-06-01T14:00:00Z"
+          },
+          {
+            "end": "2022-06-01T14:00:00Z",
+            "inflation": "1.000000002293273137",
+            "start": "2021-06-01T14:00:00Z"
+          },
+          {
+            "end": "2023-06-01T14:00:00Z",
+            "inflation": "1.000000001167363430",
+            "start": "2022-06-01T14:00:00Z"
+          },
+          {
+            "end": "2024-06-01T14:00:00Z",
+            "inflation": "1.000000000782997609",
+            "start": "2023-06-01T14:00:00Z"
+          }
+        ]
+      },
+      "previous_block_time": "2021-11-05T21:13:12.856088470Z"
+    },
+    "swap": {
+      "params": {
+        "allowed_pools": [
+          {
+            "token_a": "bnb",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "btcb",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "busd",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "hard",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "swp",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "ukava",
+            "token_b": "usdx"
+          },
+          {
+            "token_a": "usdx",
+            "token_b": "xrpb"
+          }
+        ],
+        "swap_fee": "0.001500000000000000"
+      },
+      "pool_records": [
+        {
+          "pool_id": "ukava:usdx",
+          "reserves_a": {
+            "amount": "583616549439",
+            "denom": "ukava"
+          },
+          "reserves_b": {
+            "amount": "3431399443511",
+            "denom": "usdx"
+          },
+          "total_shares": "1398497336200"
+        },
+        {
+          "pool_id": "usdx:xrpb",
+          "reserves_a": {
+            "amount": "843639517257",
+            "denom": "usdx"
+          },
+          "reserves_b": {
+            "amount": "72251274276145",
+            "denom": "xrpb"
+          },
+          "total_shares": "7739661881008"
+        }
+      ],
+      "share_records": [
+        {
+          "depositor": "kava1l77xymdt2ya0rl2mludkny5aqmr67u88ymgdje",
+          "pool_id": "usdx:xrpb",
+          "shares_owned": "29034728969"
+        },
+        {
+          "depositor": "kava1llqkrdr69wc76cuxpx6j06x9pt63f52f7mlcye",
+          "pool_id": "busd:usdx",
+          "shares_owned": "24905307583"
+        },
+        {
+          "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
+          "pool_id": "hard:usdx",
+          "shares_owned": "708138421"
+        },
+        {
+          "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
+          "pool_id": "ukava:usdx",
+          "shares_owned": "3427014047"
+        }
+      ]
+    },
+    "capability": {
+      "index": "1",
+      "owners": []
+    },
+    "transfer": {
+      "denom_traces": [],
+      "params": {
+        "receive_enabled": true,
+        "send_enabled": true
+      },
+      "port_id": "transfer"
+    },
+    "ibc": {
+      "channel_genesis": {
+        "ack_sequences": [],
+        "acknowledgements": [],
+        "channels": [],
+        "commitments": [],
+        "next_channel_sequence": "0",
+        "receipts": [],
+        "recv_sequences": [],
+        "send_sequences": []
+      },
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "create_localhost": false,
+        "next_client_sequence": "0",
+        "params": {
+          "allowed_clients": ["06-solomachine", "07-tendermint"]
+        }
+      },
+      "connection_genesis": {
+        "client_connection_paths": [],
+        "connections": [],
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
+      }
+    },
+    "upgrade": {}
+  }
+}

--- a/migrate/v0_17/testdata/genesis-v17.json
+++ b/migrate/v0_17/testdata/genesis-v17.json
@@ -1,5 +1,5 @@
 {
-  "genesis_time": "2022-05-10T16:00:00Z",
+  "genesis_time": "2022-05-10T17:00:00Z",
   "chain_id": "kava-2222-10",
   "initial_height": "1",
   "consensus_params": {

--- a/migrate/v0_17/testdata/genesis-v17.json
+++ b/migrate/v0_17/testdata/genesis-v17.json
@@ -1,0 +1,2214 @@
+{
+  "genesis_time": "2022-05-10T16:00:00Z",
+  "chain_id": "kava-2222-10",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "200000",
+      "max_gas": "20000000",
+      "time_iota_ms": "1000"
+    },
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "50000"
+    },
+    "validator": { "pub_key_types": ["ed25519"] },
+    "version": { "app_version": "1" }
+  },
+  "app_hash": "",
+  "app_state": {
+    "auction": {
+      "next_auction_id": "12",
+      "params": {
+        "max_auction_duration": "172800s",
+        "bid_duration": "600s",
+        "increment_surplus": "0.010000000000000000",
+        "increment_debt": "0.010000000000000000",
+        "increment_collateral": "0.010000000000000000"
+      },
+      "auctions": [
+        {
+          "@type": "/kava.auction.v1beta1.CollateralAuction",
+          "base_auction": {
+            "id": "3795",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          },
+          "corresponding_debt": { "denom": "debt", "amount": "0" },
+          "max_bid": { "denom": "bnb", "amount": "1" },
+          "lot_returns": {
+            "addresses": ["kava1eevfnzkf2mt6feyttyzh6ektclauq7zlayefwf"],
+            "weights": ["100"]
+          }
+        },
+        {
+          "@type": "/kava.auction.v1beta1.SurplusAuction",
+          "base_auction": {
+            "id": "3796",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          }
+        },
+        {
+          "@type": "/kava.auction.v1beta1.DebtAuction",
+          "base_auction": {
+            "id": "3895",
+            "initiator": "hard",
+            "lot": { "denom": "bnb", "amount": "1" },
+            "bidder": "",
+            "bid": { "denom": "bnb", "amount": "0" },
+            "has_received_bids": false,
+            "end_time": "9000-01-01T00:00:00Z",
+            "max_end_time": "9000-01-01T00:00:00Z"
+          },
+          "corresponding_debt": { "denom": "debt", "amount": "0" }
+        }
+      ]
+    },
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1cj7njkw2g9fqx4e768zc75dp9sks8u9znxrf0w",
+            "pub_key": null,
+            "account_number": "0",
+            "sequence": "0"
+          },
+          "name": "kavadist",
+          "permissions": ["minter"]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
+            "pub_key": null,
+            "account_number": "0",
+            "sequence": "0"
+          },
+          "name": "hard",
+          "permissions": ["minter", "burner"]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.ModuleAccount",
+          "base_account": {
+            "address": "kava1mfru9azs5nua2wxcd4sq64g5nt7nn4n8s2w8cu",
+            "pub_key": null,
+            "account_number": "32",
+            "sequence": "0"
+          },
+          "name": "swap",
+          "permissions": []
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1z3ytjpr6ancl8gw80z6f47z9smug7986x29vtj",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.vesting.v1beta1.PeriodicVestingAccount",
+          "base_vesting_account": {
+            "base_account": {
+              "address": "kava1jun8w7meyvgxl68fsjrsdhnv87zursv7dwlgee",
+              "pub_key": null,
+              "account_number": "0",
+              "sequence": "0"
+            },
+            "original_vesting": [{ "denom": "swp", "amount": "14791312" }],
+            "delegated_free": [],
+            "delegated_vesting": [],
+            "end_time": "1665767828"
+          },
+          "start_time": "1642608000",
+          "vesting_periods": [
+            {
+              "length": "23159828",
+              "amount": [{ "denom": "swp", "amount": "14791312" }]
+            }
+          ]
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1h932rkxxhwf0gz3gq23qsnedgax5vwuxw4ufhy",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1tfvn5t8qwngqd2q427za2mel48pcus3z9u73fl",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ektgdyy0z23qqnd67ns3qvfzgfgjd5xe82lf5c",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1ynf22ap74j6znl503a56y23x5stfr0aw5kntp8",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava173w2zz287s36ewnnkf4mjansnthnnsz7rtrxqc",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1fwfwmt6vupf3m9uvpdsuuc4dga8p5dtl4npcqz",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1sw54s6gq76acm35ls6m5c0kr93dstgrh6eftld",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1t4dvu32e309pzhmdn3aqcjlj79h9876plynrfm",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "kava1wuzhkn2f8nqe2aprnwt3jkjvvr9m7dlkpumtz2",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        }
+      ]
+    },
+    "bank": {
+      "params": { "send_enabled": [], "default_send_enabled": true },
+      "balances": [
+        {
+          "address": "kava1cj7njkw2g9fqx4e768zc75dp9sks8u9znxrf0w",
+          "coins": [
+            { "denom": "hard", "amount": "1000000000000" },
+            { "denom": "swp", "amount": "1000000000000" },
+            { "denom": "ukava", "amount": "1000000000000" }
+          ]
+        },
+        {
+          "address": "kava1a42xtwfzphuuu9mdp0es6633wu5mm8fhm789v3",
+          "coins": [{ "denom": "usdx", "amount": "1000000000" }]
+        },
+        {
+          "address": "kava1mfru9azs5nua2wxcd4sq64g5nt7nn4n8s2w8cu",
+          "coins": [
+            { "denom": "ukava", "amount": "1000000000000" },
+            { "denom": "usdx", "amount": "4100000000000" }
+          ]
+        },
+        {
+          "address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+          "coins": [
+            { "denom": "bnb", "amount": "100000000000000" },
+            { "denom": "ukava", "amount": "1000000000000" }
+          ]
+        },
+        {
+          "address": "kava1z3ytjpr6ancl8gw80z6f47z9smug7986x29vtj",
+          "coins": [
+            { "denom": "ukava", "amount": "565077579" },
+            { "denom": "usdx", "amount": "1363200" }
+          ]
+        },
+        {
+          "address": "kava1jun8w7meyvgxl68fsjrsdhnv87zursv7dwlgee",
+          "coins": [
+            { "denom": "swp", "amount": "15915874" },
+            { "denom": "ukava", "amount": "1000000" }
+          ]
+        },
+        {
+          "address": "kava1h932rkxxhwf0gz3gq23qsnedgax5vwuxw4ufhy",
+          "coins": [{ "denom": "ukava", "amount": "2499984990625" }]
+        },
+        {
+          "address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1tfvn5t8qwngqd2q427za2mel48pcus3z9u73fl",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1ektgdyy0z23qqnd67ns3qvfzgfgjd5xe82lf5c",
+          "coins": [
+            { "denom": "bnb", "amount": "10000000000000000" },
+            { "denom": "btcb", "amount": "10000000000000000" },
+            { "denom": "busd", "amount": "10000000000000000" },
+            { "denom": "hard", "amount": "1000000000000000000" },
+            { "denom": "hbtc", "amount": "10000000000000000" },
+            { "denom": "swp", "amount": "1000000000000000000" },
+            { "denom": "ukava", "amount": "10000000000000000" },
+            { "denom": "usdx", "amount": "100000000000000000" },
+            { "denom": "xrpb", "amount": "10000000000000000" }
+          ]
+        },
+        {
+          "address": "kava1g33w0mh4mjllhaj3y4dcwkwquxgwrma9ga5t94",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1ynf22ap74j6znl503a56y23x5stfr0aw5kntp8",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava173w2zz287s36ewnnkf4mjansnthnnsz7rtrxqc",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1fwfwmt6vupf3m9uvpdsuuc4dga8p5dtl4npcqz",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1sw54s6gq76acm35ls6m5c0kr93dstgrh6eftld",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1t4dvu32e309pzhmdn3aqcjlj79h9876plynrfm",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        },
+        {
+          "address": "kava1wuzhkn2f8nqe2aprnwt3jkjvvr9m7dlkpumtz2",
+          "coins": [{ "denom": "ukava", "amount": "1000000000000" }]
+        }
+      ],
+      "supply": [],
+      "denom_metadata": []
+    },
+    "bep3": {
+      "params": {
+        "asset_params": [
+          {
+            "denom": "btcb",
+            "coin_id": "0",
+            "supply_limit": {
+              "limit": "100000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1kla4wl0ccv7u85cemvs3y987hqk0afcv7vue84",
+            "fixed_fee": "2",
+            "min_swap_amount": "3",
+            "max_swap_amount": "2000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "xrpb",
+            "coin_id": "144",
+            "supply_limit": {
+              "limit": "2000000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava14q5sawxdxtpap5x5sgzj7v4sp3ucncjlpuk3hs",
+            "fixed_fee": "100000",
+            "min_swap_amount": "100001",
+            "max_swap_amount": "250000000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "bnb",
+            "coin_id": "714",
+            "supply_limit": {
+              "limit": "100000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1agcvt07tcw0tglu0hmwdecsnuxp2yd45f3avgm",
+            "fixed_fee": "1000",
+            "min_swap_amount": "1001",
+            "max_swap_amount": "500000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          },
+          {
+            "denom": "busd",
+            "coin_id": "727",
+            "supply_limit": {
+              "limit": "2000000000000000",
+              "time_limited": false,
+              "time_period": "0s",
+              "time_based_limit": "0"
+            },
+            "active": true,
+            "deputy_address": "kava1j9je7f6s0v6k7dmgv6u5k5ru202f5ffsc7af04",
+            "fixed_fee": "20000",
+            "min_swap_amount": "20001",
+            "max_swap_amount": "100000000000000",
+            "min_block_lock": "24686",
+            "max_block_lock": "86400"
+          }
+        ]
+      },
+      "atomic_swaps": [
+        {
+          "amount": [{ "amount": "1999955998", "denom": "btcb" }],
+          "closed_block": "1",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "838627",
+          "random_number_hash": "6F1CF8F2E13A0C0F0A359F54E47E4E265D766B8E006D2F00BDF994ABDEF1E9E4",
+          "recipient": "kava1fl2hs6y9vz986g5v52pdan9ga923n9mn5cxxkw",
+          "recipient_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "sender": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "sender_other_chain": "bnb19k9wuv2j7c7ck8tmc7kav0r0cnt3esmkrpf25x",
+          "status": "SWAP_STATUS_COMPLETED",
+          "timestamp": "1636034914"
+        },
+        {
+          "amount": [{ "amount": "19000000000", "denom": "bnb" }],
+          "closed_block": "1",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "1736797",
+          "random_number_hash": "280EB832A37F2265CC82F3957CE603AAD57BAD7038B876A1F28953AFA29FA1C3",
+          "recipient": "kava1r4v2zdhdalfj2ydazallqvrus9fkphmglhn6u6",
+          "recipient_other_chain": "bnb18nsgj50zvc4uq93w4j0ltz5gaxhwv7aq4qnq0p",
+          "sender": "kava1zw6gg4ztvly7zf25pa33mclav3spvj3ympxxna",
+          "sender_other_chain": "bnb1jh7uv2rm6339yue8k4mj9406k3509kr4wt5nxn",
+          "status": "SWAP_STATUS_COMPLETED",
+          "timestamp": "1641976566"
+        },
+        {
+          "amount": [{ "amount": "999595462080", "denom": "busd" }],
+          "closed_block": "787122",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "1",
+          "random_number_hash": "BFB7CC82DA0E0C8556AC37843F5AB136B9A7A066054368F5948944282B414D83",
+          "recipient": "kava1eufgf0w9d7hf5mgtek4zr2upkxag9stmzx6unl",
+          "recipient_other_chain": "bnb10zq89008gmedc6rrwzdfukjk94swynd7dl97w8",
+          "sender": "kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu",
+          "sender_other_chain": "bnb1vl3wn4x8kqajg2j9wxa5y5amgzdxchutkxr6at",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1635694492"
+        },
+        {
+          "amount": [{ "amount": "999595462080", "denom": "busd" }],
+          "closed_block": "787122",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "1",
+          "random_number_hash": "BFB7CC82DA0E0C8556AC37843F5AB136B9A7A066054368F5948944282B414D83",
+          "recipient": "kava1hh4x3a4suu5zyaeauvmv7ypf7w9llwlfufjmuu",
+          "recipient_other_chain": "bnb1vl3wn4x8kqajg2j9wxa5y5amgzdxchutkxr6at",
+          "sender": "kava1eufgf0w9d7hf5mgtek4zr2upkxag9stmzx6unl",
+          "sender_other_chain": "bnb10zq89008gmedc6rrwzdfukjk94swynd7dl97w8",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1635694492"
+        },
+        {
+          "amount": [{ "amount": "1000000", "denom": "btcb" }],
+          "closed_block": "0",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_OUTGOING",
+          "expire_height": "24687",
+          "random_number_hash": "A74EA1AB58D312FDF1E872D18583CACCF294E639DDA4F303939E9ADCEC081D93",
+          "recipient": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "recipient_other_chain": "bnb1lhk5ndlgf5wz55t8k35cqj6h9l3m4l5ek2w7q6",
+          "sender": "kava1d2u28azje7rhqyjtxc2ex8q0cxxpw7dfm7ltq5",
+          "sender_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "status": "SWAP_STATUS_OPEN",
+          "timestamp": "1641934114"
+        },
+        {
+          "amount": [{ "amount": "1000000", "denom": "btcb" }],
+          "closed_block": "0",
+          "cross_chain": true,
+          "direction": "SWAP_DIRECTION_INCOMING",
+          "expire_height": "1",
+          "random_number_hash": "39E9ADCEC081D93A74EA1A83CACCF294E639DDA4F3039B58D312FDF1E872D185",
+          "recipient": "kava1d2u28azje7rhqyjtxc2ex8q0cxxpw7dfm7ltq5",
+          "recipient_other_chain": "bnb1xz3xqf4p2ygrw9lhp5g5df4ep4nd20vsywnmpr",
+          "sender": "kava14qsmvzprqvhwmgql9fr0u3zv9n2qla8zhnm5pc",
+          "sender_other_chain": "bnb1lhk5ndlgf5wz55t8k35cqj6h9l3m4l5ek2w7q6",
+          "status": "SWAP_STATUS_EXPIRED",
+          "timestamp": "1641934114"
+        }
+      ],
+      "supplies": [
+        {
+          "incoming_supply": { "denom": "bnb", "amount": "0" },
+          "outgoing_supply": { "denom": "bnb", "amount": "0" },
+          "current_supply": { "denom": "bnb", "amount": "30467559434006" },
+          "time_limited_current_supply": { "denom": "bnb", "amount": "0" },
+          "time_elapsed": "0s"
+        }
+      ],
+      "previous_block_time": "1970-01-01T00:00:00Z"
+    },
+    "capability": { "index": "1", "owners": [] },
+    "cdp": {
+      "params": {
+        "collateral_params": [
+          {
+            "denom": "bnb",
+            "type": "bnb-a",
+            "liquidation_ratio": "1.500000000000000000",
+            "debt_limit": { "denom": "usdx", "amount": "20000000000000" },
+            "stability_fee": "1.000000000782997700",
+            "auction_size": "50000000000",
+            "liquidation_penalty": "0.050000000000000000",
+            "spot_market_id": "bnb:usd",
+            "liquidation_market_id": "bnb:usd:30",
+            "keeper_reward_percentage": "0.010000000000000000",
+            "check_collateralization_index_count": "10",
+            "conversion_factor": "8"
+          },
+          {
+            "denom": "hbtc",
+            "type": "hbtc-a",
+            "liquidation_ratio": "1.500000000000000000",
+            "debt_limit": { "denom": "usdx", "amount": "10000000000000" },
+            "stability_fee": "1.000000001547125958",
+            "auction_size": "1000000000000",
+            "liquidation_penalty": "0.075000000000000000",
+            "spot_market_id": "btc:usd",
+            "liquidation_market_id": "btc:usd:30",
+            "keeper_reward_percentage": "0.010000000000000000",
+            "check_collateralization_index_count": "10",
+            "conversion_factor": "8"
+          }
+        ],
+        "debt_param": {
+          "denom": "usdx",
+          "reference_asset": "usd",
+          "conversion_factor": "6",
+          "debt_floor": "10000000"
+        },
+        "global_debt_limit": { "denom": "usdx", "amount": "43000000000000" },
+        "surplus_auction_threshold": "500000000000",
+        "surplus_auction_lot": "10000000000",
+        "debt_auction_threshold": "100000000000",
+        "debt_auction_lot": "10000000000",
+        "circuit_breaker": false
+      },
+      "cdps": [
+        {
+          "id": "19",
+          "owner": "kava1u4p6a2yse66ewfndw4j7ppsa777vdcex3m4n9s",
+          "type": "bnb-a",
+          "collateral": { "denom": "bnb", "amount": "40911876" },
+          "principal": { "denom": "usdx", "amount": "10016831" },
+          "accumulated_fees": { "denom": "usdx", "amount": "36088" },
+          "fees_updated": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        },
+        {
+          "id": "22",
+          "owner": "kava1e8xjfylam4nvugcmkxwvuxh22uvvad5vknu4yh",
+          "type": "bnb-a",
+          "collateral": { "denom": "bnb", "amount": "88268546" },
+          "principal": { "denom": "usdx", "amount": "10000000" },
+          "accumulated_fees": { "denom": "usdx", "amount": "156662" },
+          "fees_updated": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        }
+      ],
+      "deposits": [
+        {
+          "cdp_id": "19",
+          "depositor": "kava1u4p6a2yse66ewfndw4j7ppsa777vdcex3m4n9s",
+          "amount": { "denom": "bnb", "amount": "40911876" }
+        },
+        {
+          "cdp_id": "22",
+          "depositor": "kava1e8xjfylam4nvugcmkxwvuxh22uvvad5vknu4yh",
+          "amount": { "denom": "bnb", "amount": "88268546" }
+        }
+      ],
+      "starting_cdp_id": "1",
+      "debt_denom": "debt",
+      "gov_denom": "ukava",
+      "previous_accumulation_times": [
+        {
+          "collateral_type": "bnb-a",
+          "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z",
+          "interest_factor": "1.002881426571765716"
+        }
+      ],
+      "total_principals": [
+        { "collateral_type": "bnb-a", "total_principal": "9285009581820" }
+      ]
+    },
+    "committee": {
+      "next_proposal_id": "1",
+      "committees": [
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "1",
+            "description": "Kava Stability Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "auction",
+                    "key": "BidDuration",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementSurplus",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementDebt",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "auction",
+                    "key": "IncrementCollateral",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "GlobalDebtLimit",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "SurplusLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtThreshold",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtLot",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DistributionFrequency",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "kavadist",
+                    "key": "Active",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "CollateralParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "type",
+                        "val": "bnb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "busd-b",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "btcb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "xrpb-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "ukava-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hard-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "hbtc-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      },
+                      {
+                        "key": "type",
+                        "val": "swp-a",
+                        "allowed_subparam_attr_changes": [
+                          "auction_size",
+                          "check_collateralization_index_count",
+                          "debt_limit",
+                          "keeper_reward_percentage",
+                          "stability_fee"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "cdp",
+                    "key": "DebtParam",
+                    "single_subparam_allowed_attrs": ["debt_floor"],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "bep3",
+                    "key": "AssetParams",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "coin_id",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "active",
+                          "limit",
+                          "max_swap_amount",
+                          "min_block_lock"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "pricefeed",
+                    "key": "Markets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "bnb:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "btc:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "xrp:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "busd:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "atom:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "atom:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "akt:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "akt:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "luna:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "luna:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "osmo:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "osmo:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "ust:usd",
+                        "allowed_subparam_attr_changes": ["active"]
+                      },
+                      {
+                        "key": "market_id",
+                        "val": "ust:usd:30",
+                        "allowed_subparam_attr_changes": ["active"]
+                      }
+                    ]
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              { "@type": "/kava.committee.v1beta1.TextPermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        },
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "2",
+            "description": "Kava Safety Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              { "@type": "/kava.committee.v1beta1.SoftwareUpgradePermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "604800s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        },
+        {
+          "@type": "/kava.committee.v1beta1.TokenCommittee",
+          "base_committee": {
+            "id": "3",
+            "description": "Hard Governance Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "hard",
+                    "key": "MinimumBorrowUSDValue",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardSupplyRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardBorrowRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "hard",
+                    "key": "MoneyMarkets",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": [
+                      {
+                        "key": "denom",
+                        "val": "bnb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "busd",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "btcb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "xrpb",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "usdx",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ukava",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "hard",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "swp",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      },
+                      {
+                        "key": "denom",
+                        "val": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+                        "allowed_subparam_attr_changes": [
+                          "borrow_limit",
+                          "interest_rate_model",
+                          "keeper_reward_percentage",
+                          "reserve_factor",
+                          "spot_market_id"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_DEADLINE"
+          },
+          "quorum": "0.330000000000000000",
+          "tally_denom": "hard"
+        },
+        {
+          "@type": "/kava.committee.v1beta1.TokenCommittee",
+          "base_committee": {
+            "id": "4",
+            "description": "Swp Governance Committee",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              {
+                "@type": "/kava.committee.v1beta1.ParamsChangePermission",
+                "allowed_params_changes": [
+                  {
+                    "subspace": "swap",
+                    "key": "AllowedPools",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "swap",
+                    "key": "SwapFee",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "HardDelegatorRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  },
+                  {
+                    "subspace": "incentive",
+                    "key": "SwapRewardPeriods",
+                    "single_subparam_allowed_attrs": [],
+                    "multi_subparams_requirements": []
+                  }
+                ]
+              }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "600s",
+            "tally_option": "TALLY_OPTION_DEADLINE"
+          },
+          "quorum": "0.330000000000000000",
+          "tally_denom": "swp"
+        },
+        {
+          "@type": "/kava.committee.v1beta1.MemberCommittee",
+          "base_committee": {
+            "id": "5",
+            "description": "Kava God Committee (testing only)",
+            "members": ["kava1n96qpdfcz2m7y364ewk8srv9zuq6ucwduyjaag"],
+            "permissions": [
+              { "@type": "/kava.committee.v1beta1.GodPermission" }
+            ],
+            "vote_threshold": "0.500000000000000000",
+            "proposal_duration": "604800s",
+            "tally_option": "TALLY_OPTION_FIRST_PAST_THE_POST"
+          }
+        }
+      ],
+      "proposals": [
+        {
+          "content": {
+            "@type": "/kava.kavadist.v1beta1.CommunityPoolMultiSpendProposal",
+            "title": "Test",
+            "description": "Test",
+            "recipient_list": [
+              {
+                "address": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+                "amount": [{ "denom": "ukava", "amount": "10" }]
+              }
+            ]
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:48:08.693415Z"
+        },
+        {
+          "content": {
+            "@type": "/cosmos.distribution.v1beta1.CommunityPoolSpendProposal",
+            "title": "Community Pool Spend",
+            "description": "Fund the community pool.",
+            "recipient": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+            "amount": [{ "denom": "ukava", "amount": "10" }]
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:49:44.219341Z"
+        },
+        {
+          "content": {
+            "@type": "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
+            "title": "Test",
+            "description": "Test",
+            "plan": {
+              "name": "Test",
+              "time": "0001-01-01T00:00:00Z",
+              "height": "100",
+              "info": "",
+              "upgraded_client_state": null
+            }
+          },
+          "id": "1",
+          "committee_id": "2",
+          "deadline": "2021-11-24T18:49:44.219693Z"
+        }
+      ],
+      "votes": [
+        {
+          "proposal_id": "1",
+          "voter": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+          "vote_type": "VOTE_TYPE_YES"
+        },
+        {
+          "proposal_id": "1",
+          "voter": "kava1ze7y9qwdddejmy7jlw4cymqqlt2wh05yhwmrv2",
+          "vote_type": "VOTE_TYPE_ABSTAIN"
+        }
+      ]
+    },
+    "crisis": { "constant_fee": { "denom": "ukava", "amount": "1333000000" } },
+    "distribution": {
+      "params": {
+        "community_tax": "0.000000000000000000",
+        "base_proposer_reward": "0.010000000000000000",
+        "bonus_proposer_reward": "0.040000000000000000",
+        "withdraw_addr_enabled": true
+      },
+      "fee_pool": { "community_pool": [] },
+      "delegator_withdraw_infos": [],
+      "previous_proposer": "",
+      "outstanding_rewards": [],
+      "validator_accumulated_commissions": [],
+      "validator_historical_rewards": [],
+      "validator_current_rewards": [],
+      "delegator_starting_infos": [],
+      "validator_slash_events": []
+    },
+    "evidence": { "evidence": [] },
+    "evm": {
+      "accounts": [],
+      "params": {
+        "evm_denom": "akava",
+        "enable_create": true,
+        "enable_call": true,
+        "extra_eips": [],
+        "chain_config": {
+          "homestead_block": "0",
+          "dao_fork_block": "0",
+          "dao_fork_support": true,
+          "eip150_block": "0",
+          "eip150_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "eip155_block": "0",
+          "eip158_block": "0",
+          "byzantium_block": "0",
+          "constantinople_block": "0",
+          "petersburg_block": "0",
+          "istanbul_block": "0",
+          "muir_glacier_block": "0",
+          "berlin_block": "0",
+          "london_block": "0",
+          "arrow_glacier_block": "0",
+          "merge_fork_block": "0"
+        }
+      }
+    },
+    "evmutil": { "accounts": [] },
+    "genutil": {
+      "gen_txs": [
+        {
+          "type": "cosmos-sdk/StdTx",
+          "value": {
+            "fee": { "amount": [], "gas": "200000" },
+            "memo": "23a5601684fa065ce9d953af5fc7d4347050ad14@192.168.0.14:26656",
+            "msg": [
+              {
+                "type": "cosmos-sdk/MsgCreateValidator",
+                "value": {
+                  "commission": {
+                    "max_change_rate": "0.010000000000000000",
+                    "max_rate": "0.200000000000000000",
+                    "rate": "0.100000000000000000"
+                  },
+                  "delegator_address": "kava1ypjp0m04pyp73hwgtc0dgkx0e9rrydecm054da",
+                  "description": {
+                    "details": "",
+                    "identity": "",
+                    "moniker": "validator",
+                    "security_contact": "",
+                    "website": ""
+                  },
+                  "min_self_delegation": "1",
+                  "pubkey": "kavavalconspub1zcjduepqvfq6egzgfmdkd6k7cqhsvsfr4lhsp6adh4uurxgkhec8h7amxcjq7gjum4",
+                  "validator_address": "kavavaloper1ypjp0m04pyp73hwgtc0dgkx0e9rrydeckewa42",
+                  "value": { "amount": "1000000000", "denom": "ukava" }
+                }
+              }
+            ],
+            "signatures": [
+              {
+                "pub_key": {
+                  "type": "tendermint/PubKeySecp256k1",
+                  "value": "AgIWiZpdEVb69gfaqyNjbA0b3oe+nRS9BZ9gH/I6oGz+"
+                },
+                "signature": "K9ZA2OYWrX2WSanMnbMHIaFIABWxhcrFjAnyF1U83nlFsVuEmUyGYMOmwo4vac54nkY4pfSzNreu5EnJxniUHA=="
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "gov": {
+      "starting_proposal_id": "1",
+      "deposits": [],
+      "votes": [],
+      "proposals": [],
+      "deposit_params": {
+        "min_deposit": [{ "denom": "ukava", "amount": "200000000" }],
+        "max_deposit_period": "600s"
+      },
+      "voting_params": { "voting_period": "600s" },
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto_threshold": "0.334000000000000000"
+      }
+    },
+    "hard": {
+      "params": {
+        "money_markets": [
+          {
+            "denom": "usdx",
+            "borrow_limit": {
+              "has_max_limit": false,
+              "maximum_limit": "20000000.000000000000000000",
+              "loan_to_value": "0.800000000000000000"
+            },
+            "spot_market_id": "usdx:usd",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.050000000000000000",
+              "base_multiplier": "0.100000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "0.500000000000000000"
+            },
+            "reserve_factor": "0.000000000000000000",
+            "keeper_reward_percentage": "0.050000000000000000"
+          },
+          {
+            "denom": "ukava",
+            "borrow_limit": {
+              "has_max_limit": false,
+              "maximum_limit": "100000000000.000000000000000000",
+              "loan_to_value": "0.800000000000000000"
+            },
+            "spot_market_id": "kava:usd",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.050000000000000000",
+              "base_multiplier": "2.000000000000000000",
+              "kink": "0.850000000000000000",
+              "jump_multiplier": "10.000000000000000000"
+            },
+            "reserve_factor": "0.100000000000000000",
+            "keeper_reward_percentage": "0.010000000000000000"
+          },
+          {
+            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "25000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "atom:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          }
+        ],
+        "minimum_borrow_usd_value": "10.000000000000000000"
+      },
+      "previous_accumulation_times": [
+        {
+          "collateral_type": "btcb",
+          "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z",
+          "supply_interest_factor": "1.000205165357775358",
+          "borrow_interest_factor": "1.002233592784895182"
+        }
+      ],
+      "deposits": [
+        {
+          "depositor": "kava1qq9ustlc0nv4aew275w93g4qy5zahqgxf5mwv9",
+          "amount": [
+            { "denom": "bnb", "amount": "162103943" },
+            { "denom": "btcb", "amount": "19428483" }
+          ],
+          "index": [{ "denom": "bnb", "value": "1.001740185031830285" }]
+        }
+      ],
+      "borrows": [
+        {
+          "borrower": "kava1qq9ustlc0nv4aew275w93g4qy5zahqgxf5mwv9",
+          "amount": [
+            { "denom": "usdx", "amount": "146724966" },
+            { "denom": "xrpb", "amount": "541061835659" }
+          ],
+          "index": [
+            { "denom": "usdx", "value": "1.000156840239586720" },
+            { "denom": "xrpb", "value": "1.002063063678030789" }
+          ]
+        }
+      ],
+      "total_supplied": [{ "denom": "bnb", "amount": "1246173151758" }],
+      "total_borrowed": [{ "denom": "busd", "amount": "704609324351367" }],
+      "total_reserves": [{ "denom": "xrpb", "amount": "711656301126744" }]
+    },
+    "ibc": {
+      "channel_genesis": {
+        "ack_sequences": [],
+        "acknowledgements": [],
+        "channels": [],
+        "commitments": [],
+        "next_channel_sequence": "0",
+        "receipts": [],
+        "recv_sequences": [],
+        "send_sequences": []
+      },
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "create_localhost": false,
+        "next_client_sequence": "0",
+        "params": { "allowed_clients": ["06-solomachine", "07-tendermint"] }
+      },
+      "connection_genesis": {
+        "client_connection_paths": [],
+        "connections": [],
+        "next_connection_sequence": "0",
+        "params": { "max_expected_time_per_block": "30000000000" }
+      }
+    },
+    "incentive": {
+      "params": {
+        "usdx_minting_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb-a",
+            "start": "2021-07-20T14:00:00Z",
+            "end": "2024-10-16T14:00:00Z",
+            "rewards_per_second": { "denom": "ukava", "amount": "122354" }
+          },
+          {
+            "active": true,
+            "collateral_type": "hard-a",
+            "start": "2021-07-20T14:00:00Z",
+            "end": "2024-10-16T14:00:00Z",
+            "rewards_per_second": { "denom": "ukava", "amount": "23809" }
+          }
+        ],
+        "hard_supply_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb",
+            "start": "2021-07-20T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "123455" }]
+          },
+          {
+            "active": true,
+            "collateral_type": "hard",
+            "start": "2021-07-20T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "123455" }]
+          }
+        ],
+        "hard_borrow_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "bnb",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "12345" }]
+          },
+          {
+            "active": true,
+            "collateral_type": "btcb",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [{ "denom": "hard", "amount": "12345" }]
+          }
+        ],
+        "delegator_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "ukava",
+            "start": "2020-01-01T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "hard", "amount": "316880" },
+              { "denom": "swp", "amount": "316880" }
+            ]
+          }
+        ],
+        "swap_reward_periods": [
+          {
+            "active": true,
+            "collateral_type": "ukava:usdx",
+            "start": "2021-07-14T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "swp", "amount": "316880" },
+              { "denom": "ukava", "amount": "31688" }
+            ]
+          },
+          {
+            "active": true,
+            "collateral_type": "swp:usdx",
+            "start": "2021-07-14T00:00:00Z",
+            "end": "2024-01-01T00:00:00Z",
+            "rewards_per_second": [
+              { "denom": "swp", "amount": "616880" },
+              { "denom": "ukava", "amount": "31688" }
+            ]
+          }
+        ],
+        "claim_multipliers": [
+          {
+            "denom": "hard",
+            "multipliers": [
+              {
+                "name": "small",
+                "months_lockup": "1",
+                "factor": "0.200000000000000000"
+              },
+              {
+                "name": "large",
+                "months_lockup": "12",
+                "factor": "1.000000000000000000"
+              }
+            ]
+          },
+          {
+            "denom": "swp",
+            "multipliers": [
+              {
+                "name": "small",
+                "months_lockup": "1",
+                "factor": "0.100000000000000000"
+              },
+              {
+                "name": "large",
+                "months_lockup": "12",
+                "factor": "1.000000000000000000"
+              }
+            ]
+          }
+        ],
+        "claim_end": "2025-01-01T00:00:00Z"
+      },
+      "usdx_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "bnb-a",
+            "previous_accumulation_time": "2021-06-10T16:43:11.679705Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "bnb-a",
+            "reward_indexes": [
+              {
+                "collateral_type": "ukava",
+                "reward_factor": "0.043949244534927716"
+              }
+            ]
+          }
+        ]
+      },
+      "hard_supply_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "bnb",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          },
+          {
+            "collateral_type": "hard",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "bnb",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "32.458112657412585027"
+              }
+            ]
+          },
+          {
+            "collateral_type": "hard",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "35.000000000000000000"
+              }
+            ]
+          }
+        ]
+      },
+      "hard_borrow_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "btcb",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "btcb",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "88.582200355378048199"
+              }
+            ]
+          }
+        ]
+      },
+      "delegator_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "ukava",
+            "previous_accumulation_time": "2021-11-05T21:13:12.856088470Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "ukava",
+            "reward_indexes": [
+              {
+                "collateral_type": "hard",
+                "reward_factor": "0.078380843036861815"
+              },
+              {
+                "collateral_type": "swp",
+                "reward_factor": "0.013629025935176301"
+              }
+            ]
+          }
+        ]
+      },
+      "swap_reward_state": {
+        "accumulation_times": [
+          {
+            "collateral_type": "btcb-a",
+            "previous_accumulation_time": "2021-06-10T16:43:11.679705Z"
+          }
+        ],
+        "multi_reward_indexes": [
+          {
+            "collateral_type": "btcb:usdx",
+            "reward_indexes": [
+              {
+                "collateral_type": "swp",
+                "reward_factor": "6.145396761233172901"
+              }
+            ]
+          }
+        ]
+      },
+      "usdx_minting_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qptt5vu26cmxpmv0hf2tnnmf293x266pjcsjar",
+            "reward": { "denom": "ukava", "amount": "550" }
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "bnb-a",
+              "reward_factor": "0.043949244534927716"
+            },
+            {
+              "collateral_type": "btcb-a",
+              "reward_factor": "0.046551281526135881"
+            }
+          ]
+        }
+      ],
+      "hard_liquidity_provider_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
+            "reward": [{ "denom": "hard", "amount": "1747514" }]
+          },
+          "supply_reward_indexes": [
+            {
+              "collateral_type": "bnb",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "22.000000000000000000"
+                }
+              ]
+            },
+            {
+              "collateral_type": "hard",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "30.000000000000000000"
+                }
+              ]
+            }
+          ],
+          "borrow_reward_indexes": [
+            {
+              "collateral_type": "btc",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "88.582200355378048199"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "base_claim": {
+            "owner": "kava1w2uj6rpejrma47vjx4rcghh3fndhmrvs6pmxph",
+            "reward": [{ "amount": "1747514", "denom": "hard" }]
+          },
+          "borrow_reward_indexes": [],
+          "supply_reward_indexes": []
+        }
+      ],
+      "delegator_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qqqvdyv8w0xdu7gjdtt598q78gtgqyukct4yz2",
+            "reward": []
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "ukava",
+              "reward_indexes": [
+                {
+                  "collateral_type": "hard",
+                  "reward_factor": "0.000000000000000000"
+                },
+                {
+                  "collateral_type": "swp",
+                  "reward_factor": "0.000000100000000000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "swap_claims": [
+        {
+          "base_claim": {
+            "owner": "kava1qzease8mre5adak7wcc2twh6ryh9evnxpr6caj",
+            "reward": [{ "denom": "swp", "amount": "1960368" }]
+          },
+          "reward_indexes": [
+            {
+              "collateral_type": "busd:usdx",
+              "reward_indexes": [
+                {
+                  "collateral_type": "swp",
+                  "reward_factor": "0.018083281889996318"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "issuance": {
+      "params": {
+        "assets": [
+          {
+            "blockable": true,
+            "blocked_addresses": [],
+            "denom": "hbtc",
+            "owner": "kava1dmm9zpdnm6mfhywzt9sstm4p33y0cnsd0m673z",
+            "paused": false,
+            "rate_limit": { "active": false, "limit": "0", "time_period": "0s" }
+          }
+        ]
+      },
+      "supplies": [
+        {
+          "current_supply": { "denom": "ukava", "amount": "100" },
+          "time_elapsed": "3600s"
+        },
+        {
+          "current_supply": { "denom": "bnb", "amount": "300" },
+          "time_elapsed": "300s"
+        }
+      ]
+    },
+    "kavadist": {
+      "params": {
+        "active": true,
+        "periods": [
+          {
+            "end": "2021-06-01T14:00:00Z",
+            "inflation": "1.000000000000000000",
+            "start": "2020-06-01T14:00:00Z"
+          },
+          {
+            "end": "2022-06-01T14:00:00Z",
+            "inflation": "1.000000002293273137",
+            "start": "2021-06-01T14:00:00Z"
+          },
+          {
+            "end": "2023-06-01T14:00:00Z",
+            "inflation": "1.000000001167363430",
+            "start": "2022-06-01T14:00:00Z"
+          },
+          {
+            "end": "2024-06-01T14:00:00Z",
+            "inflation": "1.000000000782997609",
+            "start": "2023-06-01T14:00:00Z"
+          }
+        ]
+      },
+      "previous_block_time": "2021-11-05T21:13:12.856088470Z"
+    },
+    "mint": {
+      "minter": {
+        "inflation": "0.020000000000000000",
+        "annual_provisions": "0.000000000000000000"
+      },
+      "params": {
+        "mint_denom": "ukava",
+        "inflation_rate_change": "0.130000000000000000",
+        "inflation_max": "0.130000000000000000",
+        "inflation_min": "0.010000000000000000",
+        "goal_bonded": "0.670000000000000000",
+        "blocks_per_year": "6311520"
+      }
+    },
+    "params": null,
+    "pricefeed": {
+      "params": {
+        "markets": [
+          {
+            "active": true,
+            "base_asset": "bnb",
+            "market_id": "bnb:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "bnb",
+            "market_id": "bnb:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "atom",
+            "market_id": "atom:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "atom",
+            "market_id": "atom:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "akt",
+            "market_id": "akt:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "akt",
+            "market_id": "akt:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "luna",
+            "market_id": "luna:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "luna",
+            "market_id": "luna:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "osmo",
+            "market_id": "osmo:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "osmo",
+            "market_id": "osmo:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "ust",
+            "market_id": "ust:usd",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          },
+          {
+            "active": true,
+            "base_asset": "ust",
+            "market_id": "ust:usd:30",
+            "oracles": ["kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em"],
+            "quote_asset": "usd"
+          }
+        ]
+      },
+      "posted_prices": [
+        {
+          "expiry": "2022-07-20T00:00:00Z",
+          "market_id": "bnb:usd",
+          "oracle_address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "price": "215.962650000000001782"
+        },
+        {
+          "expiry": "2022-07-20T00:00:00Z",
+          "market_id": "bnb:usd:30",
+          "oracle_address": "kava1acge4tcvhf3q6fh53fgwaa7vsq40wvx6wn50em",
+          "price": "217.962650000000001782"
+        }
+      ]
+    },
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.010000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.000100000000000000"
+      },
+      "signing_infos": [],
+      "missed_blocks": []
+    },
+    "staking": {
+      "params": {
+        "unbonding_time": "3600s",
+        "max_validators": 100,
+        "max_entries": 7,
+        "historical_entries": 10000,
+        "bond_denom": "ukava"
+      },
+      "last_total_power": "0",
+      "last_validator_powers": [],
+      "validators": [],
+      "delegations": [],
+      "unbonding_delegations": [],
+      "redelegations": [],
+      "exported": false
+    },
+    "swap": {
+      "params": {
+        "allowed_pools": [
+          { "token_a": "bnb", "token_b": "usdx" },
+          { "token_a": "btcb", "token_b": "usdx" },
+          { "token_a": "busd", "token_b": "usdx" },
+          { "token_a": "hard", "token_b": "usdx" },
+          { "token_a": "swp", "token_b": "usdx" },
+          { "token_a": "ukava", "token_b": "usdx" },
+          { "token_a": "usdx", "token_b": "xrpb" }
+        ],
+        "swap_fee": "0.001500000000000000"
+      },
+      "pool_records": [
+        {
+          "pool_id": "ukava:usdx",
+          "reserves_a": { "amount": "583616549439", "denom": "ukava" },
+          "reserves_b": { "amount": "3431399443511", "denom": "usdx" },
+          "total_shares": "1398497336200"
+        },
+        {
+          "pool_id": "usdx:xrpb",
+          "reserves_a": { "amount": "843639517257", "denom": "usdx" },
+          "reserves_b": { "amount": "72251274276145", "denom": "xrpb" },
+          "total_shares": "7739661881008"
+        }
+      ],
+      "share_records": [
+        {
+          "depositor": "kava1l77xymdt2ya0rl2mludkny5aqmr67u88ymgdje",
+          "pool_id": "usdx:xrpb",
+          "shares_owned": "29034728969"
+        },
+        {
+          "depositor": "kava1llqkrdr69wc76cuxpx6j06x9pt63f52f7mlcye",
+          "pool_id": "busd:usdx",
+          "shares_owned": "24905307583"
+        },
+        {
+          "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
+          "pool_id": "hard:usdx",
+          "shares_owned": "708138421"
+        },
+        {
+          "depositor": "kava1ll3ndyv333aet6mzqltu5wdepqhyme8umv34es",
+          "pool_id": "ukava:usdx",
+          "shares_owned": "3427014047"
+        }
+      ]
+    },
+    "transfer": {
+      "denom_traces": [],
+      "params": { "receive_enabled": true, "send_enabled": true },
+      "port_id": "transfer"
+    },
+    "upgrade": {}
+  }
+}


### PR DESCRIPTION
- Sets up our migrate cmd to now migrate from v16 to v17
- Add v16 -> v17 migrate function and add migration logic for `evm` and `evmutil`
- Tests for migrating a whole genesis file + tests for validating the migrated gen state for all modified modules.

Notes:
- evm param uses the default values expect for the evm denom, which needs to be `akava`.