### PR TITLE
Fix error on querying account earn "bkava" deposit when account has non-bkava deposits

### DIFF
--- a/x/earn/keeper/grpc_query.go
+++ b/x/earn/keeper/grpc_query.go
@@ -343,8 +343,16 @@ func (s queryServer) getOneAccountBkavaVaultDeposit(
 		return nil, err
 	}
 
+	// Remove non-bkava coins, GetStakedTokensForDerivatives expects only bkava
+	totalBkavaValue := sdk.NewCoins()
+	for _, coin := range totalAccountValue {
+		if s.keeper.liquidKeeper.IsDerivativeDenom(ctx, coin.Denom) {
+			totalBkavaValue = totalBkavaValue.Add(coin)
+		}
+	}
+
 	// Use account value with only the aggregate bkava converted to underlying staked tokens
-	stakedValue, err := s.keeper.liquidKeeper.GetStakedTokensForDerivatives(ctx, totalAccountValue)
+	stakedValue, err := s.keeper.liquidKeeper.GetStakedTokensForDerivatives(ctx, totalBkavaValue)
 	if err != nil {
 		return nil, err
 	}

--- a/x/earn/types/expected_keepers.go
+++ b/x/earn/types/expected_keepers.go
@@ -28,6 +28,7 @@ type BankKeeper interface {
 // LiquidKeeper defines the expected interface needed for derivative to staked token conversions.
 type LiquidKeeper interface {
 	GetStakedTokensForDerivatives(ctx sdk.Context, derivatives sdk.Coins) (sdk.Coin, error)
+	IsDerivativeDenom(ctx sdk.Context, denom string) bool
 }
 
 // HardKeeper defines the expected interface needed for the hard strategy.


### PR DESCRIPTION
Currently `/kava/earn/v1beta1/deposits?depositor=...denom=bkava` returns an error such as `"invalid derivative denom: cannot parse denom erc20/multichain/usdc: invalid request"` if the account has non-bkava deposits as `GetStakedTokensForDerivatives` only expects bkava denoms.

This excludes non-bkava denoms from aggregate underlying ukava calculation. This is done in the query handler instead of ignoring non-bkava denoms in liquid `GetStakedTokensForDerivatives` to avoid implicit behavior.