### PR TITLE
Fix high gas usage for coin conversions

### DIFF
--- a/x/evmutil/keeper/conversion_test.go
+++ b/x/evmutil/keeper/conversion_test.go
@@ -164,13 +164,17 @@ func (suite *ConversionTestSuite) TestConvertCoinToERC20() {
 	)
 	suite.Require().NoError(err)
 
+	// convert coin to erc20
+	ctx := suite.Ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	err = suite.Keeper.ConvertCoinToERC20(
-		suite.Ctx,
+		ctx,
 		originAcc,
 		recipientAcc,
 		sdk.NewCoin(pair.Denom, sdk.NewIntFromBigInt(amount)),
 	)
 	suite.Require().NoError(err)
+	suite.Require().LessOrEqual(ctx.GasMeter().GasConsumed(), uint64(500000))
+	suite.Require().GreaterOrEqual(ctx.GasMeter().GasConsumed(), uint64(50000))
 
 	// Source should decrease
 	bal := suite.App.GetBankKeeper().GetBalance(suite.Ctx, originAcc, pair.Denom)
@@ -279,15 +283,18 @@ func (suite *ConversionTestSuite) TestConvertERC20ToCoin() {
 	)
 	suite.Require().NoError(err)
 
+	ctx := suite.Ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	convertAmt := sdk.NewInt(50)
 	err = suite.Keeper.ConvertERC20ToCoin(
-		suite.Ctx,
+		ctx,
 		userEvmAddr,
 		userAddr,
 		pair.GetAddress(),
 		convertAmt,
 	)
 	suite.Require().NoError(err)
+	suite.Require().LessOrEqual(ctx.GasMeter().GasConsumed(), uint64(500000))
+	suite.Require().GreaterOrEqual(ctx.GasMeter().GasConsumed(), uint64(50000))
 
 	// bank balance should decrease
 	bal := suite.App.GetBankKeeper().GetBalance(suite.Ctx, userAddr, pair.Denom)

--- a/x/evmutil/keeper/evm.go
+++ b/x/evmutil/keeper/evm.go
@@ -125,11 +125,11 @@ func (k Keeper) CallEVMWithData(
 		return nil, err
 	}
 
-	ctx.GasMeter().ConsumeGas(res.GasUsed, "evm gas consumed")
-
 	if res.Failed() {
 		return nil, sdkerrors.Wrap(evmtypes.ErrVMExecution, res.VmError)
 	}
+
+	ctx.GasMeter().ConsumeGas(res.GasUsed, "evm gas consumed")
 
 	return res, nil
 }


### PR DESCRIPTION
Uses an infinite gas meter during evm gas estimation and apply message, then uses the evm response to charge gas.