### PR TITLE
Redeem derivative tokens for delegation shares

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -221,7 +221,7 @@ var (
 		hardtypes.ModuleAccountName:     {authtypes.Minter},
 		savingstypes.ModuleAccountName:  nil,
 		bridgetypes.ModuleName:          {authtypes.Minter, authtypes.Burner},
-		liquidtypes.ModuleAccountName:   {authtypes.Minter},
+		liquidtypes.ModuleAccountName:   {authtypes.Minter, authtypes.Burner},
 	}
 )
 

--- a/docs/core/proto-docs.md
+++ b/docs/core/proto-docs.md
@@ -343,6 +343,8 @@
     - [Query](#kava.liquid.v1beta1.Query)
   
 - [kava/liquid/v1beta1/tx.proto](#kava/liquid/v1beta1/tx.proto)
+    - [MsgBurnDerivative](#kava.liquid.v1beta1.MsgBurnDerivative)
+    - [MsgBurnDerivativeResponse](#kava.liquid.v1beta1.MsgBurnDerivativeResponse)
     - [MsgMintDerivative](#kava.liquid.v1beta1.MsgMintDerivative)
     - [MsgMintDerivativeResponse](#kava.liquid.v1beta1.MsgMintDerivativeResponse)
   
@@ -4836,6 +4838,38 @@ Query defines the gRPC querier service for liquid module
 
 
 
+<a name="kava.liquid.v1beta1.MsgBurnDerivative"></a>
+
+### MsgBurnDerivative
+MsgBurnDerivative defines the Msg/BurnDerivative request type.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `sender` | [string](#string) |  |  |
+| `validator` | [string](#string) |  |  |
+| `amount` | [cosmos.base.v1beta1.Coin](#cosmos.base.v1beta1.Coin) |  |  |
+
+
+
+
+
+
+<a name="kava.liquid.v1beta1.MsgBurnDerivativeResponse"></a>
+
+### MsgBurnDerivativeResponse
+MsgBurnDerivativeResponse defines the Msg/BurnDerivative response type.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `amount` | [cosmos.base.v1beta1.Coin](#cosmos.base.v1beta1.Coin) |  |  |
+
+
+
+
+
+
 <a name="kava.liquid.v1beta1.MsgMintDerivative"></a>
 
 ### MsgMintDerivative
@@ -4859,6 +4893,11 @@ MsgMintDerivative defines the Msg/MintDerivative request type.
 MsgMintDerivativeResponse defines the Msg/MintDerivative response type.
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `amount` | [cosmos.base.v1beta1.Coin](#cosmos.base.v1beta1.Coin) |  |  |
+
+
 
 
 
@@ -4877,6 +4916,7 @@ Msg defines the liquid Msg service.
 | Method Name | Request Type | Response Type | Description | HTTP Verb | Endpoint |
 | ----------- | ------------ | ------------- | ------------| ------- | -------- |
 | `MintDerivative` | [MsgMintDerivative](#kava.liquid.v1beta1.MsgMintDerivative) | [MsgMintDerivativeResponse](#kava.liquid.v1beta1.MsgMintDerivativeResponse) | MintDerivative defines a method for minting deriviatives | |
+| `BurnDerivative` | [MsgBurnDerivative](#kava.liquid.v1beta1.MsgBurnDerivative) | [MsgBurnDerivativeResponse](#kava.liquid.v1beta1.MsgBurnDerivativeResponse) | BurnDerivative defines a method for burning deriviatives | |
 
  <!-- end services -->
 

--- a/proto/kava/liquid/v1beta1/tx.proto
+++ b/proto/kava/liquid/v1beta1/tx.proto
@@ -12,6 +12,9 @@ service Msg {
 
   // MintDerivative defines a method for minting deriviatives
   rpc MintDerivative(MsgMintDerivative) returns (MsgMintDerivativeResponse);
+
+  // BurnDerivative defines a method for burning deriviatives
+  rpc BurnDerivative(MsgBurnDerivative) returns (MsgBurnDerivativeResponse);
 }
 
 // MsgMintDerivative defines the Msg/MintDerivative request type.
@@ -22,4 +25,18 @@ message MsgMintDerivative {
 }
 
 // MsgMintDerivativeResponse defines the Msg/MintDerivative response type.
-message MsgMintDerivativeResponse {}
+message MsgMintDerivativeResponse {
+  cosmos.base.v1beta1.Coin amount = 1 [(gogoproto.nullable) = false];
+}
+
+// MsgBurnDerivative defines the Msg/BurnDerivative request type.
+message MsgBurnDerivative {
+  string                   sender    = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string                   validator = 2;
+  cosmos.base.v1beta1.Coin amount    = 3 [(gogoproto.nullable) = false];
+}
+
+// MsgBurnDerivativeResponse defines the Msg/BurnDerivative response type.
+message MsgBurnDerivativeResponse {
+  cosmos.base.v1beta1.Coin amount = 1 [(gogoproto.nullable) = false];
+}

--- a/x/liquid/client/cli/tx.go
+++ b/x/liquid/client/cli/tx.go
@@ -27,6 +27,7 @@ func GetTxCmd() *cobra.Command {
 
 	cmds := []*cobra.Command{
 		getCmdMintDerivative(),
+		getCmdBurnDerivative(),
 	}
 
 	for _, cmd := range cmds {
@@ -62,6 +63,38 @@ func getCmdMintDerivative() *cobra.Command {
 			}
 
 			msg := types.NewMsgMintDerivative(clientCtx.GetFromAddress(), valAddr, coin)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
+		},
+	}
+}
+
+func getCmdBurnDerivative() *cobra.Command {
+	return &cobra.Command{
+		Use:   "burn [validator-addr] [amount]",
+		Short: "burn stKava derivative to redeem a delegation",
+		Example: fmt.Sprintf(
+			`%s tx %s burn kavavaloper16lnfpgn6llvn4fstg5nfrljj6aaxyee9z59jqd 10000000ukava --from <key>`, version.AppName, types.ModuleName,
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			valAddr, err := sdk.ValAddressFromBech32(args[0])
+			if err != nil {
+				return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())
+			}
+
+			amount, err := sdk.ParseCoinNormalized(args[1])
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgBurnDerivative(clientCtx.GetFromAddress(), valAddr, amount)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/liquid/keeper/derivative.go
+++ b/x/liquid/keeper/derivative.go
@@ -28,7 +28,7 @@ func (k Keeper) MintDerivative(ctx sdk.Context, delegatorAddr sdk.AccAddress, va
 	}
 
 	delegationAmount := validator.Tokens.ToDec().Mul(delegation.GetShares()).Quo(validator.DelegatorShares)
-	if amount.Amount.GT(sdk.Int(delegationAmount)) {
+	if amount.Amount.ToDec().GT(delegationAmount) {
 		return types.ErrNotEnoughDelegationShares
 	}
 
@@ -145,6 +145,9 @@ func (k Keeper) BurnDerivative(ctx sdk.Context, delegatorAddr sdk.AccAddress, va
 	// (moduleAccountTotalDelegation * redeemAmount) / totalIssue
 	maccAddr := k.accountKeeper.GetModuleAddress(types.ModuleAccountName)
 	delegation, found := k.stakingKeeper.GetDelegation(ctx, maccAddr, valAddr)
+	if !found {
+		return types.ErrNotEnoughDelegationShares
+	}
 	shareDenomSupply := k.bankKeeper.GetSupply(ctx, amount.Denom)
 	shares := delegation.Shares.Mul(amount.Amount.ToDec()).QuoInt(shareDenomSupply.Amount)
 

--- a/x/liquid/keeper/derivative.go
+++ b/x/liquid/keeper/derivative.go
@@ -49,12 +49,12 @@ func (k Keeper) MintDerivative(ctx sdk.Context, delegatorAddr sdk.AccAddress, va
 
 	liquidTokenDenom := k.GetLiquidStakingTokenDenom(ctx, valAddr)
 	liquidToken := sdk.NewCoin(liquidTokenDenom, amount.Amount)
-	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.Coins{liquidToken})
+	err := k.bankKeeper.MintCoins(ctx, types.ModuleAccountName, sdk.Coins{liquidToken})
 	if err != nil {
 		return err
 	}
 
-	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, delegatorAddr, sdk.Coins{liquidToken})
+	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, delegatorAddr, sdk.Coins{liquidToken})
 	if err != nil {
 		return err
 	}
@@ -115,6 +115,75 @@ func (k Keeper) MintDerivative(ctx sdk.Context, delegatorAddr sdk.AccAddress, va
 			sdk.NewAttribute(sdk.AttributeKeyAmount, liquidToken.String()),
 			sdk.NewAttribute(types.AttributeKeyValidator, validator.String()),
 			sdk.NewAttribute(types.AttributeKeyModuleAccount, moduleAccAddress.String()),
+		),
+	)
+
+	return nil
+}
+
+// BurnDerivative burns an existing derivative
+func (k Keeper) BurnDerivative(ctx sdk.Context, delegatorAddr sdk.AccAddress, valAddr sdk.ValAddress, amount sdk.Coin) error {
+
+	// User must have enough tokens to fulfill redeem request
+	balance := k.bankKeeper.GetBalance(ctx, delegatorAddr, amount.Denom)
+	if balance.Amount.LT(amount.Amount) {
+		return types.ErrNotEnoughBalance
+	}
+
+	validator, found := k.stakingKeeper.GetValidator(ctx, valAddr)
+	if !found {
+		return types.ErrNoValidatorFound
+	}
+
+	// Confirm that the coin's denom matches the validator's specific liquidate staking coin denom
+	coinDenom := k.GetLiquidStakingTokenDenom(ctx, valAddr)
+	if coinDenom != amount.Denom {
+		return types.ErrInvalidDerivativeDenom
+	}
+
+	// Calculate the ratio between shares and redeem amount:
+	// (moduleAccountTotalDelegation * redeemAmount) / totalIssue
+	maccAddr := k.accountKeeper.GetModuleAddress(types.ModuleAccountName)
+	delegation, found := k.stakingKeeper.GetDelegation(ctx, maccAddr, valAddr)
+	shareDenomSupply := k.bankKeeper.GetSupply(ctx, amount.Denom)
+	shares := delegation.Shares.Mul(amount.Amount.ToDec()).QuoInt(shareDenomSupply.Amount)
+
+	returnAmount, err := k.stakingKeeper.Unbond(ctx, maccAddr, valAddr, shares)
+	if err != nil {
+		return err
+	}
+
+	if validator.IsBonded() {
+		k.bondedTokensToNotBonded(ctx, returnAmount)
+	}
+
+	// Burn share amount from user's address
+	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, delegatorAddr, types.ModuleAccountName, sdk.NewCoins(amount))
+	if err != nil {
+		return err
+	}
+	err = k.bankKeeper.BurnCoins(ctx, types.ModuleAccountName, sdk.NewCoins(amount))
+	if err != nil {
+		return err
+	}
+
+	// Create a delegation for an equivalent amount of KAVA tokens from the user
+	returnCoin := sdk.NewCoin(k.stakingKeeper.BondDenom(ctx), returnAmount)
+	err = k.bankKeeper.UndelegateCoinsFromModuleToAccount(ctx, stakingtypes.NotBondedPoolName, delegatorAddr, sdk.NewCoins(returnCoin))
+	if err != nil {
+		return err
+	}
+	_, err = k.stakingKeeper.Delegate(ctx, delegatorAddr, returnAmount, stakingtypes.Unbonded, validator, true)
+	if err != nil {
+		return err
+	}
+
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeBurnDerivative,
+			sdk.NewAttribute(types.AttributeKeyAmountBurned, amount.String()),
+			sdk.NewAttribute(types.AttributeKeyAmountReturned, returnCoin.String()),
+			sdk.NewAttribute(types.AttributeKeyModuleAccount, maccAddr.String()),
 		),
 	)
 

--- a/x/liquid/keeper/derivative_test.go
+++ b/x/liquid/keeper/derivative_test.go
@@ -112,3 +112,109 @@ func (suite *KeeperTestSuite) TestMintDerivative() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestBurnDerivative() {
+	testCases := []struct {
+		name           string
+		balance        sdk.Coin
+		mintAmount     sdk.Coin
+		burnAmountInt  sdk.Int // sdk.Int instead of sdk.Coin because we don't know the validator-specific token denom yet
+		bondValidator  bool
+		vestingAccount bool
+	}{
+		{
+			name:          "validator unbonded",
+			balance:       sdk.NewInt64Coin("stake", 1e9),
+			mintAmount:    sdk.NewCoin("stake", sdk.NewInt(1e6)),
+			burnAmountInt: sdk.NewInt(1e6),
+		},
+		{
+			name:          "validator unbonded; burn less than full amount",
+			balance:       sdk.NewInt64Coin("stake", 1e9),
+			mintAmount:    sdk.NewCoin("stake", sdk.NewInt(1e6)),
+			burnAmountInt: sdk.NewInt(999999),
+		},
+		{
+			name:          "validator bonded",
+			balance:       sdk.NewInt64Coin("stake", 1e9),
+			mintAmount:    sdk.NewCoin("stake", sdk.NewInt(1e6)),
+			burnAmountInt: sdk.NewInt(1e6),
+			bondValidator: true,
+		},
+		{
+			name:           "delegator is vesting account",
+			balance:        sdk.NewInt64Coin("stake", 1e9),
+			mintAmount:     sdk.NewCoin("stake", sdk.NewInt(1e6)),
+			burnAmountInt:  sdk.NewInt(1e6),
+			vestingAccount: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+
+			// Set up delegation to validator
+			var delegatorAcc authtypes.AccountI
+			if !tc.vestingAccount {
+				delegatorAcc = suite.CreateAccount(sdk.NewCoins(tc.balance))
+			} else {
+				delegatorAcc = suite.CreateVestingAccount(
+					sdk.NewCoins(tc.balance),
+					sdk.NewCoins(sdk.NewCoin(tc.balance.Denom, tc.balance.Amount.Mul(sdk.NewInt(10)))),
+				)
+			}
+
+			delegatorAddr := delegatorAcc.GetAddress()
+			validatorAddr := sdk.ValAddress(delegatorAddr)
+			err := suite.deliverMsgCreateValidator(suite.Ctx, validatorAddr, tc.balance)
+			suite.NoError(err)
+
+			validator, _ := suite.StakingKeeper.GetValidator(suite.Ctx, validatorAddr)
+			suite.Equal("BOND_STATUS_UNBONDED", validator.Status.String())
+			// Run the EndBlocker to bond validator
+			if tc.bondValidator {
+				_ = suite.App.EndBlocker(suite.Ctx, abci.RequestEndBlock{})
+				validator, _ = suite.StakingKeeper.GetValidator(suite.Ctx, validatorAddr)
+				suite.Equal("BOND_STATUS_BONDED", validator.Status.String())
+			}
+
+			msgMint := types.NewMsgMintDerivative(
+				delegatorAddr,
+				validatorAddr,
+				tc.mintAmount,
+			)
+			_, err = suite.App.MsgServiceRouter().Handler(&msgMint)(suite.Ctx, &msgMint)
+			suite.NoError(err)
+
+			initialDelegation, _ := suite.StakingKeeper.GetDelegation(suite.Ctx, delegatorAddr, validatorAddr)
+
+			// Confirm that the delegator has available stKava to burn
+			liquidTokenDenom := suite.Keeper.GetLiquidStakingTokenDenom(suite.Ctx, validatorAddr)
+			preBurnBalance := suite.BankKeeper.GetBalance(suite.Ctx, delegatorAddr, liquidTokenDenom)
+			suite.Equal(sdk.NewCoin(liquidTokenDenom, tc.mintAmount.Amount), preBurnBalance) // delegated 'stake' converted to 'stStake'
+
+			shares, err := validator.SharesFromTokens(tc.burnAmountInt)
+			suite.NoError(err)
+
+			burnAmount := sdk.NewCoin(liquidTokenDenom, tc.burnAmountInt)
+			msgBurn := types.NewMsgBurnDerivative(
+				delegatorAddr,
+				validatorAddr,
+				burnAmount,
+			)
+			_, err = suite.App.MsgServiceRouter().Handler(&msgBurn)(suite.Ctx, &msgBurn)
+			suite.NoError(err)
+
+			// Confirm that coins were burned from the delegator's address
+			postBurnBalance := suite.BankKeeper.GetBalance(suite.Ctx, delegatorAddr, liquidTokenDenom)
+			// Hacky way to compare values without sdk.Coin/sdk.Int nil throwing an error
+			suite.Equal(postBurnBalance.Amount.Uint64(), preBurnBalance.Sub(burnAmount).Amount.Uint64())
+
+			// Confirm that the delegation has been successfully returned to delegator
+			delegation, found := suite.StakingKeeper.GetDelegation(suite.Ctx, delegatorAddr, validatorAddr)
+			suite.True(found)
+			suite.Equal(initialDelegation.Shares.Add(shares), delegation.Shares)
+		})
+	}
+}

--- a/x/liquid/types/events.go
+++ b/x/liquid/types/events.go
@@ -2,10 +2,13 @@ package types
 
 const (
 	EventTypeMintDerivative = "mint_derivative"
+	EventTypeBurnDerivative = "burn_derivative"
 
-	AttributeValueCategory    = ModuleName
-	AttributeKeyAmount        = "amount"
-	AttributeKeySender        = "sender"
-	AttributeKeyValidator     = "validator"
-	AttributeKeyModuleAccount = "module_account"
+	AttributeValueCategory     = ModuleName
+	AttributeKeyAmount         = "amount"
+	AttributeKeySender         = "sender"
+	AttributeKeyValidator      = "validator"
+	AttributeKeyModuleAccount  = "module_account"
+	AttributeKeyAmountReturned = "returned"
+	AttributeKeyAmountBurned   = "burned"
 )

--- a/x/liquid/types/msg.go
+++ b/x/liquid/types/msg.go
@@ -56,3 +56,50 @@ func (msg MsgMintDerivative) GetSigners() []sdk.AccAddress {
 	}
 	return []sdk.AccAddress{sender}
 }
+
+// NewMsgBurnDerivative returns a new MsgBurnDerivative
+func NewMsgBurnDerivative(sender sdk.AccAddress, validator sdk.ValAddress, amount sdk.Coin) MsgBurnDerivative {
+	return MsgBurnDerivative{
+		Sender:    sender.String(),
+		Validator: validator.String(),
+		Amount:    amount,
+	}
+}
+
+// Route return the message type used for routing the message.
+func (msg MsgBurnDerivative) Route() string { return RouterKey }
+
+// Type returns a human-readable string for the message, intended for utilization within tags.
+func (msg MsgBurnDerivative) Type() string { return "burn_derivative" }
+
+// ValidateBasic does a simple validation check that doesn't require access to any other information.
+func (msg MsgBurnDerivative) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())
+	}
+
+	_, err = sdk.ValAddressFromBech32(msg.Validator)
+	if err != nil {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())
+	}
+	if msg.Amount.IsNil() {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "amount %s", msg.Amount)
+	}
+	return nil
+}
+
+// GetSignBytes gets the canonical byte representation of the Msg.
+func (msg MsgBurnDerivative) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(&msg)
+	return sdk.MustSortJSON(bz)
+}
+
+// GetSigners returns the addresses of signers that must sign.
+func (msg MsgBurnDerivative) GetSigners() []sdk.AccAddress {
+	sender, err := sdk.AccAddressFromBech32(msg.Sender)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{sender}
+}

--- a/x/liquid/types/tx.pb.go
+++ b/x/liquid/types/tx.pb.go
@@ -93,6 +93,7 @@ func (m *MsgMintDerivative) GetAmount() types.Coin {
 
 // MsgMintDerivativeResponse defines the Msg/MintDerivative response type.
 type MsgMintDerivativeResponse struct {
+	Amount types.Coin `protobuf:"bytes,1,opt,name=amount,proto3" json:"amount"`
 }
 
 func (m *MsgMintDerivativeResponse) Reset()         { *m = MsgMintDerivativeResponse{} }
@@ -128,36 +129,154 @@ func (m *MsgMintDerivativeResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgMintDerivativeResponse proto.InternalMessageInfo
 
+func (m *MsgMintDerivativeResponse) GetAmount() types.Coin {
+	if m != nil {
+		return m.Amount
+	}
+	return types.Coin{}
+}
+
+// MsgBurnDerivative defines the Msg/BurnDerivative request type.
+type MsgBurnDerivative struct {
+	Sender    string     `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
+	Validator string     `protobuf:"bytes,2,opt,name=validator,proto3" json:"validator,omitempty"`
+	Amount    types.Coin `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount"`
+}
+
+func (m *MsgBurnDerivative) Reset()         { *m = MsgBurnDerivative{} }
+func (m *MsgBurnDerivative) String() string { return proto.CompactTextString(m) }
+func (*MsgBurnDerivative) ProtoMessage()    {}
+func (*MsgBurnDerivative) Descriptor() ([]byte, []int) {
+	return fileDescriptor_738981106e50f269, []int{2}
+}
+func (m *MsgBurnDerivative) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgBurnDerivative) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgBurnDerivative.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgBurnDerivative) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgBurnDerivative.Merge(m, src)
+}
+func (m *MsgBurnDerivative) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgBurnDerivative) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgBurnDerivative.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgBurnDerivative proto.InternalMessageInfo
+
+func (m *MsgBurnDerivative) GetSender() string {
+	if m != nil {
+		return m.Sender
+	}
+	return ""
+}
+
+func (m *MsgBurnDerivative) GetValidator() string {
+	if m != nil {
+		return m.Validator
+	}
+	return ""
+}
+
+func (m *MsgBurnDerivative) GetAmount() types.Coin {
+	if m != nil {
+		return m.Amount
+	}
+	return types.Coin{}
+}
+
+// MsgBurnDerivativeResponse defines the Msg/BurnDerivative response type.
+type MsgBurnDerivativeResponse struct {
+	Amount types.Coin `protobuf:"bytes,1,opt,name=amount,proto3" json:"amount"`
+}
+
+func (m *MsgBurnDerivativeResponse) Reset()         { *m = MsgBurnDerivativeResponse{} }
+func (m *MsgBurnDerivativeResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgBurnDerivativeResponse) ProtoMessage()    {}
+func (*MsgBurnDerivativeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_738981106e50f269, []int{3}
+}
+func (m *MsgBurnDerivativeResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgBurnDerivativeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgBurnDerivativeResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgBurnDerivativeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgBurnDerivativeResponse.Merge(m, src)
+}
+func (m *MsgBurnDerivativeResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgBurnDerivativeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgBurnDerivativeResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgBurnDerivativeResponse proto.InternalMessageInfo
+
+func (m *MsgBurnDerivativeResponse) GetAmount() types.Coin {
+	if m != nil {
+		return m.Amount
+	}
+	return types.Coin{}
+}
+
 func init() {
 	proto.RegisterType((*MsgMintDerivative)(nil), "kava.liquid.v1beta1.MsgMintDerivative")
 	proto.RegisterType((*MsgMintDerivativeResponse)(nil), "kava.liquid.v1beta1.MsgMintDerivativeResponse")
+	proto.RegisterType((*MsgBurnDerivative)(nil), "kava.liquid.v1beta1.MsgBurnDerivative")
+	proto.RegisterType((*MsgBurnDerivativeResponse)(nil), "kava.liquid.v1beta1.MsgBurnDerivativeResponse")
 }
 
 func init() { proto.RegisterFile("kava/liquid/v1beta1/tx.proto", fileDescriptor_738981106e50f269) }
 
 var fileDescriptor_738981106e50f269 = []byte{
-	// 330 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x91, 0xb1, 0x4e, 0xc2, 0x40,
-	0x18, 0xc7, 0x7b, 0x62, 0x48, 0x38, 0x13, 0x13, 0x2b, 0x43, 0x41, 0x72, 0x12, 0x06, 0xc3, 0xc2,
-	0x9d, 0xe0, 0xe0, 0x6c, 0x75, 0x65, 0xa9, 0x9b, 0x8b, 0xb9, 0xd2, 0x4b, 0xb9, 0x08, 0xf7, 0x61,
-	0xbf, 0xa3, 0xc1, 0xb7, 0xf0, 0x01, 0x7c, 0x0c, 0x1f, 0x82, 0x91, 0x38, 0x39, 0x19, 0x03, 0x2f,
-	0x62, 0x4a, 0x5b, 0x4d, 0xc4, 0xc1, 0xed, 0x6b, 0x7f, 0xff, 0xff, 0xff, 0xfe, 0xf7, 0x1d, 0x6d,
-	0x3d, 0xc8, 0x54, 0x8a, 0x89, 0x7e, 0x9c, 0xeb, 0x48, 0xa4, 0xfd, 0x50, 0x59, 0xd9, 0x17, 0x76,
-	0xc1, 0x67, 0x09, 0x58, 0x70, 0x8f, 0x33, 0xca, 0x73, 0xca, 0x0b, 0xda, 0xac, 0xc7, 0x10, 0xc3,
-	0x96, 0x8b, 0x6c, 0xca, 0xa5, 0x4d, 0x36, 0x02, 0x9c, 0x02, 0x8a, 0x50, 0xa2, 0xfa, 0x0e, 0x1a,
-	0x81, 0x36, 0x05, 0x6f, 0xe4, 0xfc, 0x3e, 0x37, 0xe6, 0x1f, 0x39, 0xea, 0xbc, 0x10, 0x7a, 0x34,
-	0xc4, 0x78, 0xa8, 0x8d, 0xbd, 0x51, 0x89, 0x4e, 0xa5, 0xd5, 0xa9, 0x72, 0xcf, 0x69, 0x15, 0x95,
-	0x89, 0x54, 0xe2, 0x91, 0x36, 0xe9, 0xd6, 0x7c, 0xef, 0xed, 0xb5, 0x57, 0x2f, 0x7c, 0x57, 0x51,
-	0x94, 0x28, 0xc4, 0x5b, 0x9b, 0x68, 0x13, 0x07, 0x85, 0xce, 0x6d, 0xd1, 0x5a, 0x2a, 0x27, 0x3a,
-	0x92, 0x16, 0x12, 0x6f, 0x2f, 0x33, 0x05, 0x3f, 0x3f, 0xdc, 0x4b, 0x5a, 0x95, 0x53, 0x98, 0x1b,
-	0xeb, 0x55, 0xda, 0xa4, 0x7b, 0x30, 0x68, 0xf0, 0x22, 0x2c, 0x6b, 0x5c, 0x5e, 0x8e, 0x5f, 0x83,
-	0x36, 0xfe, 0xfe, 0xf2, 0xe3, 0xd4, 0x09, 0x0a, 0x79, 0xe7, 0x84, 0x36, 0x76, 0xda, 0x05, 0x0a,
-	0x67, 0x60, 0x50, 0x0d, 0x80, 0x56, 0x86, 0x18, 0xbb, 0x63, 0x7a, 0xf8, 0xab, 0xfe, 0x19, 0xff,
-	0x63, 0x77, 0x7c, 0x27, 0xa8, 0xc9, 0xff, 0xa7, 0x2b, 0x0f, 0xf4, 0xfd, 0xe5, 0x9a, 0x91, 0xd5,
-	0x9a, 0x91, 0xcf, 0x35, 0x23, 0xcf, 0x1b, 0xe6, 0xac, 0x36, 0xcc, 0x79, 0xdf, 0x30, 0xe7, 0xae,
-	0x1b, 0x6b, 0x3b, 0x9e, 0x87, 0x7c, 0x04, 0x53, 0x91, 0x65, 0xf6, 0x26, 0x32, 0xc4, 0xed, 0x24,
-	0x16, 0xe5, 0x0b, 0xdb, 0xa7, 0x99, 0xc2, 0xb0, 0xba, 0xdd, 0xfb, 0xc5, 0x57, 0x00, 0x00, 0x00,
-	0xff, 0xff, 0x97, 0x49, 0x96, 0x87, 0xfd, 0x01, 0x00, 0x00,
+	// 369 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x53, 0xcd, 0x4e, 0xf2, 0x40,
+	0x14, 0xed, 0x7c, 0x7c, 0x21, 0x61, 0x4c, 0x48, 0xac, 0x2c, 0x0a, 0x21, 0x95, 0xb0, 0x30, 0x6c,
+	0x98, 0x11, 0x5c, 0xb8, 0xb6, 0xba, 0x65, 0x53, 0x5d, 0xb9, 0x31, 0x53, 0x3a, 0x29, 0x13, 0x61,
+	0x06, 0x67, 0xa6, 0x0d, 0xbe, 0x85, 0x0f, 0xe0, 0x63, 0xf8, 0x10, 0x2c, 0x89, 0x2b, 0xdd, 0x18,
+	0x03, 0x2f, 0x62, 0x4a, 0x07, 0x94, 0xbf, 0x44, 0xe3, 0xc6, 0xdd, 0x6d, 0xcf, 0xb9, 0xe7, 0x9e,
+	0x73, 0xdb, 0x0b, 0xab, 0xb7, 0x24, 0x21, 0xb8, 0xcf, 0xee, 0x62, 0x16, 0xe2, 0xa4, 0x15, 0x50,
+	0x4d, 0x5a, 0x58, 0x8f, 0xd0, 0x50, 0x0a, 0x2d, 0xec, 0x83, 0x14, 0x45, 0x19, 0x8a, 0x0c, 0x5a,
+	0x29, 0x45, 0x22, 0x12, 0x73, 0x1c, 0xa7, 0x55, 0x46, 0xad, 0xb8, 0x5d, 0xa1, 0x06, 0x42, 0xe1,
+	0x80, 0x28, 0xba, 0x14, 0xea, 0x0a, 0xc6, 0x0d, 0x5e, 0xce, 0xf0, 0x9b, 0xac, 0x31, 0x7b, 0xc8,
+	0xa0, 0xfa, 0x23, 0x80, 0xfb, 0x1d, 0x15, 0x75, 0x18, 0xd7, 0x17, 0x54, 0xb2, 0x84, 0x68, 0x96,
+	0x50, 0xfb, 0x18, 0xe6, 0x15, 0xe5, 0x21, 0x95, 0x0e, 0xa8, 0x81, 0x46, 0xc1, 0x73, 0x9e, 0x9f,
+	0x9a, 0x25, 0xd3, 0x77, 0x16, 0x86, 0x92, 0x2a, 0x75, 0xa9, 0x25, 0xe3, 0x91, 0x6f, 0x78, 0x76,
+	0x15, 0x16, 0x12, 0xd2, 0x67, 0x21, 0xd1, 0x42, 0x3a, 0xff, 0xd2, 0x26, 0xff, 0xf3, 0x85, 0x7d,
+	0x0a, 0xf3, 0x64, 0x20, 0x62, 0xae, 0x9d, 0x5c, 0x0d, 0x34, 0xf6, 0xda, 0x65, 0x64, 0xc4, 0x52,
+	0xc7, 0x8b, 0x70, 0xe8, 0x5c, 0x30, 0xee, 0xfd, 0x1f, 0xbf, 0x1d, 0x5a, 0xbe, 0xa1, 0xd7, 0xaf,
+	0x60, 0x79, 0xc3, 0x9d, 0x4f, 0xd5, 0x50, 0x70, 0x45, 0xbf, 0xa8, 0x82, 0x9f, 0xa9, 0x9a, 0xd0,
+	0x5e, 0x2c, 0xf9, 0xdf, 0x0d, 0xbd, 0xea, 0xee, 0xd7, 0xa1, 0xdb, 0xaf, 0x00, 0xe6, 0x3a, 0x2a,
+	0xb2, 0x7b, 0xb0, 0xb8, 0xf6, 0xb5, 0x8f, 0xd0, 0x96, 0x5f, 0x0d, 0x6d, 0xec, 0xbd, 0x82, 0xbe,
+	0xc7, 0x5b, 0x5a, 0xed, 0xc1, 0xe2, 0xda, 0x8a, 0x77, 0x4e, 0x5a, 0xe5, 0xed, 0x9e, 0xb4, 0x7d,
+	0x29, 0x9e, 0x37, 0x9e, 0xba, 0x60, 0x32, 0x75, 0xc1, 0xfb, 0xd4, 0x05, 0x0f, 0x33, 0xd7, 0x9a,
+	0xcc, 0x5c, 0xeb, 0x65, 0xe6, 0x5a, 0xd7, 0x8d, 0x88, 0xe9, 0x5e, 0x1c, 0xa0, 0xae, 0x18, 0xe0,
+	0x54, 0xb3, 0xd9, 0x27, 0x81, 0x9a, 0x57, 0x78, 0xb4, 0x38, 0x3d, 0x7d, 0x3f, 0xa4, 0x2a, 0xc8,
+	0xcf, 0x0f, 0xe2, 0xe4, 0x23, 0x00, 0x00, 0xff, 0xff, 0xd5, 0xe4, 0x28, 0xd6, 0x96, 0x03, 0x00,
+	0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -174,6 +293,8 @@ const _ = grpc.SupportPackageIsVersion4
 type MsgClient interface {
 	// MintDerivative defines a method for minting deriviatives
 	MintDerivative(ctx context.Context, in *MsgMintDerivative, opts ...grpc.CallOption) (*MsgMintDerivativeResponse, error)
+	// BurnDerivative defines a method for burning deriviatives
+	BurnDerivative(ctx context.Context, in *MsgBurnDerivative, opts ...grpc.CallOption) (*MsgBurnDerivativeResponse, error)
 }
 
 type msgClient struct {
@@ -193,10 +314,21 @@ func (c *msgClient) MintDerivative(ctx context.Context, in *MsgMintDerivative, o
 	return out, nil
 }
 
+func (c *msgClient) BurnDerivative(ctx context.Context, in *MsgBurnDerivative, opts ...grpc.CallOption) (*MsgBurnDerivativeResponse, error) {
+	out := new(MsgBurnDerivativeResponse)
+	err := c.cc.Invoke(ctx, "/kava.liquid.v1beta1.Msg/BurnDerivative", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// MintDerivative defines a method for minting deriviatives
 	MintDerivative(context.Context, *MsgMintDerivative) (*MsgMintDerivativeResponse, error)
+	// BurnDerivative defines a method for burning deriviatives
+	BurnDerivative(context.Context, *MsgBurnDerivative) (*MsgBurnDerivativeResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -205,6 +337,9 @@ type UnimplementedMsgServer struct {
 
 func (*UnimplementedMsgServer) MintDerivative(ctx context.Context, req *MsgMintDerivative) (*MsgMintDerivativeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method MintDerivative not implemented")
+}
+func (*UnimplementedMsgServer) BurnDerivative(ctx context.Context, req *MsgBurnDerivative) (*MsgBurnDerivativeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BurnDerivative not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -229,6 +364,24 @@ func _Msg_MintDerivative_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_BurnDerivative_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgBurnDerivative)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).BurnDerivative(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/kava.liquid.v1beta1.Msg/BurnDerivative",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).BurnDerivative(ctx, req.(*MsgBurnDerivative))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "kava.liquid.v1beta1.Msg",
 	HandlerType: (*MsgServer)(nil),
@@ -236,6 +389,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MintDerivative",
 			Handler:    _Msg_MintDerivative_Handler,
+		},
+		{
+			MethodName: "BurnDerivative",
+			Handler:    _Msg_BurnDerivative_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -309,6 +466,96 @@ func (m *MsgMintDerivativeResponse) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	_ = i
 	var l int
 	_ = l
+	{
+		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgBurnDerivative) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgBurnDerivative) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgBurnDerivative) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x1a
+	if len(m.Validator) > 0 {
+		i -= len(m.Validator)
+		copy(dAtA[i:], m.Validator)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Validator)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Sender) > 0 {
+		i -= len(m.Sender)
+		copy(dAtA[i:], m.Sender)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Sender)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgBurnDerivativeResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgBurnDerivativeResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgBurnDerivativeResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -348,6 +595,38 @@ func (m *MsgMintDerivativeResponse) Size() (n int) {
 	}
 	var l int
 	_ = l
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgBurnDerivative) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Sender)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = len(m.Validator)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgBurnDerivativeResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
 	return n
 }
 
@@ -533,6 +812,269 @@ func (m *MsgMintDerivativeResponse) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: MsgMintDerivativeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgBurnDerivative) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgBurnDerivative: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgBurnDerivative: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sender", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sender = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Validator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Validator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgBurnDerivativeResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgBurnDerivativeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgBurnDerivativeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipTx(dAtA[iNdEx:])


### PR DESCRIPTION
Implements burning of derivative tokens to receive original delegation shares. Tests are passing - but I noticed that if the validator is `Unbonded` for the token mint and then moves to `Bonded` state attempted token burns will fail.