### PR TITLE
Add `/incentive/apy` query endpoint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -635,7 +635,6 @@ func NewApp(
 		&earnKeeper,
 		app.mintKeeper,
 		app.distrKeeper,
-		app.kavadistKeeper,
 		app.pricefeedKeeper,
 	)
 	app.routerKeeper = routerkeeper.NewKeeper(

--- a/app/app.go
+++ b/app/app.go
@@ -633,6 +633,9 @@ func NewApp(
 		&savingsKeeper,
 		&app.liquidKeeper,
 		&earnKeeper,
+		app.mintKeeper,
+		app.distrKeeper,
+		app.kavadistKeeper,
 	)
 	app.routerKeeper = routerkeeper.NewKeeper(
 		&app.earnKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -636,6 +636,7 @@ func NewApp(
 		app.mintKeeper,
 		app.distrKeeper,
 		app.kavadistKeeper,
+		app.pricefeedKeeper,
 	)
 	app.routerKeeper = routerkeeper.NewKeeper(
 		&app.earnKeeper,

--- a/x/incentive/client/rest/query.go
+++ b/x/incentive/client/rest/query.go
@@ -19,6 +19,7 @@ func registerQueryRoutes(cliCtx client.Context, r *mux.Router) {
 	r.HandleFunc(fmt.Sprintf("/%s/rewards", types.ModuleName), queryRewardsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/parameters", types.ModuleName), queryParamsHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/reward-factors", types.ModuleName), queryRewardFactorsHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/apy", types.ModuleName), queryAPYsHandlerFn(cliCtx)).Methods("GET")
 }
 
 func queryRewardsHandlerFn(cliCtx client.Context) http.HandlerFunc {
@@ -272,4 +273,24 @@ func executeAllRewardQueries(w http.ResponseWriter, cliCtx client.Context, param
 	}
 
 	rest.PostProcessResponse(w, cliCtx, resBz)
+}
+
+func queryAPYsHandlerFn(cliCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		route := fmt.Sprintf("custom/%s/%s", types.ModuleName, types.QueryGetAPYs)
+
+		res, height, err := cliCtx.QueryWithData(route, nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
 }

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -24,6 +24,11 @@ type Keeper struct {
 	savingsKeeper types.SavingsKeeper
 	liquidKeeper  types.LiquidKeeper
 	earnKeeper    types.EarnKeeper
+
+	// Keepers used for APY queries
+	mintKeeper     types.MintKeeper
+	distrKeeper    types.DistrKeeper
+	kavadistKeeper types.KavadistKeeper
 }
 
 // NewKeeper creates a new keeper
@@ -31,24 +36,28 @@ func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramstore types.ParamSubspace, bk types.BankKeeper,
 	cdpk types.CdpKeeper, hk types.HardKeeper, ak types.AccountKeeper, stk types.StakingKeeper,
 	swpk types.SwapKeeper, svk types.SavingsKeeper, lqk types.LiquidKeeper, ek types.EarnKeeper,
+	mk types.MintKeeper, dk types.DistrKeeper, kdk types.KavadistKeeper,
 ) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
 	}
 
 	return Keeper{
-		accountKeeper: ak,
-		cdc:           cdc,
-		key:           key,
-		paramSubspace: paramstore,
-		bankKeeper:    bk,
-		cdpKeeper:     cdpk,
-		hardKeeper:    hk,
-		stakingKeeper: stk,
-		swapKeeper:    swpk,
-		savingsKeeper: svk,
-		liquidKeeper:  lqk,
-		earnKeeper:    ek,
+		accountKeeper:  ak,
+		cdc:            cdc,
+		key:            key,
+		paramSubspace:  paramstore,
+		bankKeeper:     bk,
+		cdpKeeper:      cdpk,
+		hardKeeper:     hk,
+		stakingKeeper:  stk,
+		swapKeeper:     swpk,
+		savingsKeeper:  svk,
+		liquidKeeper:   lqk,
+		earnKeeper:     ek,
+		mintKeeper:     mk,
+		distrKeeper:    dk,
+		kavadistKeeper: kdk,
 	}
 }
 

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -26,9 +26,10 @@ type Keeper struct {
 	earnKeeper    types.EarnKeeper
 
 	// Keepers used for APY queries
-	mintKeeper     types.MintKeeper
-	distrKeeper    types.DistrKeeper
-	kavadistKeeper types.KavadistKeeper
+	mintKeeper      types.MintKeeper
+	distrKeeper     types.DistrKeeper
+	kavadistKeeper  types.KavadistKeeper
+	pricefeedKeeper types.PricefeedKeeper
 }
 
 // NewKeeper creates a new keeper
@@ -36,28 +37,29 @@ func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramstore types.ParamSubspace, bk types.BankKeeper,
 	cdpk types.CdpKeeper, hk types.HardKeeper, ak types.AccountKeeper, stk types.StakingKeeper,
 	swpk types.SwapKeeper, svk types.SavingsKeeper, lqk types.LiquidKeeper, ek types.EarnKeeper,
-	mk types.MintKeeper, dk types.DistrKeeper, kdk types.KavadistKeeper,
+	mk types.MintKeeper, dk types.DistrKeeper, kdk types.KavadistKeeper, pfk types.PricefeedKeeper,
 ) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
 	}
 
 	return Keeper{
-		accountKeeper:  ak,
-		cdc:            cdc,
-		key:            key,
-		paramSubspace:  paramstore,
-		bankKeeper:     bk,
-		cdpKeeper:      cdpk,
-		hardKeeper:     hk,
-		stakingKeeper:  stk,
-		swapKeeper:     swpk,
-		savingsKeeper:  svk,
-		liquidKeeper:   lqk,
-		earnKeeper:     ek,
-		mintKeeper:     mk,
-		distrKeeper:    dk,
-		kavadistKeeper: kdk,
+		accountKeeper:   ak,
+		cdc:             cdc,
+		key:             key,
+		paramSubspace:   paramstore,
+		bankKeeper:      bk,
+		cdpKeeper:       cdpk,
+		hardKeeper:      hk,
+		stakingKeeper:   stk,
+		swapKeeper:      swpk,
+		savingsKeeper:   svk,
+		liquidKeeper:    lqk,
+		earnKeeper:      ek,
+		mintKeeper:      mk,
+		distrKeeper:     dk,
+		kavadistKeeper:  kdk,
+		pricefeedKeeper: pfk,
 	}
 }
 

--- a/x/incentive/keeper/keeper.go
+++ b/x/incentive/keeper/keeper.go
@@ -28,7 +28,6 @@ type Keeper struct {
 	// Keepers used for APY queries
 	mintKeeper      types.MintKeeper
 	distrKeeper     types.DistrKeeper
-	kavadistKeeper  types.KavadistKeeper
 	pricefeedKeeper types.PricefeedKeeper
 }
 
@@ -37,7 +36,7 @@ func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramstore types.ParamSubspace, bk types.BankKeeper,
 	cdpk types.CdpKeeper, hk types.HardKeeper, ak types.AccountKeeper, stk types.StakingKeeper,
 	swpk types.SwapKeeper, svk types.SavingsKeeper, lqk types.LiquidKeeper, ek types.EarnKeeper,
-	mk types.MintKeeper, dk types.DistrKeeper, kdk types.KavadistKeeper, pfk types.PricefeedKeeper,
+	mk types.MintKeeper, dk types.DistrKeeper, pfk types.PricefeedKeeper,
 ) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
@@ -58,7 +57,6 @@ func NewKeeper(
 		earnKeeper:      ek,
 		mintKeeper:      mk,
 		distrKeeper:     dk,
-		kavadistKeeper:  kdk,
 		pricefeedKeeper: pfk,
 	}
 }

--- a/x/incentive/keeper/querier.go
+++ b/x/incentive/keeper/querier.go
@@ -468,7 +468,7 @@ func GetStakingAPR(ctx sdk.Context, k Keeper, params types.Params) (sdk.Dec, err
 	}
 
 	// Incentive APR = rewards per second * seconds per year / total supplied to earn vaults
-	// Override collateral type to use "ukava" instead of "bkava" when fetching prices
+	// Override collateral type to use "kava" instead of "bkava" when fetching
 	incentiveAPY, err := GetAPYFromMultiRewardPeriod(ctx, k, types.BondDenom, bkavaRewardPeriod, totalEarnBkavaDeposited)
 	if err != nil {
 		return sdk.ZeroDec(), err
@@ -486,6 +486,10 @@ func GetAPYFromMultiRewardPeriod(
 	rewardPeriod types.MultiRewardPeriod,
 	totalSupply sdk.Int,
 ) (sdk.Dec, error) {
+	if totalSupply.IsZero() {
+		return sdk.ZeroDec(), nil
+	}
+
 	// Get USD value of collateral type
 	collateralUSDValue, err := k.pricefeedKeeper.GetCurrentPrice(ctx, getMarketID(collateralType))
 	if err != nil {
@@ -520,5 +524,10 @@ func GetAPYFromMultiRewardPeriod(
 }
 
 func getMarketID(denom string) string {
+	if denom == types.BondDenom {
+		// Rewrite "ukava" to "kava" as pricefeed only has "kava" and not "ukava"
+		return getMarketID("kava")
+	}
+
 	return fmt.Sprintf("%s:usd:30", denom)
 }

--- a/x/incentive/keeper/querier_test.go
+++ b/x/incentive/keeper/querier_test.go
@@ -1,0 +1,99 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/incentive/keeper"
+	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTotalInfrastructureInflation(t *testing.T) {
+	blockTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		periods       kavadisttypes.Periods
+		wantInflation sdk.Dec
+	}{
+		{
+			"one period",
+			kavadisttypes.Periods{
+				kavadisttypes.NewPeriod(
+					blockTime.Add(-time.Hour),
+					blockTime.Add(time.Hour),
+					sdk.MustNewDecFromStr("1.000000003022265980"),
+				),
+			},
+			sdk.MustNewDecFromStr("0.000000003022265980").MulInt64(keeper.SecondsPerYear),
+		},
+		{
+			"one period expired",
+			kavadisttypes.Periods{
+				kavadisttypes.NewPeriod(
+					blockTime.Add(-2*time.Hour),
+					blockTime.Add(-time.Hour),
+					sdk.MustNewDecFromStr("1.000000003022265980"),
+				),
+			},
+			sdk.ZeroDec(),
+		},
+		{
+			"one period in future",
+			kavadisttypes.Periods{
+				kavadisttypes.NewPeriod(
+					blockTime.Add(time.Hour),
+					blockTime.Add(2*time.Hour),
+					sdk.MustNewDecFromStr("1.000000003022265980"),
+				),
+			},
+			sdk.ZeroDec(),
+		},
+		{
+			"two periods active",
+			kavadisttypes.Periods{
+				// Additional expired period
+				kavadisttypes.NewPeriod(
+					blockTime.Add(-2*time.Hour),
+					blockTime.Add(-time.Hour),
+					sdk.MustNewDecFromStr("1.000000003022265980"),
+				),
+				// Two active periods
+				kavadisttypes.NewPeriod(
+					blockTime.Add(-time.Hour),
+					blockTime.Add(time.Hour),
+					sdk.MustNewDecFromStr("1.000000003022265980"),
+				),
+				kavadisttypes.NewPeriod(
+					blockTime.Add(-2*time.Hour),
+					blockTime.Add(2*time.Hour),
+					sdk.MustNewDecFromStr("1.0000000095129375"),
+				),
+				// An additional future period
+				kavadisttypes.NewPeriod(
+					blockTime.Add(2*time.Hour),
+					blockTime.Add(3*time.Hour),
+					sdk.MustNewDecFromStr("1.0000000095129375"),
+				),
+			},
+			sdk.MustNewDecFromStr("0.000000003022265980").
+				Add(sdk.MustNewDecFromStr("0.0000000095129375")).
+				MulInt64(keeper.SecondsPerYear),
+		},
+	}
+
+	ctx := NewTestContext().WithBlockTime(blockTime)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inflation := keeper.GetTotalInfrastructureInflation(ctx, tc.periods)
+			t.Logf("inflation per year: %s (~%v%%)",
+				inflation, inflation.MulInt64(100).RoundInt64())
+
+			require.Equal(t, tc.wantInflation, inflation)
+		})
+	}
+}

--- a/x/incentive/keeper/querier_test.go
+++ b/x/incentive/keeper/querier_test.go
@@ -55,7 +55,7 @@ func (suite *QuerierTestSuite) TestGetStakingAPR() {
 			newFakePricefeedKeeper().
 				setPrice(
 					pricefeedtypes.NewCurrentPrice(
-						"ukava:usd:30",
+						"kava:usd:30",
 						sdk.MustNewDecFromStr("1.5"),
 					)),
 		).

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -74,7 +74,11 @@ func (suite *unitTester) NewKeeper(
 	ak types.AccountKeeper, stk types.StakingKeeper, swk types.SwapKeeper,
 	svk types.SavingsKeeper, lqk types.LiquidKeeper, ek types.EarnKeeper,
 ) keeper.Keeper {
-	return keeper.NewKeeper(suite.cdc, suite.incentiveStoreKey, paramSubspace, bk, cdpk, hk, ak, stk, swk, svk, lqk, ek)
+	return keeper.NewKeeper(
+		suite.cdc, suite.incentiveStoreKey, paramSubspace,
+		bk, cdpk, hk, ak, stk, swk, svk, lqk, ek,
+		nil, nil, nil,
+	)
 }
 
 func (suite *unitTester) storeGlobalBorrowIndexes(indexes types.MultiRewardIndexes) {

--- a/x/incentive/keeper/unit_test.go
+++ b/x/incentive/keeper/unit_test.go
@@ -77,7 +77,7 @@ func (suite *unitTester) NewKeeper(
 	return keeper.NewKeeper(
 		suite.cdc, suite.incentiveStoreKey, paramSubspace,
 		bk, cdpk, hk, ak, stk, swk, svk, lqk, ek,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 }
 
@@ -412,6 +412,15 @@ func (k *fakeEarnKeeper) GetVaultTotalShares(
 ) (shares earntypes.VaultShare, found bool) {
 	vaultShares, found := k.vaultShares[denom]
 	return vaultShares, found
+}
+
+func (k *fakeEarnKeeper) GetVaultTotalValue(ctx sdk.Context, denom string) (sdk.Coin, error) {
+	vaultShares, found := k.vaultShares[denom]
+	if !found {
+		return sdk.NewCoin(denom, sdk.ZeroInt()), nil
+	}
+
+	return sdk.NewCoin(denom, vaultShares.Amount.RoundInt()), nil
 }
 
 func (k *fakeEarnKeeper) GetVaultAccountShares(

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -3,11 +3,13 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	earntypes "github.com/kava-labs/kava/x/earn/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
+	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 	savingstypes "github.com/kava-labs/kava/x/savings/types"
 )
 
@@ -23,6 +25,7 @@ type ParamSubspace interface {
 type BankKeeper interface {
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	GetSupply(ctx sdk.Context, denom string) sdk.Coin
 }
 
 // StakingKeeper defines the expected staking keeper for module accounts
@@ -88,6 +91,21 @@ type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
 	GetModuleAccount(ctx sdk.Context, name string) authtypes.ModuleAccountI
+}
+
+// MintKeeper defines the required methods needed by this modules keeper
+type MintKeeper interface {
+	GetMinter(ctx sdk.Context) (minter minttypes.Minter)
+}
+
+// DistrKeeper defines the required methods needed by this modules keeper
+type DistrKeeper interface {
+	GetCommunityTax(ctx sdk.Context) (percent sdk.Dec)
+}
+
+// DistrKeeper defines the required methods needed by this modules keeper
+type KavadistKeeper interface {
+	GetParams(ctx sdk.Context) (params kavadisttypes.Params)
 }
 
 // CDPHooks event hooks for other keepers to run code in response to CDP modifications

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -9,7 +9,6 @@ import (
 	cdptypes "github.com/kava-labs/kava/x/cdp/types"
 	earntypes "github.com/kava-labs/kava/x/earn/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
-	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 	savingstypes "github.com/kava-labs/kava/x/savings/types"
 )
@@ -103,11 +102,6 @@ type MintKeeper interface {
 // DistrKeeper defines the required methods needed by this modules keeper
 type DistrKeeper interface {
 	GetCommunityTax(ctx sdk.Context) (percent sdk.Dec)
-}
-
-// KavadistKeeper defines the required methods needed by this modules keeper
-type KavadistKeeper interface {
-	GetParams(ctx sdk.Context) (params kavadisttypes.Params)
 }
 
 // PricefeedKeeper defines the required methods needed by this modules keeper

--- a/x/incentive/types/expected_keepers.go
+++ b/x/incentive/types/expected_keepers.go
@@ -10,6 +10,7 @@ import (
 	earntypes "github.com/kava-labs/kava/x/earn/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
+	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 	savingstypes "github.com/kava-labs/kava/x/savings/types"
 )
 
@@ -70,6 +71,7 @@ type SavingsKeeper interface {
 // EarnKeeper defines the required methods needed by this modules keeper
 type EarnKeeper interface {
 	GetVaultTotalShares(ctx sdk.Context, denom string) (shares earntypes.VaultShare, found bool)
+	GetVaultTotalValue(ctx sdk.Context, denom string) (sdk.Coin, error)
 	GetVaultAccountShares(ctx sdk.Context, acc sdk.AccAddress) (shares earntypes.VaultShares, found bool)
 	IterateVaultRecords(ctx sdk.Context, cb func(record earntypes.VaultRecord) (stop bool))
 }
@@ -103,9 +105,14 @@ type DistrKeeper interface {
 	GetCommunityTax(ctx sdk.Context) (percent sdk.Dec)
 }
 
-// DistrKeeper defines the required methods needed by this modules keeper
+// KavadistKeeper defines the required methods needed by this modules keeper
 type KavadistKeeper interface {
 	GetParams(ctx sdk.Context) (params kavadisttypes.Params)
+}
+
+// PricefeedKeeper defines the required methods needed by this modules keeper
+type PricefeedKeeper interface {
+	GetCurrentPrice(ctx sdk.Context, marketID string) (pricefeedtypes.CurrentPrice, error)
 }
 
 // CDPHooks event hooks for other keepers to run code in response to CDP modifications

--- a/x/incentive/types/querier.go
+++ b/x/incentive/types/querier.go
@@ -14,6 +14,7 @@ const (
 	QueryGetEarnRewards        = "earn-rewards"
 	QueryGetRewardFactors      = "reward-factors"
 	QueryGetParams             = "parameters"
+	QueryGetAPYs               = "apys"
 
 	RestClaimCollateralType = "collateral_type"
 	RestClaimOwner          = "owner"
@@ -62,5 +63,34 @@ func NewQueryGetRewardFactorsResponse(usdxMintingFactors RewardIndexes, supplyFa
 		SwapRewardFactors:        swapFactors,
 		SavingsRewardFactors:     savingsFactors,
 		EarnRewardFactors:        earnFactors,
+	}
+}
+
+// APY contains the APY for a given collateral type
+type APY struct {
+	CollateralType string  `json:"collateral_type" yaml:"collateral_type"`
+	APY            sdk.Dec `json:"apy" yaml:"apy"`
+}
+
+// NewAPY returns a new instance of APY
+func NewAPY(collateralType string, apy sdk.Dec) APY {
+	return APY{
+		CollateralType: collateralType,
+		APY:            apy,
+	}
+}
+
+// APYs is a slice of APY
+type APYs []APY
+
+// QueryGetAPYsResponse holds the response to a APY query
+type QueryGetAPYsResponse struct {
+	Earn []APY `json:"earn" yaml:"earn"`
+}
+
+// NewQueryGetAPYsResponse returns a new instance of QueryGetAPYsResponse
+func NewQueryGetAPYsResponse(earn []APY) QueryGetAPYsResponse {
+	return QueryGetAPYsResponse{
+		Earn: earn,
 	}
 }


### PR DESCRIPTION
Example response with bkava and usdc apy

```json
{
  "height": "168",
  "result": {
    "earn": [
      {
        "collateral_type": "bkava",
        "apy": "0.256254226277473541"
      },
      {
        "collateral_type": "ukava",
        "apy": "0.000000000000000000"
      },
      {
        "collateral_type": "usdx",
        "apy": "0.000000000000000000"
      },
      {
        "collateral_type": "erc20/multichain/usdc",
        "apy": "0.099981734400000000"
      }
    ]
  }
}
```