### PR TITLE
Remove usdx vault from initial earn vaults

### DIFF
--- a/x/earn/keeper/vault_share_test.go
+++ b/x/earn/keeper/vault_share_test.go
@@ -41,7 +41,6 @@ func (suite *vaultShareTestSuite) TestConvertToShares() {
 		},
 		{
 			name: "value doubled",
-
 			beforeConvert: func() {
 				// set total shares set total value for hard
 				// value is double than shares
@@ -73,6 +72,8 @@ func (suite *vaultShareTestSuite) TestConvertToShares() {
 				sdk.NewCoins(sdk.NewInt64Coin(vaultDenom, 10000)),
 			)
 			suite.Require().NoError(err)
+
+			suite.CreateVault(vaultDenom, types.StrategyTypes{types.STRATEGY_TYPE_HARD}, false, nil)
 
 			// Run any deposits or any other setup
 			tt.beforeConvert()

--- a/x/earn/types/genesis.go
+++ b/x/earn/types/genesis.go
@@ -49,13 +49,6 @@ func DefaultGenesisState() GenesisState {
 					true,
 					[]sdk.AccAddress{authtypes.NewModuleAddress(kavadisttypes.FundModuleAccount)},
 				),
-				// usdx
-				NewAllowedVault(
-					"usdx",
-					StrategyTypes{STRATEGY_TYPE_HARD},
-					false,
-					[]sdk.AccAddress{},
-				),
 				NewAllowedVault(
 					"bkava",
 					StrategyTypes{STRATEGY_TYPE_SAVINGS},


### PR DESCRIPTION
Due to missing hard incentive redistribution, removed until incentives are implemented.