### PR TITLE
x/authz migration

### DIFF
--- a/migrate/v0_17/kava.go
+++ b/migrate/v0_17/kava.go
@@ -3,6 +3,7 @@ package v0_17
 import (
 	"github.com/cosmos/cosmos-sdk/client"
 
+	authz "github.com/cosmos/cosmos-sdk/x/authz"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 	feemarkettypes "github.com/tharsis/ethermint/x/feemarket/types"
@@ -33,4 +34,8 @@ func migrateAppState(appState genutiltypes.AppMap, clientCtx client.Context) {
 	// x/feemarket
 	feemarketState := feemarkettypes.DefaultGenesisState()
 	appState[feemarkettypes.ModuleName] = codec.MustMarshalJSON(feemarketState)
+
+	// x/authz
+	authzState := authz.DefaultGenesisState()
+	appState[authz.ModuleName] = codec.MustMarshalJSON(authzState)
 }

--- a/migrate/v0_17/migrate_test.go
+++ b/migrate/v0_17/migrate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	authz "github.com/cosmos/cosmos-sdk/x/authz"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -33,7 +34,7 @@ func TestMigrateGenesisDoc(t *testing.T) {
 }
 
 func TestMigrateEvmUtil(t *testing.T) {
-	appMap, ctx := migrateToV16AndGetAppMap(t)
+	appMap, ctx := migrateToV17AndGetAppMap(t)
 	var genstate evmutiltypes.GenesisState
 	err := ctx.Codec.UnmarshalJSON(appMap[evmutiltypes.ModuleName], &genstate)
 	assert.NoError(t, err)
@@ -41,7 +42,7 @@ func TestMigrateEvmUtil(t *testing.T) {
 }
 
 func TestMigrateEvm(t *testing.T) {
-	appMap, ctx := migrateToV16AndGetAppMap(t)
+	appMap, ctx := migrateToV17AndGetAppMap(t)
 	var genstate evmtypes.GenesisState
 	err := ctx.Codec.UnmarshalJSON(appMap[evmtypes.ModuleName], &genstate)
 	assert.NoError(t, err)
@@ -56,14 +57,24 @@ func TestMigrateEvm(t *testing.T) {
 }
 
 func TestMigrateFeeMarket(t *testing.T) {
-	appMap, ctx := migrateToV16AndGetAppMap(t)
+	appMap, ctx := migrateToV17AndGetAppMap(t)
 	var genstate feemarkettypes.GenesisState
 	err := ctx.Codec.UnmarshalJSON(appMap[feemarkettypes.ModuleName], &genstate)
 	assert.NoError(t, err)
 	assert.Equal(t, genstate, *feemarkettypes.DefaultGenesisState())
 }
 
-func migrateToV16AndGetAppMap(t *testing.T) (genutiltypes.AppMap, client.Context) {
+func TestMigrateAuthz(t *testing.T) {
+	appMap, ctx := migrateToV17AndGetAppMap(t)
+	var genstate authz.GenesisState
+	err := ctx.Codec.UnmarshalJSON(appMap[authz.ModuleName], &genstate)
+	assert.NoError(t, err)
+	assert.Equal(t, genstate, authz.GenesisState{
+		Authorization: []authz.GrantAuthorization{},
+	})
+}
+
+func migrateToV17AndGetAppMap(t *testing.T) (genutiltypes.AppMap, client.Context) {
 	genDoc, err := tmtypes.GenesisDocFromFile(filepath.Join("testdata", "genesis-v16.json"))
 	assert.NoError(t, err)
 

--- a/migrate/v0_17/testdata/genesis-v17.json
+++ b/migrate/v0_17/testdata/genesis-v17.json
@@ -2219,6 +2219,9 @@
         "base_fee": "1000000000"
       },
       "block_gas": "0"
+    },
+    "authz": {
+      "authorization": []
     }
   }
 }


### PR DESCRIPTION
- v17 authz migration with default state
- removed the go.mod file in the migrations folder
- added a go.mod file for v16 migrations to silence errors. I didn't just remove that folder since it will create a bunch of extra changes and we already removed it in a separate pr https://github.com/Kava-Labs/kava/pull/1216