### PR TITLE
kavadist module account migration

### DIFF
--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -168,7 +168,6 @@ func (suite *UpgradeTestSuite) TestAddKavadistFundAccount() {
 	dstk := suite.App.GetDistrKeeper()
 
 	communityCoinsBefore := dstk.GetFeePoolCommunityCoins(suite.Ctx)
-	suite.T().Logf("community coins before: %s", communityCoinsBefore)
 
 	acc := ak.NewAccountWithAddress(suite.Ctx, maccAddr)
 	ak.SetAccount(suite.Ctx, acc)
@@ -194,7 +193,6 @@ func (suite *UpgradeTestSuite) TestAddKavadistFundAccount() {
 	suite.Require().Implements((*authtypes.ModuleAccountI)(nil), acc)
 
 	communityCoinsAfter := dstk.GetFeePoolCommunityCoins(suite.Ctx)
-	suite.T().Logf("community coins after: %s", communityCoinsAfter)
 
 	suite.Equal(
 		communityCoinsBefore.Add(sdk.NewDecCoinsFromCoins(bal...)...),

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/kava-labs/kava/app"
+	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	etherminttypes "github.com/tharsis/ethermint/types"
@@ -158,4 +159,45 @@ func (suite *UpgradeTestSuite) TestConvertEOAsToBaseAccount() {
 	suite.Greater(accCount, 0)
 	suite.Greater(accCountAfter, 0)
 	suite.Equal(accCount, accCountAfter, "account count should be unchanged")
+}
+
+func (suite *UpgradeTestSuite) TestAddKavadistFundAccount() {
+	ak := suite.App.GetAccountKeeper()
+	maccAddr := ak.GetModuleAddress(kavadisttypes.FundModuleAccount)
+
+	dstk := suite.App.GetDistrKeeper()
+
+	communityCoinsBefore := dstk.GetFeePoolCommunityCoins(suite.Ctx)
+	suite.T().Logf("community coins before: %s", communityCoinsBefore)
+
+	acc := ak.NewAccountWithAddress(suite.Ctx, maccAddr)
+	ak.SetAccount(suite.Ctx, acc)
+
+	bal := sdk.NewCoins(sdk.NewCoin("ukava", sdk.NewInt(1000000000000)))
+	suite.App.FundAccount(suite.Ctx, maccAddr, bal)
+
+	// Ensure it is a module account prior to migration
+	acc = ak.GetAccount(suite.Ctx, maccAddr)
+	_, ok := acc.(authtypes.ModuleAccountI)
+	suite.Require().Falsef(ok, "account should not a ModuleAccount: %T", acc)
+
+	suite.Require().IsType(&authtypes.BaseAccount{}, acc)
+
+	app.AddKavadistFundAccount(
+		suite.Ctx,
+		ak,
+		suite.App.GetBankKeeper(),
+		dstk,
+	)
+
+	acc = ak.GetAccount(suite.Ctx, maccAddr)
+	suite.Require().Implements((*authtypes.ModuleAccountI)(nil), acc)
+
+	communityCoinsAfter := dstk.GetFeePoolCommunityCoins(suite.Ctx)
+	suite.T().Logf("community coins after: %s", communityCoinsAfter)
+
+	suite.Equal(
+		communityCoinsBefore.Add(sdk.NewDecCoinsFromCoins(bal...)...),
+		communityCoinsAfter,
+	)
 }

--- a/x/kavadist/genesis.go
+++ b/x/kavadist/genesis.go
@@ -27,6 +27,12 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, accountKeeper types.AccountKe
 	if moduleAcc == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.KavaDistMacc))
 	}
+
+	// check if the fund account exists
+	fundModuleAcc := accountKeeper.GetModuleAccount(ctx, types.FundModuleAccount)
+	if fundModuleAcc == nil {
+		panic(fmt.Sprintf("%s module account has not been set", types.FundModuleAccount))
+	}
 }
 
 // ExportGenesis export genesis state for cdp module


### PR DESCRIPTION
Instantiates new kavadist module account (kava1g655pg22nnhcsku4v3pe7mz9tzqj37rlej0jmn) as part of migration. As a security measure, checks that the account doesn't already exist as a non-module account and transfers the balance to the community pool. 