### PR TITLE
Use base account for new accounts.

### DIFF
--- a/app/accounts.go
+++ b/app/accounts.go
@@ -4,8 +4,8 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	ethermint "github.com/tharsis/ethermint/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 )
 
 var _ authkeeper.ProtoAccountConstructor = newProtoAccount
@@ -13,11 +13,9 @@ var _ authkeeper.ProtoAccountConstructor = newProtoAccount
 func newProtoAccount(currentBlockheight int64) authtypes.AccountI {
 	if currentBlockheight < FixDefaultAccountUpgradeHeight {
 
-		emptyCodeHash := crypto.Keccak256(nil)
-
 		return &ethermint.EthAccount{
 			BaseAccount: &authtypes.BaseAccount{},
-			CodeHash:    common.BytesToHash(emptyCodeHash).String(),
+			CodeHash:    common.BytesToHash(evmtypes.EmptyCodeHash).String(),
 		}
 	}
 	return &authtypes.BaseAccount{}

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -29,6 +29,7 @@ type HandlerOptions struct {
 	FeeMarketKeeper evmtypes.FeeMarketKeeper
 	MaxTxGasWanted  uint64
 	AddressFetchers []AddressFetcher
+	UpgradeHeight   int64
 }
 
 func (options HandlerOptions) Validate() error {
@@ -119,7 +120,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		authante.NewValidateSigCountDecorator(options.AccountKeeper),
 		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
-		NewConvertEthAccounts(options.AccountKeeper),                  // TODO only activate after upgrade height
+		ActivateAfter(NewConvertEthAccounts(options.AccountKeeper), options.UpgradeHeight),
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper), // innermost AnteDecorator
 		ibcante.NewAnteDecorator(options.IBCKeeper),
 	)

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -119,6 +119,7 @@ func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		authante.NewValidateSigCountDecorator(options.AccountKeeper),
 		authante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		authante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		NewConvertEthAccounts(options.AccountKeeper),                  // TODO only activate after upgrade height
 		authante.NewIncrementSequenceDecorator(options.AccountKeeper), // innermost AnteDecorator
 		ibcante.NewAnteDecorator(options.IBCKeeper),
 	)

--- a/app/ante/authorized_test.go
+++ b/app/ante/authorized_test.go
@@ -25,6 +25,19 @@ func (mah *MockAnteHandler) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 	return ctx, nil
 }
 
+var _ sdk.AnteDecorator = &MockAnteDecorator{}
+
+type MockAnteDecorator struct {
+	WasCalled bool
+	CalledCtx sdk.Context
+}
+
+func (mad *MockAnteDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	mad.WasCalled = true
+	mad.CalledCtx = ctx
+	return next(ctx, tx, simulate)
+}
+
 func mockAddressFetcher(addresses ...sdk.AccAddress) ante.AddressFetcher {
 	return func(sdk.Context) []sdk.AccAddress { return addresses }
 }

--- a/app/ante/authz.go
+++ b/app/ante/authz.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
+var _ sdk.AnteDecorator = AuthzLimiterDecorator{}
+
 // AuthzLimiterDecorator blocks certain msg types from being granted or executed within authz.
 type AuthzLimiterDecorator struct {
 	// disabledMsgTypes is the type urls of the msgs to block.

--- a/app/ante/convert_account.go
+++ b/app/ante/convert_account.go
@@ -15,6 +15,8 @@ type AccountKeeper interface {
 	authante.AccountKeeper
 }
 
+var _ sdk.AnteDecorator = ConvertEthAccounts{}
+
 // ConvertEthAccounts converts non contract eth accounts to base accounts, and calls the next ante handle with an updated context.
 // This should run after signature verification to ensure only owners can convert accounts.
 type ConvertEthAccounts struct {

--- a/app/ante/convert_account.go
+++ b/app/ante/convert_account.go
@@ -30,6 +30,10 @@ func NewConvertEthAccounts(ak AccountKeeper) ConvertEthAccounts {
 }
 
 func (cea ConvertEthAccounts) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if ctx.IsCheckTx() || ctx.IsReCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")

--- a/app/ante/convert_account.go
+++ b/app/ante/convert_account.go
@@ -12,10 +12,11 @@ import (
 )
 
 type AccountKeeper interface {
-	authante.AccountKeeper // TODO inline?
+	authante.AccountKeeper
 }
 
-// ConvertEthAccounts converts non contract eth accounts to base accounts, and calls the next ante handle with an updated context
+// ConvertEthAccounts converts non contract eth accounts to base accounts, and calls the next ante handle with an updated context.
+// This should run after signature verification to ensure only owners can convert accounts.
 type ConvertEthAccounts struct {
 	ak AccountKeeper
 }
@@ -31,13 +32,8 @@ func (cea ConvertEthAccounts) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	if !ok {
 		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
 	}
-	pubkeys, err := sigTx.GetPubKeys() // TODO is this needed?
-	if err != nil {
-		return ctx, err
-	}
 	signers := sigTx.GetSigners()
-
-	for i := range pubkeys {
+	for i := range signers {
 		if err := convertAccount(ctx, cea.ak, signers[i]); err != nil {
 			return ctx, err
 		}

--- a/app/ante/convert_account.go
+++ b/app/ante/convert_account.go
@@ -1,0 +1,62 @@
+package ante
+
+import (
+	"bytes"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	ethermint "github.com/tharsis/ethermint/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
+)
+
+type AccountKeeper interface {
+	authante.AccountKeeper // TODO inline?
+}
+
+// ConvertEthAccounts converts non contract eth accounts to base accounts, and calls the next ante handle with an updated context
+type ConvertEthAccounts struct {
+	ak AccountKeeper
+}
+
+func NewConvertEthAccounts(ak AccountKeeper) ConvertEthAccounts {
+	return ConvertEthAccounts{
+		ak: ak,
+	}
+}
+
+func (cea ConvertEthAccounts) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+	pubkeys, err := sigTx.GetPubKeys() // TODO is this needed?
+	if err != nil {
+		return ctx, err
+	}
+	signers := sigTx.GetSigners()
+
+	for i := range pubkeys {
+		if err := convertAccount(ctx, cea.ak, signers[i]); err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func convertAccount(ctx sdk.Context, ak AccountKeeper, address sdk.AccAddress) error {
+	acc, err := authante.GetSignerAcc(ctx, ak, address)
+	if err != nil {
+		return err
+	}
+	ethAcc, isEthAcc := acc.(*ethermint.EthAccount)
+	if isEthAcc {
+		isNotContract := bytes.Equal(ethAcc.GetCodeHash().Bytes(), evmtypes.EmptyCodeHash)
+		if isNotContract {
+			ak.SetAccount(ctx, ethAcc.BaseAccount)
+		}
+	}
+	return nil
+}

--- a/app/ante/convert_account_test.go
+++ b/app/ante/convert_account_test.go
@@ -1,0 +1,185 @@
+package ante_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/simapp/helpers"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	ethermint "github.com/tharsis/ethermint/types"
+	evmtypes "github.com/tharsis/ethermint/x/evm/types"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/app/ante"
+)
+
+func TestConvertEthAccounts(t *testing.T) {
+	chainID := "kavatest_1-1"
+	testPrivKeys, testAddresses := app.GeneratePrivKeyAddressPairs(5)
+	encodingConfig := app.MakeEncodingConfig()
+
+	testCases := []struct {
+		name            string
+		account         authtypes.GenesisAccount
+		tx              sdk.Tx
+		expectedErr     error
+		expectedAccount authtypes.GenesisAccount
+	}{
+		{
+			name:    "missing account fails antehandler, does not create an account",
+			account: nil,
+			tx: mustGenTx(
+				encodingConfig.TxConfig,
+				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
+				sdk.NewCoins(), // no fee
+				helpers.DefaultGenTxGas,
+				chainID,
+				[]uint64{0},
+				[]uint64{0},
+				testPrivKeys[0],
+			),
+			expectedErr:     sdkerrors.ErrUnknownAddress,
+			expectedAccount: nil,
+		},
+		{
+			name: "base account is left unchanged",
+			account: authtypes.NewBaseAccount(
+				testAddresses[0],
+				nil, // no pubkey set
+				0,
+				0,
+			),
+			tx: mustGenTx(
+				encodingConfig.TxConfig,
+				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
+				sdk.NewCoins(), // no fee
+				helpers.DefaultGenTxGas,
+				chainID,
+				[]uint64{0},
+				[]uint64{0},
+				testPrivKeys[0],
+			),
+			expectedErr: nil,
+			expectedAccount: authtypes.NewBaseAccount(
+				testAddresses[0],
+				nil, // no pubkey set
+				0,
+				0,
+			),
+		},
+		{
+			name: "eth account is converted to base account",
+			account: &ethermint.EthAccount{
+				BaseAccount: authtypes.NewBaseAccount(
+					testAddresses[0],
+					nil, // no pubkey set
+					0,
+					0,
+				),
+				CodeHash: common.BytesToHash(evmtypes.EmptyCodeHash).String(), // code hash includes 0x prefix
+			},
+			tx: mustGenTx(
+				encodingConfig.TxConfig,
+				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
+				sdk.NewCoins(), // no fee
+				helpers.DefaultGenTxGas,
+				chainID,
+				[]uint64{0},
+				[]uint64{0},
+				testPrivKeys[0],
+			),
+			expectedErr: nil,
+			expectedAccount: authtypes.NewBaseAccount(
+				testAddresses[0],
+				nil, // no pubkey set
+				0,
+				0,
+			),
+		},
+		{
+			name: "contract eth account is left unchanged",
+			// This test case isn't super important as it's impossible to create a valid signature from a contract account, so the tx would never reach this antehandler.
+			account: &ethermint.EthAccount{
+				BaseAccount: authtypes.NewBaseAccount(
+					testAddresses[0],
+					nil, // no pubkey set
+					0,
+					0,
+				),
+				CodeHash: "0x6cba8c69b5f9084d8eefd5dd7cf71ed5469f5bbb9d8446533ebe4beccdfb3ce9",
+			},
+			tx: mustGenTx(
+				encodingConfig.TxConfig,
+				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
+				sdk.NewCoins(), // no fee
+				helpers.DefaultGenTxGas,
+				chainID,
+				[]uint64{0},
+				[]uint64{0},
+				testPrivKeys[0],
+			),
+			expectedErr: nil,
+			expectedAccount: &ethermint.EthAccount{
+				BaseAccount: authtypes.NewBaseAccount(
+					testAddresses[0],
+					nil, // no pubkey set
+					0,
+					0,
+				),
+				CodeHash: "0x6cba8c69b5f9084d8eefd5dd7cf71ed5469f5bbb9d8446533ebe4beccdfb3ce9",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tApp := app.NewTestApp()
+
+			authGenState := app.NewAuthBankGenesisBuilder()
+			if tc.account != nil {
+				authGenState = authGenState.WithAccounts(tc.account)
+			}
+
+			tApp = tApp.InitializeFromGenesisStatesWithTimeAndChainID(
+				time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC),
+				chainID,
+				authGenState.BuildMarshalled(encodingConfig.Marshaler),
+			)
+
+			handler := ante.NewConvertEthAccounts(tApp.GetAccountKeeper())
+
+			mmd := MockAnteHandler{}
+
+			ctx := tApp.NewContext(true, tmproto.Header{Height: 1})
+
+			_, err := handler.AnteHandle(ctx, tc.tx, false, mmd.AnteHandle)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+				require.False(t, mmd.WasCalled)
+			} else {
+				require.NoError(t, err)
+				require.True(t, mmd.WasCalled)
+			}
+
+			actualAcc := tApp.GetAccountKeeper().GetAccount(ctx, testAddresses[0])
+			require.Equal(t, tc.expectedAccount, actualAcc)
+		})
+	}
+}
+
+func mustGenTx(gen client.TxConfig, msgs []sdk.Msg, feeAmt sdk.Coins, gas uint64, chainID string, accNums, accSeqs []uint64, priv ...cryptotypes.PrivKey) sdk.Tx {
+	tx, err := helpers.GenTx(gen, msgs, feeAmt, gas, chainID, accNums, accSeqs, priv...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to generate tx: %v", err))
+	}
+	return tx
+}

--- a/app/ante/convert_account_test.go
+++ b/app/ante/convert_account_test.go
@@ -159,7 +159,7 @@ func TestConvertEthAccounts(t *testing.T) {
 
 			mmd := MockAnteHandler{}
 
-			ctx := tApp.NewContext(true, tmproto.Header{Height: 1})
+			ctx := tApp.NewContext(false, tmproto.Header{Height: 1})
 
 			_, err := handler.AnteHandle(ctx, tc.tx, false, mmd.AnteHandle)
 			if tc.expectedErr != nil {

--- a/app/ante/convert_account_test.go
+++ b/app/ante/convert_account_test.go
@@ -40,7 +40,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			tx: mustGenTx(
 				encodingConfig.TxConfig,
 				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
-				sdk.NewCoins(), // no fee
+				sdk.NewCoins(),
 				helpers.DefaultGenTxGas,
 				chainID,
 				[]uint64{0},
@@ -54,14 +54,14 @@ func TestConvertEthAccounts(t *testing.T) {
 			name: "base account is left unchanged",
 			account: authtypes.NewBaseAccount(
 				testAddresses[0],
-				nil, // no pubkey set
+				nil,
 				0,
 				0,
 			),
 			tx: mustGenTx(
 				encodingConfig.TxConfig,
 				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
-				sdk.NewCoins(), // no fee
+				sdk.NewCoins(),
 				helpers.DefaultGenTxGas,
 				chainID,
 				[]uint64{0},
@@ -71,7 +71,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			expectedErr: nil,
 			expectedAccount: authtypes.NewBaseAccount(
 				testAddresses[0],
-				nil, // no pubkey set
+				nil,
 				0,
 				0,
 			),
@@ -81,7 +81,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			account: &ethermint.EthAccount{
 				BaseAccount: authtypes.NewBaseAccount(
 					testAddresses[0],
-					nil, // no pubkey set
+					nil,
 					0,
 					0,
 				),
@@ -90,7 +90,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			tx: mustGenTx(
 				encodingConfig.TxConfig,
 				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
-				sdk.NewCoins(), // no fee
+				sdk.NewCoins(),
 				helpers.DefaultGenTxGas,
 				chainID,
 				[]uint64{0},
@@ -100,18 +100,17 @@ func TestConvertEthAccounts(t *testing.T) {
 			expectedErr: nil,
 			expectedAccount: authtypes.NewBaseAccount(
 				testAddresses[0],
-				nil, // no pubkey set
+				nil,
 				0,
 				0,
 			),
 		},
 		{
 			name: "contract eth account is left unchanged",
-			// This test case isn't super important as it's impossible to create a valid signature from a contract account, so the tx would never reach this antehandler.
 			account: &ethermint.EthAccount{
 				BaseAccount: authtypes.NewBaseAccount(
 					testAddresses[0],
-					nil, // no pubkey set
+					nil,
 					0,
 					0,
 				),
@@ -120,7 +119,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			tx: mustGenTx(
 				encodingConfig.TxConfig,
 				[]sdk.Msg{banktypes.NewMsgSend(testAddresses[0], testAddresses[1], sdk.NewCoins(sdk.NewInt64Coin("ukava", 1)))},
-				sdk.NewCoins(), // no fee
+				sdk.NewCoins(),
 				helpers.DefaultGenTxGas,
 				chainID,
 				[]uint64{0},
@@ -131,7 +130,7 @@ func TestConvertEthAccounts(t *testing.T) {
 			expectedAccount: &ethermint.EthAccount{
 				BaseAccount: authtypes.NewBaseAccount(
 					testAddresses[0],
-					nil, // no pubkey set
+					nil,
 					0,
 					0,
 				),
@@ -157,17 +156,17 @@ func TestConvertEthAccounts(t *testing.T) {
 
 			handler := ante.NewConvertEthAccounts(tApp.GetAccountKeeper())
 
-			mmd := MockAnteHandler{}
+			mah := MockAnteHandler{}
 
 			ctx := tApp.NewContext(false, tmproto.Header{Height: 1})
 
-			_, err := handler.AnteHandle(ctx, tc.tx, false, mmd.AnteHandle)
+			_, err := handler.AnteHandle(ctx, tc.tx, false, mah.AnteHandle)
 			if tc.expectedErr != nil {
 				require.ErrorIs(t, err, tc.expectedErr)
-				require.False(t, mmd.WasCalled)
+				require.False(t, mah.WasCalled)
 			} else {
 				require.NoError(t, err)
-				require.True(t, mmd.WasCalled)
+				require.True(t, mah.WasCalled)
 			}
 
 			actualAcc := tApp.GetAccountKeeper().GetAccount(ctx, testAddresses[0])

--- a/app/ante/upgrade.go
+++ b/app/ante/upgrade.go
@@ -6,6 +6,8 @@ import (
 
 var _ sdk.AnteDecorator = ActivateAfterDecorator{}
 
+// ActivateAfterDecorator wraps a ante decorator, disabling it before a block height.
+// It can be used to modify the antehandler in asynchronous chain upgrades.
 type ActivateAfterDecorator struct {
 	WrappedDecorator sdk.AnteDecorator
 	upgradeHeight    int64

--- a/app/ante/upgrade.go
+++ b/app/ante/upgrade.go
@@ -1,0 +1,26 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ sdk.AnteDecorator = ActivateAfterDecorator{}
+
+type ActivateAfterDecorator struct {
+	WrappedDecorator sdk.AnteDecorator
+	upgradeHeight    int64
+}
+
+func ActivateAfter(decorator sdk.AnteDecorator, upgradeHeight int64) ActivateAfterDecorator {
+	return ActivateAfterDecorator{
+		WrappedDecorator: decorator,
+		upgradeHeight:    upgradeHeight,
+	}
+}
+
+func (aad ActivateAfterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if ctx.BlockHeight() >= aad.upgradeHeight {
+		return aad.WrappedDecorator.AnteHandle(ctx, tx, simulate, next)
+	}
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/upgrade_test.go
+++ b/app/ante/upgrade_test.go
@@ -1,0 +1,57 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmtime "github.com/tendermint/tendermint/types/time"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/app/ante"
+)
+
+func TestActivateAfterDecorator_AnteHandle(t *testing.T) {
+
+	tApp := app.NewTestApp()
+	var upgradeHeight int64 = 1000
+
+	testCases := []struct {
+		name   string
+		height int64
+	}{
+		{
+			name:   "zero height",
+			height: 0,
+		},
+		{
+			name:   "before upgrade height wrapped decorator doesn't run",
+			height: upgradeHeight - 1,
+		},
+		{
+			name:   "at upgrade height wrapped decorator runs",
+			height: upgradeHeight,
+		},
+		{
+			name:   "after upgrade height wrapped decorator runs",
+			height: upgradeHeight + 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrappedDecorator := &MockAnteDecorator{}
+			decorator := ante.ActivateAfter(wrappedDecorator, upgradeHeight)
+			mmd := MockAnteHandler{}
+
+			ctx := tApp.NewContext(true, tmproto.Header{Height: tc.height, Time: tmtime.Now()})
+
+			_, err := decorator.AnteHandle(ctx, nil, false, mmd.AnteHandle)
+			require.NoError(t, err)
+
+			require.True(t, mmd.WasCalled)
+			shouldHaveRan := tc.height >= upgradeHeight
+			require.Equal(t, shouldHaveRan, wrappedDecorator.WasCalled)
+		})
+	}
+}

--- a/app/ante/upgrade_test.go
+++ b/app/ante/upgrade_test.go
@@ -3,17 +3,14 @@ package ante_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	tmtime "github.com/tendermint/tendermint/types/time"
 
-	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/app/ante"
 )
 
 func TestActivateAfterDecorator_AnteHandle(t *testing.T) {
 
-	tApp := app.NewTestApp()
 	var upgradeHeight int64 = 1000
 
 	testCases := []struct {
@@ -42,14 +39,14 @@ func TestActivateAfterDecorator_AnteHandle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			wrappedDecorator := &MockAnteDecorator{}
 			decorator := ante.ActivateAfter(wrappedDecorator, upgradeHeight)
-			mmd := MockAnteHandler{}
+			mah := MockAnteHandler{}
 
-			ctx := tApp.NewContext(true, tmproto.Header{Height: tc.height, Time: tmtime.Now()})
+			ctx := sdk.Context{}.WithBlockHeight(tc.height)
 
-			_, err := decorator.AnteHandle(ctx, nil, false, mmd.AnteHandle)
+			_, err := decorator.AnteHandle(ctx, nil, false, mah.AnteHandle)
 			require.NoError(t, err)
 
-			require.True(t, mmd.WasCalled)
+			require.True(t, mah.WasCalled)
 			shouldHaveRan := tc.height >= upgradeHeight
 			require.Equal(t, shouldHaveRan, wrappedDecorator.WasCalled)
 		})

--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -6,6 +6,8 @@ import (
 	vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
+var _ sdk.AnteDecorator = VestingAccountDecorator{}
+
 // VestingAccountDecorator blocks MsgCreateVestingAccount from reaching the mempool
 type VestingAccountDecorator struct{}
 

--- a/app/app.go
+++ b/app/app.go
@@ -870,6 +870,7 @@ func NewApp(
 		SigGasConsumer:  evmante.DefaultSigVerificationGasConsumer,
 		MaxTxGasWanted:  options.EVMMaxGasWanted,
 		AddressFetchers: fetchers,
+		UpgradeHeight:   FixDefaultAccountUpgradeHeight,
 	}
 
 	antehandler, err := ante.NewAnteHandler(anteOptions)

--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ import (
 
 const (
 	appName                        = "kava"
-	FixDefaultAccountUpgradeHeight = 84000 // TODO
+	FixDefaultAccountUpgradeHeight = 138592
 )
 
 var (

--- a/app/test_common.go
+++ b/app/test_common.go
@@ -167,7 +167,6 @@ func (tApp TestApp) InitializeFromGenesisStatesWithTimeAndChainIDAndHeight(genTi
 			InitialHeight: initialHeight,
 		},
 	)
-	// TODO remove Commit, as tendermint doesn't call it between InitChain and BeginBlock
 	tApp.Commit()
 	tApp.BeginBlock(abci.RequestBeginBlock{
 		Header: tmproto.Header{

--- a/app/test_common.go
+++ b/app/test_common.go
@@ -44,8 +44,9 @@ import (
 )
 
 var (
-	emptyTime   time.Time
-	testChainID = "kavatest_1-1"
+	emptyTime            time.Time
+	testChainID                = "kavatest_1-1"
+	defaultInitialHeight int64 = 1
 )
 
 // TestApp is a simple wrapper around an App. It exposes internal keepers for use in integration tests.
@@ -116,18 +117,27 @@ func (app *App) AppCodec() codec.Codec {
 	return app.appCodec
 }
 
-// InitializeFromGenesisStates calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states
+// InitializeFromGenesisStates calls InitChain on the app using the provided genesis states.
+// If any module genesis states are missing, defaults are used.
 func (tApp TestApp) InitializeFromGenesisStates(genesisStates ...GenesisState) TestApp {
-	return tApp.InitializeFromGenesisStatesWithTimeAndChainID(emptyTime, testChainID, genesisStates...)
+	return tApp.InitializeFromGenesisStatesWithTimeAndChainIDAndHeight(emptyTime, testChainID, defaultInitialHeight, genesisStates...)
 }
 
-// InitializeFromGenesisStatesWithTime calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states and genesis Time
+// InitializeFromGenesisStatesWithTime calls InitChain on the app using the provided genesis states and time.
+// If any module genesis states are missing, defaults are used.
 func (tApp TestApp) InitializeFromGenesisStatesWithTime(genTime time.Time, genesisStates ...GenesisState) TestApp {
-	return tApp.InitializeFromGenesisStatesWithTimeAndChainID(genTime, testChainID, genesisStates...)
+	return tApp.InitializeFromGenesisStatesWithTimeAndChainIDAndHeight(genTime, testChainID, defaultInitialHeight, genesisStates...)
 }
 
-// InitializeFromGenesisStatesWithTimeAndChainID calls InitChain on the app using the default genesis state, overwitten with any passed in genesis states and genesis Time
+// InitializeFromGenesisStatesWithTimeAndChainID calls InitChain on the app using the provided genesis states, time, and chain id.
+// If any module genesis states are missing, defaults are used.
 func (tApp TestApp) InitializeFromGenesisStatesWithTimeAndChainID(genTime time.Time, chainID string, genesisStates ...GenesisState) TestApp {
+	return tApp.InitializeFromGenesisStatesWithTimeAndChainIDAndHeight(genTime, chainID, defaultInitialHeight, genesisStates...)
+}
+
+// InitializeFromGenesisStatesWithTimeAndChainIDAndHeight calls InitChain on the app using the provided genesis states and other parameters.
+// If any module genesis states are missing, defaults are used.
+func (tApp TestApp) InitializeFromGenesisStatesWithTimeAndChainIDAndHeight(genTime time.Time, chainID string, initialHeight int64, genesisStates ...GenesisState) TestApp {
 	// Create a default genesis state and overwrite with provided values
 	genesisState := NewDefaultGenesisState()
 	for _, state := range genesisStates {
@@ -154,8 +164,10 @@ func (tApp TestApp) InitializeFromGenesisStatesWithTimeAndChainID(genTime time.T
 					MaxGas:   20000000,
 				},
 			},
+			InitialHeight: initialHeight,
 		},
 	)
+	// TODO remove Commit, as tendermint doesn't call it between InitChain and BeginBlock
 	tApp.Commit()
 	tApp.BeginBlock(abci.RequestBeginBlock{
 		Header: tmproto.Header{


### PR DESCRIPTION
Current situation: any new accounts are `EthAccount`s
Consequences:
- grpc account queries return `EthAccount`, causing problems for wallets (most expect a base account)
- claiming incentive rewards doesn't work as it doesn't handle `EthAccount`s
- sending cosmos txs is ok, `EthAccount`s can contain normal pubkey types.
- sending evm txs is ok
- contract accounts are fine, they should be EthAccount anyway to hold the code hash.

Intended situtation: any new account should be `BaseAccount`
Consequences:
- grpc account queries return `BaseAccount` as in kava-9
- claiming incentive rewards is ok
- sending cosmos txs is ok, works as in kava-9
- sending eth txs is ok as `BaseAccount`s can hold ethsecp256k1 pubkeys and their corresponding addresses. CodeHash is filled in with emptyHash when the account is loaded from state.
- creating contract accounts is ok as the evm module converts `BaseAccount` to `EthAccount` as needed to store the non empty codehash

How to migrate between these:
- #1260 replaces the default account proto func to return `BaseAccount`s after the upgrade
- But any new account created in kava-10 is an `EthAccount`. If it's a contract account that's good. But user accounts should be `BaseAccount`s for both cosmos and evm users.
- This PR adds an antehandler to convert an `EthAccount` to a `BaseAccount` when someone sends a tx from it. This is only implemented in the cosmos antehandler, but could be added to the evm antehandler if there's time.