### PR TITLE
evmutil invariant fix

### DIFF
--- a/x/evmutil/keeper/invariants_test.go
+++ b/x/evmutil/keeper/invariants_test.go
@@ -87,11 +87,11 @@ func (suite *invariantTestSuite) TestFullyBackedInvariant() {
 	_, broken = suite.runInvariant("fully-backed", keeper.FullyBackedInvariant)
 	suite.Equal(false, broken)
 
-	// break invariant by decreasing minor balances without decreasing module balance
-	suite.Keeper.RemoveBalance(suite.Ctx, suite.Addrs[0], sdk.OneInt())
+	// break invariant by increasing total minor balances above module balance
+	suite.Keeper.AddBalance(suite.Ctx, suite.Addrs[0], sdk.OneInt())
 
 	message, broken := suite.runInvariant("fully-backed", keeper.FullyBackedInvariant)
-	suite.Equal("evmutil: fully backed broken invariant\nminor balances do not match module account\n", message)
+	suite.Equal("evmutil: fully backed broken invariant\nsum of minor balances greater than module account\n", message)
 	suite.Equal(true, broken)
 }
 


### PR DESCRIPTION
There is an edge case where kava can be burned by the evm.
This could break the invariant that ensures all akava is exactly backed by ukava in the evmutil module balance.

This PR changes the invariant to check all minor balances ≤ module balance.