### PR TITLE
(v0.17.x) Fix: Schedule upgrade plan the block before

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -903,7 +903,7 @@ func NewApp(
 
 // BeginBlocker contains app specific logic for the BeginBlock abci call.
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
-	if ctx.BlockHeight() == EthermintPatchUpgradeHeight {
+	if ctx.BlockHeight() == EthermintPatchUpgradeHeight-1 {
 		upgradePlan := upgradetypes.Plan{
 			Name:   EthermintPatchUpgradeName,
 			Height: EthermintPatchUpgradeHeight,


### PR DESCRIPTION
This ensures the plan is persisted to state before chain panic.