### PR TITLE
feat: add evm-alpha testnet migrations for new modules

### DIFF
--- a/x/auction/keeper/migrations.go
+++ b/x/auction/keeper/migrations.go
@@ -1,0 +1,23 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v017 "github.com/kava-labs/kava/x/auction/migrations/v017"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator returns a new Migrator.
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{
+		keeper: keeper,
+	}
+}
+
+// Migrate1to2 migrates from version 1 to 2.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v017.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc, m.keeper.paramSubspace)
+}

--- a/x/auction/migrations/v017/store.go
+++ b/x/auction/migrations/v017/store.go
@@ -16,8 +16,6 @@ func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.Binar
 }
 
 func migrateParamsStore(ctx sdk.Context, paramstore paramtypes.Subspace) {
-	paramstore.WithKeyTable(types.ParamKeyTable())
 	paramstore.Set(ctx, types.KeyForwardBidDuration, types.DefaultForwardBidDuration)
 	paramstore.Set(ctx, types.KeyReverseBidDuration, types.DefaultReverseBidDuration)
-
 }

--- a/x/auction/migrations/v017/store.go
+++ b/x/auction/migrations/v017/store.go
@@ -1,0 +1,23 @@
+package v017
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/kava-labs/kava/x/auction/types"
+)
+
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec, paramstore paramtypes.Subspace) error {
+	migrateParamsStore(ctx, paramstore)
+
+	return nil
+}
+
+func migrateParamsStore(ctx sdk.Context, paramstore paramtypes.Subspace) {
+	paramstore.WithKeyTable(types.ParamKeyTable())
+	paramstore.Set(ctx, types.KeyForwardBidDuration, types.DefaultForwardBidDuration)
+	paramstore.Set(ctx, types.KeyReverseBidDuration, types.DefaultReverseBidDuration)
+
+}

--- a/x/auction/module.go
+++ b/x/auction/module.go
@@ -127,13 +127,16 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 {
-	return 1
+	return 2
 }
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper))
+
+	m := keeper.NewMigrator(am.keeper)
+	cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
 }
 
 // InitGenesis module init-genesis

--- a/x/incentive/keeper/migrations.go
+++ b/x/incentive/keeper/migrations.go
@@ -1,0 +1,23 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v017 "github.com/kava-labs/kava/x/incentive/migrations/v017"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator returns a new Migrator.
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{
+		keeper: keeper,
+	}
+}
+
+// Migrate1to2 migrates from version 1 to 2.x
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v017.MigrateStore(ctx, m.keeper.key, m.keeper.cdc, m.keeper.paramSubspace)
+}

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -131,6 +131,14 @@ func (subspace *fakeParamSubspace) WithKeyTable(paramtypes.KeyTable) paramtypes.
 	return paramtypes.Subspace{}
 }
 
+func (subspace *fakeParamSubspace) Get(ctx sdk.Context, key []byte, ptr interface{}) {
+
+}
+
+func (subspace *fakeParamSubspace) Set(ctx sdk.Context, key []byte, param interface{}) {
+
+}
+
 // fakeSwapKeeper is a stub swap keeper.
 // It can be used to return values to the incentive keeper without having to initialize a full swap keeper.
 type fakeSwapKeeper struct {

--- a/x/incentive/migrations/v017/store.go
+++ b/x/incentive/migrations/v017/store.go
@@ -4,18 +4,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
-func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec, paramstore paramtypes.Subspace) error {
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec, paramstore types.ParamSubspace) error {
 	migrateParamsStore(ctx, paramstore)
 
 	return nil
 }
 
-func migrateParamsStore(ctx sdk.Context, paramstore paramtypes.Subspace) {
-	paramstore.WithKeyTable(types.ParamKeyTable())
+func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 	paramstore.Set(ctx, types.KeySavingsRewardPeriods, types.DefaultMultiRewardPeriods)
 }

--- a/x/incentive/migrations/v017/store.go
+++ b/x/incentive/migrations/v017/store.go
@@ -1,0 +1,21 @@
+package v017
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec, paramstore paramtypes.Subspace) error {
+	migrateParamsStore(ctx, paramstore)
+
+	return nil
+}
+
+func migrateParamsStore(ctx sdk.Context, paramstore paramtypes.Subspace) {
+	paramstore.WithKeyTable(types.ParamKeyTable())
+	paramstore.Set(ctx, types.KeySavingsRewardPeriods, types.DefaultMultiRewardPeriods)
+}

--- a/x/incentive/module.go
+++ b/x/incentive/module.go
@@ -81,7 +81,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 {
-	return 1
+	return 2
 }
 
 // GetTxCmd returns the root tx command for the incentive module.
@@ -136,7 +136,11 @@ func (AppModule) QuerierRoute() string {
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	// TODO: types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
+
+	// types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
+
+	m := keeper.NewMigrator(am.keeper)
+	cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2)
 }
 
 // InitGenesis performs genesis initialization for the incentive module. It returns no validator updates.

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -14,6 +14,8 @@ import (
 type ParamSubspace interface {
 	GetParamSet(sdk.Context, paramtypes.ParamSet)
 	SetParamSet(sdk.Context, paramtypes.ParamSet)
+	Get(ctx sdk.Context, key []byte, ptr interface{})
+	Set(ctx sdk.Context, key []byte, param interface{})
 	WithKeyTable(paramtypes.KeyTable) paramtypes.Subspace
 	HasKeyTable() bool
 }


### PR DESCRIPTION
Modules added

* savings
* bridge
* authz

Note I'm merging into `kd-v0.17.0-alpha.3`, as these migrations are only needed for testnet and shouldn't be included in `master` branch. `kd-v0.17.0-alpha.3` is tagged from the current `v0.17.0-alpha.3` release