### PR TITLE
Add legacy msg support for earn msgs

### DIFF
--- a/x/earn/types/msg.go
+++ b/x/earn/types/msg.go
@@ -3,11 +3,20 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
 )
 
 var (
-	_ sdk.Msg = &MsgDeposit{}
-	_ sdk.Msg = &MsgWithdraw{}
+	_ sdk.Msg            = &MsgDeposit{}
+	_ sdk.Msg            = &MsgWithdraw{}
+	_ legacytx.LegacyMsg = &MsgDeposit{}
+	_ legacytx.LegacyMsg = &MsgWithdraw{}
+)
+
+// legacy message types
+const (
+	TypeMsgDeposit  = "earn_msg_deposit"
+	TypeMsgWithdraw = "earn_msg_withdraw"
 )
 
 // NewMsgDeposit returns a new MsgDeposit.
@@ -47,6 +56,16 @@ func (msg MsgDeposit) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{depositor}
 }
 
+// Route implements the LegacyMsg.Route method.
+func (msg MsgDeposit) Route() string {
+	return RouterKey
+}
+
+// Type implements the LegacyMsg.Type method.
+func (msg MsgDeposit) Type() string {
+	return TypeMsgDeposit
+}
+
 // NewMsgWithdraw returns a new MsgWithdraw.
 func NewMsgWithdraw(from string, amount sdk.Coin) *MsgWithdraw {
 	return &MsgWithdraw{
@@ -82,4 +101,14 @@ func (msg MsgWithdraw) GetSigners() []sdk.AccAddress {
 	}
 
 	return []sdk.AccAddress{depositor}
+}
+
+// Route implements the LegacyMsg.Route method.
+func (msg MsgWithdraw) Route() string {
+	return RouterKey
+}
+
+// Type implements the LegacyMsg.Type method.
+func (msg MsgWithdraw) Type() string {
+	return TypeMsgWithdraw
 }


### PR DESCRIPTION
Messages that can be sent front the FE needs to support amino msg. The earn messages was causing issues from the FE due to missing support.