### PR TITLE
Fix allowed depositors for ukava earn vault

### DIFF
--- a/x/earn/types/genesis.go
+++ b/x/earn/types/genesis.go
@@ -3,7 +3,8 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 )
 
 // NewGenesisState creates a new genesis state.
@@ -46,7 +47,7 @@ func DefaultGenesisState() GenesisState {
 					"ukava",
 					StrategyTypes{STRATEGY_TYPE_SAVINGS},
 					true,
-					[]sdk.AccAddress{authtypes.NewModuleAddress(distrtypes.ModuleName)},
+					[]sdk.AccAddress{authtypes.NewModuleAddress(kavadisttypes.FundModuleAccount)},
 				),
 				// usdx
 				NewAllowedVault(


### PR DESCRIPTION
Depositing from community pool is intermediated by the `kavadist` `FundModuleAccount` (kava1g655pg22nnhcsku4v3pe7mz9tzqj37rlej0jmn).

Updates the default genesis state in earn to use that account for `allowed_depositors` to the `ukava` earn vault
