### PR TITLE
Add migrations for updated incentive parameters

### DIFF
--- a/x/incentive/migrations/migrations.go
+++ b/x/incentive/migrations/migrations.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	v2 "github.com/kava-labs/kava/x/incentive/migrations/v2"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	keeper keeper.Keeper
+}
+
+// NewMigrator returns a new Migrator.
+func NewMigrator(keeper keeper.Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+// Migrate1to2 migrates from version 1 to 2.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v2.MigrateParams(ctx, m.keeper)
+}

--- a/x/incentive/migrations/v2/store.go
+++ b/x/incentive/migrations/v2/store.go
@@ -1,0 +1,127 @@
+package v2
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
+)
+
+// MigrateParams performs in-place migrations from kava 10 to kava 11.
+// The migration includes:
+//
+// 1. Add rewards for bkava liquid staking = 10% APR
+// 2. Add rewards for USDC = 10% APR
+// 3. Change APR for vanilla kava staking from 23% --> 20%
+// 4. Remove lockup periods from claims (going forward)
+// 5. Remove HARD and SWP delegation rewards for vanilla staking
+func MigrateParams(ctx sdk.Context, k keeper.Keeper) error {
+	params := k.GetParams(ctx)
+
+	periodStart := time.Date(2022, 10, 12, 15, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2024, 10, 12, 15, 0, 0, 0, time.UTC)
+
+	params.EarnRewardPeriods = types.MultiRewardPeriods{
+		// 1. Add rewards for bkava liquid staking = 10% APR
+		types.NewMultiRewardPeriod(
+			true,
+			"bkava",
+			periodStart,
+			periodEnd,
+			sdk.NewCoins(
+				// 0.1902587519 KAVA == 190258.752ukava
+				sdk.NewCoin("ukava", sdk.NewInt(190258)),
+			),
+		),
+		// 2. Add rewards for USDC = 10% APR
+		types.NewMultiRewardPeriod(
+			true,
+			"erc20/multichain/usdc",
+			periodStart,
+			periodEnd,
+			sdk.NewCoins(
+				// 0.005284965331 USDC == 5284.965331 (6 decimals!)
+				sdk.NewCoin("ukava", sdk.NewInt(5284)),
+			),
+		),
+	}
+
+	// Update hard supply rewards
+	for i, period := range params.HardSupplyRewardPeriods {
+		if period.CollateralType == "usdx" {
+			params.HardSupplyRewardPeriods[i] = types.NewMultiRewardPeriod(
+				true,
+				period.CollateralType,
+				period.Start,
+				period.End,
+				sdk.NewCoins(
+					// Same hard rewards as before
+					sdk.NewCoin("hard", period.RewardsPerSecond.AmountOf("hard")),
+					// 0.4735328936ukava == 473532.8936ukava
+					sdk.NewCoin("ukava", sdk.NewInt(473532)),
+				),
+			)
+		}
+
+		// ATOM
+		// https://api.data.kava.io/ibc/apps/transfer/v1/denom_traces/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2
+		if period.CollateralType == "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2" {
+			params.HardSupplyRewardPeriods[i] = types.NewMultiRewardPeriod(
+				true,
+				period.CollateralType,
+				period.Start,
+				period.End,
+				sdk.NewCoins(
+					// Same hard rewards as before
+					sdk.NewCoin("hard", period.RewardsPerSecond.AmountOf("hard")),
+					// 0.01109842719ukava == 11098.42719ukava
+					sdk.NewCoin("ukava", sdk.NewInt(11098)),
+				),
+			)
+		}
+	}
+
+	// New multiplier with 0 lockup and full rewards factor
+	newMultiplier := types.NewMultiplier("large", 0, sdk.OneDec())
+
+	// 4. Remove lockup periods from claims (going forward)
+	// All claim multipliers have 0 lockup period
+	params.ClaimMultipliers = types.MultipliersPerDenoms{
+		{
+			Denom: "hard",
+			Multipliers: types.Multipliers{
+				newMultiplier,
+			},
+		},
+		{
+			Denom: "ukava",
+			Multipliers: types.Multipliers{
+				newMultiplier,
+			},
+		},
+		{
+			Denom: "swp",
+			Multipliers: types.Multipliers{
+				newMultiplier,
+			},
+		},
+		{
+			Denom: "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+			Multipliers: types.Multipliers{
+				newMultiplier,
+			},
+		},
+	}
+
+	// 5. Remove HARD and SWP rewards for vanilla staking
+	params.DelegatorRewardPeriods = types.MultiRewardPeriods{}
+
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	k.SetParams(ctx, params)
+	return nil
+}

--- a/x/incentive/migrations/v2/store_test.go
+++ b/x/incentive/migrations/v2/store_test.go
@@ -1,0 +1,749 @@
+package v2_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/app"
+	v2 "github.com/kava-labs/kava/x/incentive/migrations/v2"
+	"github.com/kava-labs/kava/x/incentive/testutil"
+	"github.com/kava-labs/kava/x/incentive/types"
+	"github.com/stretchr/testify/suite"
+)
+
+var kava10ParamsJson = `{
+	"usdx_minting_reward_periods": null,
+	"hard_supply_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "usdx",
+			"start": "2022-04-29T00:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "393201"
+				},
+				{
+					"denom": "ukava",
+					"amount": "491574"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+			"start": "2022-04-29T00:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "88787"
+				},
+				{
+					"denom": "ukava",
+					"amount": "44688"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+			"start": "2022-02-26T02:00:00Z",
+			"end": "2022-05-26T02:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "38052"
+				},
+				{
+					"denom": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+					"amount": "38052"
+				},
+				{
+					"denom": "ukava",
+					"amount": "3799"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "hard",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "31710"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "bnb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "20611"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "busd",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "6342"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "btcb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "31710"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "xrpb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "17440"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ukava",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "6342"
+				}
+			]
+		}
+	],
+	"hard_borrow_reward_periods": null,
+	"delegator_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "ukava",
+			"start": "2022-02-26T01:30:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "316880"
+				},
+				{
+					"denom": "swp",
+					"amount": "198186"
+				}
+			]
+		}
+	],
+	"swap_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "bnb:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "btcb:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "busd:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "136986"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "hard:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "15221"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "53272"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "7610"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "swp:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "152207"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ukava:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "167428"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "usdx:xrpb",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		}
+	],
+	"claim_multipliers": [
+		{
+			"denom": "hard",
+			"multipliers": [
+				{
+					"name": "small",
+					"months_lockup": "1",
+					"factor": "0.200000000000000000"
+				},
+				{
+					"name": "large",
+					"months_lockup": "12",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "ukava",
+			"multipliers": [
+				{
+					"name": "small",
+					"months_lockup": "1",
+					"factor": "0.200000000000000000"
+				},
+				{
+					"name": "large",
+					"months_lockup": "12",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "swp",
+			"multipliers": [
+				{
+					"name": "small",
+					"months_lockup": "1",
+					"factor": "0.100000000000000000"
+				},
+				{
+					"name": "large",
+					"months_lockup": "12",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+			"multipliers": [
+				{
+					"name": "large",
+					"factor": "1.000000000000000000"
+				}
+			]
+		}
+	],
+	"claim_end": "2026-04-08T14:00:00Z",
+	"savings_reward_periods": null
+}`
+
+var kava11ParamsJson = `{
+	"usdx_minting_reward_periods": [],
+	"hard_supply_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "usdx",
+			"start": "2022-04-29T00:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "393201"
+				},
+				{
+					"denom": "ukava",
+					"amount": "473532"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+			"start": "2022-04-29T00:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "88787"
+				},
+				{
+					"denom": "ukava",
+					"amount": "11098"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+			"start": "2022-02-26T02:00:00Z",
+			"end": "2022-05-26T02:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "38052"
+				},
+				{
+					"denom": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+					"amount": "38052"
+				},
+				{
+					"denom": "ukava",
+					"amount": "3799"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "hard",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "31710"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "bnb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "20611"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "busd",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "6342"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "btcb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "31710"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "xrpb",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "17440"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ukava",
+			"start": "2020-10-16T14:00:00Z",
+			"end": "2024-10-16T14:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "hard",
+					"amount": "6342"
+				}
+			]
+		}
+	],
+	"hard_borrow_reward_periods": [],
+	"delegator_reward_periods": [],
+	"swap_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "bnb:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "btcb:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "busd:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "136986"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "hard:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "15221"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "53272"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098:usdx",
+			"start": "2022-03-31T00:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "7610"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "swp:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "152207"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "ukava:usdx",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "167428"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "usdx:xrpb",
+			"start": "2021-08-30T15:00:00Z",
+			"end": "2025-08-29T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "swp",
+					"amount": "38052"
+				}
+			]
+		}
+	],
+	"claim_multipliers": [
+		{
+			"denom": "hard",
+			"multipliers": [
+				{
+					"name": "large",
+					"months_lockup": "0",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "ukava",
+			"multipliers": [
+				{
+					"name": "large",
+					"months_lockup": "0",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "swp",
+			"multipliers": [
+				{
+					"name": "large",
+					"months_lockup": "0",
+					"factor": "1.000000000000000000"
+				}
+			]
+		},
+		{
+			"denom": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+			"multipliers": [
+				{
+					"name": "large",
+					"months_lockup": "0",
+					"factor": "1.000000000000000000"
+				}
+			]
+		}
+	],
+	"earn_reward_periods": [
+		{
+			"active": true,
+			"collateral_type": "bkava",
+			"start": "2022-10-12T15:00:00Z",
+			"end": "2024-10-12T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "ukava",
+					"amount": "190258"
+				}
+			]
+		},
+		{
+			"active": true,
+			"collateral_type": "erc20/multichain/usdc",
+			"start": "2022-10-12T15:00:00Z",
+			"end": "2024-10-12T15:00:00Z",
+			"rewards_per_second": [
+				{
+					"denom": "ukava",
+					"amount": "5284"
+				}
+			]
+		}
+	],
+	"claim_end": "2026-04-08T14:00:00Z",
+	"savings_reward_periods": []
+}`
+
+type MigrateTestSuite struct {
+	testutil.IntegrationTester
+
+	genesisTime time.Time
+}
+
+func TestMigrateTestSuite(t *testing.T) {
+	suite.Run(t, new(MigrateTestSuite))
+}
+
+func (suite *MigrateTestSuite) SetupTest() {
+	suite.genesisTime = time.Date(2020, 12, 15, 14, 0, 0, 0, time.UTC)
+}
+
+func (suite *MigrateTestSuite) TestMigrate() {
+	suite.SetApp()
+	cdc := suite.App.AppCodec()
+
+	var kava10Params types.Params
+	cdc.MustUnmarshalJSON([]byte(kava10ParamsJson), &kava10Params)
+
+	var kava11Params types.Params
+	cdc.MustUnmarshalJSON([]byte(kava11ParamsJson), &kava11Params)
+
+	suite.Require().NoError(kava10Params.Validate())
+	suite.Require().NoError(kava11Params.Validate())
+
+	incentiveGs := types.NewGenesisState(
+		kava10Params,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultGenesisRewardState,
+		types.DefaultUSDXClaims,
+		types.DefaultHardClaims,
+		types.DefaultDelegatorClaims,
+		types.DefaultSwapClaims,
+		types.DefaultSavingsClaims,
+		types.DefaultEarnClaims,
+	)
+
+	suite.StartChain(
+		suite.genesisTime,
+		app.GenesisState{
+			types.ModuleName: cdc.MustMarshalJSON(&incentiveGs),
+		},
+	)
+
+	err := v2.MigrateParams(suite.Ctx, suite.App.GetIncentiveKeeper())
+	suite.Require().NoError(err)
+
+	newParams := suite.App.GetIncentiveKeeper().GetParams(suite.Ctx)
+
+	suite.Require().JSONEq(
+		kava11ParamsJson,
+		string(cdc.MustMarshalJSON(&newParams)),
+		"migrated params should match expected params",
+	)
+
+	// Extra checks for expected changes
+
+	suite.Nil(newParams.DelegatorRewardPeriods, "delegator reward periods should be removed")
+
+	for _, multiplier := range newParams.ClaimMultipliers {
+		suite.Len(multiplier.Multipliers, 1)
+		suite.Equal(
+			types.Multiplier{
+				Name:         "large",
+				MonthsLockup: 0,
+				Factor:       sdk.OneDec(),
+			},
+			multiplier.Multipliers[0],
+			"all multipliers should be \"large\" with 0 months lockup and factor 1",
+		)
+	}
+
+	suite.Len(newParams.EarnRewardPeriods, 2)
+}

--- a/x/incentive/module.go
+++ b/x/incentive/module.go
@@ -2,6 +2,7 @@ package incentive
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -18,6 +19,7 @@ import (
 	"github.com/kava-labs/kava/x/incentive/client/cli"
 	"github.com/kava-labs/kava/x/incentive/client/rest"
 	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/migrations"
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
@@ -26,6 +28,9 @@ var (
 	_ module.AppModuleBasic = AppModuleBasic{}
 	// _ module.AppModuleSimulation = AppModule{}
 )
+
+// ConsensusVersion defines the current module consensus version.
+const ConsensusVersion = 2
 
 // AppModuleBasic defines the basic application module used by the incentive module.
 type AppModuleBasic struct{}
@@ -81,7 +86,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 {
-	return 1
+	return ConsensusVersion
 }
 
 // GetTxCmd returns the root tx command for the incentive module.
@@ -137,6 +142,11 @@ func (AppModule) QuerierRoute() string {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	// TODO: types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServerImpl(am.keeper, am.accountKeeper, am.bankKeeper))
+
+	m := migrations.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/incentive from version 1 to 2: %v", err))
+	}
 }
 
 // InitGenesis performs genesis initialization for the incentive module. It returns no validator updates.


### PR DESCRIPTION
This includes the following changes:

1. Add earn rewards for bkava liquid staking
2. Add earn rewards for usdc
3. Remove lockup periods from claim multipliers
4. Remove hard and swp delegation rewards for vanilla staking
5. Update hard incentives for usdx and uatom

This PR does **not** update vanilla staking APR.