### PR TITLE
Return empty coins when querying x/hard total supplied/borrowed

### DIFF
--- a/x/hard/keeper/grpc_query.go
+++ b/x/hard/keeper/grpc_query.go
@@ -373,7 +373,8 @@ func (s queryServer) TotalBorrowed(ctx context.Context, req *types.QueryTotalBor
 
 	borrowedCoins, found := s.keeper.GetBorrowedCoins(sdkCtx)
 	if !found {
-		return nil, types.ErrBorrowedCoinsNotFound
+		// Use empty coins instead of returning an error
+		borrowedCoins = sdk.NewCoins()
 	}
 
 	// If user specified a denom only return coins of that denom type
@@ -395,7 +396,8 @@ func (s queryServer) TotalDeposited(ctx context.Context, req *types.QueryTotalDe
 
 	suppliedCoins, found := s.keeper.GetSuppliedCoins(sdkCtx)
 	if !found {
-		return nil, types.ErrSuppliedCoinsNotFound
+		// Use empty coins instead of returning an error
+		suppliedCoins = sdk.NewCoins()
 	}
 
 	// If user specified a denom only return coins of that denom type

--- a/x/hard/keeper/grpc_query_test.go
+++ b/x/hard/keeper/grpc_query_test.go
@@ -364,6 +364,26 @@ func (suite *grpcQueryTestSuite) TestGrpcQueryTotalDeposited() {
 	}, totalDeposited)
 }
 
+func (suite *grpcQueryTestSuite) TestGrpcQueryTotalDeposited_Empty() {
+	totalDeposited, err := suite.queryServer.TotalDeposited(sdk.WrapSDKContext(suite.ctx), &types.QueryTotalDepositedRequest{})
+	suite.Require().NoError(err)
+
+	suite.Equal(&types.QueryTotalDepositedResponse{
+		SuppliedCoins: cs(),
+	}, totalDeposited)
+}
+
+func (suite *grpcQueryTestSuite) TestGrpcQueryTotalDeposited_Denom_Empty() {
+	totalDeposited, err := suite.queryServer.TotalDeposited(sdk.WrapSDKContext(suite.ctx), &types.QueryTotalDepositedRequest{
+		Denom: "bnb",
+	})
+	suite.Require().NoError(err)
+
+	suite.Equal(&types.QueryTotalDepositedResponse{
+		SuppliedCoins: cs(),
+	}, totalDeposited)
+}
+
 func (suite *grpcQueryTestSuite) TestGrpcQueryTotalDeposited_Denom() {
 	suite.addDeposits()
 

--- a/x/hard/keeper/querier.go
+++ b/x/hard/keeper/querier.go
@@ -350,7 +350,7 @@ func queryGetTotalBorrowed(ctx sdk.Context, req abci.RequestQuery, k Keeper, leg
 
 	borrowedCoins, found := k.GetBorrowedCoins(ctx)
 	if !found {
-		return nil, types.ErrBorrowedCoinsNotFound
+		borrowedCoins = sdk.NewCoins()
 	}
 
 	// If user specified a denom only return coins of that denom type
@@ -375,7 +375,7 @@ func queryGetTotalDeposited(ctx sdk.Context, req abci.RequestQuery, k Keeper, le
 
 	suppliedCoins, found := k.GetSuppliedCoins(ctx)
 	if !found {
-		return nil, types.ErrSuppliedCoinsNotFound
+		suppliedCoins = sdk.NewCoins()
 	}
 
 	// If user specified a denom only return coins of that denom type


### PR DESCRIPTION
Currently on main/testnet GET `/hard/total-deposited` returns an error `"rpc error: code = Unknown desc = no supplied coins found"` for when there are no deposits. Similar error for `/hard/total-borrowed`.

This change returns an empty coins array `result: []` instead of the error when there are no deposits/borrows.