### PR TITLE
Remove embedded json EOA EthAccounts to BaseAccount conversion

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 
@@ -103,9 +102,6 @@ func UpdateEvmutilPermissions(ctx sdk.Context, accountKeeper authkeeper.AccountK
 	}
 	accountKeeper.SetModuleAccount(ctx, evmutilAcc)
 }
-
-//go:embed eth_eoa_addresses.json
-var ethEOAAddresses []byte
 
 func IterateEOAAddresses(f func(addr string)) {
 	var addresses []string

--- a/app/upgrades_eoa_addresses.go
+++ b/app/upgrades_eoa_addresses.go
@@ -1,4 +1,6 @@
-[
+package app
+
+var ethEOAAddresses = []byte(`[
   "kava1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpjqqhvg",
   "kava1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzun4pzh",
   "kava1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrp9p5l9",
@@ -33142,4 +33144,4 @@
   "kava1lll2wh9a0wkumhz5wdxu9jzd64slupzemgwzxv",
   "kava1lllsq67nkf8gt299v0duxkahqcacgaxz6qp2s4",
   "kava1llleudw5lun6ucm3z9fv6xnp65tndy0eeauu6f"
-]
+]`)


### PR DESCRIPTION
Follow up of #1326

Removes the need of the embed package and just uses a go file.