### PR TITLE
Update incorrect init-new-chain address

### DIFF
--- a/contrib/devnet/init-new-chain.sh
+++ b/contrib/devnet/init-new-chain.sh
@@ -2,10 +2,10 @@
 set -e
 
 validatorMnemonic="equip town gesture square tomorrow volume nephew minute witness beef rich gadget actress egg sing secret pole winter alarm law today check violin uncover"
-# kava1ak4pa9z2aty94ze2cs06wsdnkg9hsvfkp40r02
+# kava1ffv7nhd3z6sych2qpqkk03ec6hzkmufy0r2s4c
 
 faucetMnemonic="crash sort dwarf disease change advice attract clump avoid mobile clump right junior axis book fresh mask tube front require until face effort vault"
-# kava123fxg0l602etulhhcdm0vt7l57qya5wjcrwhzz
+# kava1adkm6svtzjsxxvg7g6rshg6kj9qwej8gwqadqd
 
 evmFaucetMnemonic="hundred flash cattle inquiry gorilla quick enact lazy galaxy apple bitter liberty print sun hurdle oak town cash because round chalk marriage response success"
 # 0x3C854F92F726A7897C8B23F55B2D6E2C482EF3E0


### PR DESCRIPTION
Previous addresses were for keys generate using the --eth flag. This update it to reflect the current behaviour.