### PR TITLE
Disable savings incentives

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -666,7 +666,7 @@ func NewApp(
 	app.swapKeeper = *swapKeeper.SetHooks(app.incentiveKeeper.Hooks())
 	app.cdpKeeper = *cdpKeeper.SetHooks(cdptypes.NewMultiCDPHooks(app.incentiveKeeper.Hooks()))
 	app.hardKeeper = *hardKeeper.SetHooks(hardtypes.NewMultiHARDHooks(app.incentiveKeeper.Hooks()))
-	app.savingsKeeper = *savingsKeeper.SetHooks(savingstypes.NewMultiSavingsHooks(app.incentiveKeeper.Hooks()))
+	app.savingsKeeper = savingsKeeper // savings incentive hooks disabled
 	app.earnKeeper = *earnKeeper.SetHooks(app.incentiveKeeper.Hooks())
 
 	// create gov keeper with router

--- a/x/incentive/keeper/hooks.go
+++ b/x/incentive/keeper/hooks.go
@@ -172,12 +172,12 @@ func (h Hooks) BeforePoolDepositModified(ctx sdk.Context, poolID string, deposit
 
 // AfterSavingsDepositCreated function that runs after a deposit is created
 func (h Hooks) AfterSavingsDepositCreated(ctx sdk.Context, deposit savingstypes.Deposit) {
-	h.k.InitializeSavingsReward(ctx, deposit)
+	// h.k.InitializeSavingsReward(ctx, deposit)
 }
 
 // BeforeSavingsDepositModified function that runs before a deposit is modified
 func (h Hooks) BeforeSavingsDepositModified(ctx sdk.Context, deposit savingstypes.Deposit, incomingDenoms []string) {
-	h.k.SynchronizeSavingsReward(ctx, deposit, incomingDenoms)
+	// h.k.SynchronizeSavingsReward(ctx, deposit, incomingDenoms)
 }
 
 // ------------------- Earn Module Hooks -------------------

--- a/x/incentive/keeper/msg_server.go
+++ b/x/incentive/keeper/msg_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/kava-labs/kava/x/incentive/types"
 )
@@ -92,21 +93,8 @@ func (k msgServer) ClaimSwapReward(goCtx context.Context, msg *types.MsgClaimSwa
 }
 
 func (k msgServer) ClaimSavingsReward(goCtx context.Context, msg *types.MsgClaimSavingsReward) (*types.MsgClaimSavingsRewardResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	sender, err := sdk.AccAddressFromBech32(msg.Sender)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, selection := range msg.DenomsToClaim {
-		err := k.keeper.ClaimSavingsReward(ctx, sender, sender, selection.Denom, selection.MultiplierName)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return &types.MsgClaimSavingsRewardResponse{}, nil
+	err := sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "savings claims disabled")
+	return nil, err
 }
 
 func (k msgServer) ClaimEarnReward(goCtx context.Context, msg *types.MsgClaimEarnReward) (*types.MsgClaimEarnRewardResponse, error) {

--- a/x/savings/keeper/deposit.go
+++ b/x/savings/keeper/deposit.go
@@ -24,14 +24,14 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 	deposit := types.NewDeposit(depositor, coins)
 	if foundDeposit {
 		deposit.Amount = deposit.Amount.Add(currDeposit.Amount...)
-		k.hooks.BeforeSavingsDepositModified(ctx, deposit, setDifference(getDenoms(coins), getDenoms(deposit.Amount)))
+		k.BeforeSavingsDepositModified(ctx, deposit, setDifference(getDenoms(coins), getDenoms(deposit.Amount)))
 
 	}
 
 	k.SetDeposit(ctx, deposit)
 
 	if !foundDeposit {
-		k.hooks.AfterSavingsDepositCreated(ctx, deposit)
+		k.AfterSavingsDepositCreated(ctx, deposit)
 	}
 
 	ctx.EventManager().EmitEvent(


### PR DESCRIPTION
Disable incentives for the savings module.
Prevent hooks or msgs calling into sync savings to ensure no invald savings claims are created.
The accumulation code should be ok to leave. Without params it won't run.