### PR TITLE
Releases/public testnet v0.19.5 testnet

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -8,11 +8,10 @@ import (
 	bankKeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
 	kavadisttypes "github.com/kava-labs/kava/x/kavadist/types"
 )
 
-const UpgradeName = "v0.19.4-testnet"
+const UpgradeName = "v0.19.5-testnet"
 
 func (app App) RegisterUpgradeHandlers() {
 	app.upgradeKeeper.SetUpgradeHandler(UpgradeName,
@@ -21,18 +20,6 @@ func (app App) RegisterUpgradeHandlers() {
 			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 		},
 	)
-}
-
-func UpdateEvmutilPermissions(ctx sdk.Context, accountKeeper authkeeper.AccountKeeper) {
-	// add minter and burner permissions to evmutil
-	evmutilAcc, ok := accountKeeper.GetModuleAccount(ctx, evmutiltypes.ModuleName).(*authtypes.ModuleAccount)
-	if !ok {
-		panic("unable to fetch evmutil module account")
-	}
-	evmutilAcc.Permissions = []string{
-		authtypes.Minter, authtypes.Burner,
-	}
-	accountKeeper.SetModuleAccount(ctx, evmutilAcc)
 }
 
 func AddKavadistFundAccount(ctx sdk.Context, accountKeeper authkeeper.AccountKeeper, bankKeeper bankKeeper.Keeper, distKeeper distrkeeper.Keeper) {

--- a/x/earn/keeper/deposit.go
+++ b/x/earn/keeper/deposit.go
@@ -79,8 +79,8 @@ func (k *Keeper) Deposit(
 
 	isNew := vaultShareRecord.Shares.AmountOf(amount.Denom).IsZero()
 	if !isNew {
-		// If deposits for this vault already exists
-		k.BeforeVaultDepositModified(ctx, amount.Denom, depositor, vaultRecord.TotalShares.Amount)
+		// If deposits for this vault already exists, call hook with user's existing shares
+		k.BeforeVaultDepositModified(ctx, amount.Denom, depositor, vaultShareRecord.Shares.AmountOf(amount.Denom))
 	}
 
 	// Increment VaultRecord total shares and account shares

--- a/x/earn/keeper/hooks_test.go
+++ b/x/earn/keeper/hooks_test.go
@@ -32,8 +32,11 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 
 	vault1Denom := "usdx"
 	vault2Denom := "ukava"
-	deposit1Amount := sdk.NewInt64Coin(vault1Denom, 100)
-	deposit2Amount := sdk.NewInt64Coin(vault2Denom, 100)
+	acc1deposit1Amount := sdk.NewInt64Coin(vault1Denom, 100)
+	acc1deposit2Amount := sdk.NewInt64Coin(vault2Denom, 200)
+
+	acc2deposit1Amount := sdk.NewInt64Coin(vault1Denom, 200)
+	acc2deposit2Amount := sdk.NewInt64Coin(vault2Denom, 300)
 
 	suite.CreateVault(vault1Denom, types.StrategyTypes{types.STRATEGY_TYPE_HARD}, false, nil)
 	suite.CreateVault(vault2Denom, types.StrategyTypes{types.STRATEGY_TYPE_SAVINGS}, false, nil)
@@ -53,14 +56,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"AfterVaultDepositCreated",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc1deposit1Amount.Denom,
 		acc.GetAddress(),
-		deposit1Amount.Amount.ToDec(),
+		acc1deposit1Amount.Amount.ToDec(),
 	).Once()
 	err := suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit1Amount,
+		acc1deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -70,14 +73,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc1deposit1Amount.Denom,
 		acc.GetAddress(),
-		deposit1Amount.Amount.ToDec(),
+		acc1deposit1Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit1Amount,
+		acc1deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -94,14 +97,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc1deposit1Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit1Amount.Denom),
+		shareRecord.AmountOf(acc1deposit1Amount.Denom),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit1Amount,
+		acc1deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -110,14 +113,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"AfterVaultDepositCreated",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		deposit2Amount.Amount.ToDec(),
+		acc1deposit2Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -126,14 +129,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		deposit2Amount.Amount.ToDec(),
+		acc1deposit2Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -149,14 +152,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit2Amount.Denom),
+		shareRecord.AmountOf(acc1deposit2Amount.Denom),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -169,14 +172,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"AfterVaultDepositCreated",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc2deposit1Amount.Denom,
 		acc2.GetAddress(),
-		deposit1Amount.Amount.ToDec(),
+		acc2deposit1Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit1Amount,
+		acc2deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -187,14 +190,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc2deposit1Amount.Denom,
 		acc2.GetAddress(),
-		deposit1Amount.Amount.ToDec(),
+		acc2deposit1Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit1Amount,
+		acc2deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -211,14 +214,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc2deposit1Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord2.AmountOf(deposit1Amount.Denom),
+		shareRecord2.AmountOf(acc2deposit1Amount.Denom),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit1Amount,
+		acc2deposit1Amount,
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -227,14 +230,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"AfterVaultDepositCreated",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		deposit2Amount.Amount.ToDec(),
+		acc2deposit2Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -243,14 +246,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		deposit2Amount.Amount.ToDec(),
+		acc2deposit2Amount.Amount.ToDec(),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -266,14 +269,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord2.AmountOf(deposit2Amount.Denom),
+		shareRecord2.AmountOf(acc2deposit2Amount.Denom),
 	).Once()
 	err = suite.Keeper.Deposit(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -290,15 +293,15 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc1deposit1Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit1Amount.Denom),
+		shareRecord.AmountOf(acc1deposit1Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc.GetAddress(),
 		// 3 deposits, multiply original deposit amount by 3
-		sdk.NewCoin(deposit1Amount.Denom, deposit1Amount.Amount.MulRaw(3)),
+		sdk.NewCoin(acc1deposit1Amount.Denom, acc1deposit1Amount.Amount.MulRaw(3)),
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -314,14 +317,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit2Amount.Denom),
+		shareRecord.AmountOf(acc1deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -337,14 +340,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit2Amount.Denom),
+		shareRecord.AmountOf(acc1deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -360,14 +363,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc1deposit2Amount.Denom,
 		acc.GetAddress(),
-		shareRecord.AmountOf(deposit2Amount.Denom),
+		shareRecord.AmountOf(acc1deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc.GetAddress(),
-		deposit2Amount,
+		acc1deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -386,15 +389,15 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit1Amount.Denom,
+		acc2deposit1Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord.AmountOf(deposit1Amount.Denom),
+		shareRecord.AmountOf(acc2deposit1Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc2.GetAddress(),
 		// 3 deposits, multiply original deposit amount by 3
-		sdk.NewCoin(deposit1Amount.Denom, deposit1Amount.Amount.MulRaw(3)),
+		sdk.NewCoin(acc2deposit1Amount.Denom, acc2deposit1Amount.Amount.MulRaw(3)),
 		types.STRATEGY_TYPE_HARD,
 	)
 	suite.Require().NoError(err)
@@ -410,14 +413,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord2.AmountOf(deposit2Amount.Denom),
+		shareRecord2.AmountOf(acc2deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -433,14 +436,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord2.AmountOf(deposit2Amount.Denom),
+		shareRecord2.AmountOf(acc2deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)
@@ -456,14 +459,14 @@ func (suite *hookTestSuite) TestHooks_DepositAndWithdraw() {
 	earnHooks.On(
 		"BeforeVaultDepositModified",
 		suite.Ctx,
-		deposit2Amount.Denom,
+		acc2deposit2Amount.Denom,
 		acc2.GetAddress(),
-		shareRecord2.AmountOf(deposit2Amount.Denom),
+		shareRecord2.AmountOf(acc2deposit2Amount.Denom),
 	).Once()
 	_, err = suite.Keeper.Withdraw(
 		suite.Ctx,
 		acc2.GetAddress(),
-		deposit2Amount,
+		acc2deposit2Amount,
 		types.STRATEGY_TYPE_SAVINGS,
 	)
 	suite.Require().NoError(err)

--- a/x/earn/keeper/withdraw.go
+++ b/x/earn/keeper/withdraw.go
@@ -126,8 +126,8 @@ func (k *Keeper) Withdraw(
 		withdrawShares = vaultShareRecord.Shares.GetShare(withdrawAmount.Denom)
 	}
 
-	// Call hook before record is modified
-	k.BeforeVaultDepositModified(ctx, wantAmount.Denom, from, vaultRecord.TotalShares.Amount)
+	// Call hook before record is modified with the user's current shares
+	k.BeforeVaultDepositModified(ctx, wantAmount.Denom, from, accCurrentShares)
 
 	// Decrement VaultRecord and VaultShareRecord supplies - must delete same
 	// amounts

--- a/x/incentive/keeper/msg_server_earn_test.go
+++ b/x/incentive/keeper/msg_server_earn_test.go
@@ -1,0 +1,172 @@
+package keeper_test
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	earntypes "github.com/kava-labs/kava/x/earn/types"
+	"github.com/kava-labs/kava/x/incentive/testutil"
+	"github.com/kava-labs/kava/x/incentive/types"
+	liquidtypes "github.com/kava-labs/kava/x/liquid/types"
+)
+
+func (suite *HandlerTestSuite) TestEarnLiquidClaim() {
+	userAddr1, userAddr2, validatorAddr1, validatorAddr2 := suite.addrs[0], suite.addrs[1], suite.addrs[2], suite.addrs[3]
+	valAddr1 := sdk.ValAddress(validatorAddr1)
+	valAddr2 := sdk.ValAddress(validatorAddr2)
+
+	bkavaDenom1 := fmt.Sprintf("bkava-%s", valAddr1.String())
+	bkavaDenom2 := fmt.Sprintf("bkava-%s", valAddr2.String())
+
+	authBuilder := suite.authBuilder().
+		WithSimpleAccount(userAddr1, cs(c("ukava", 1e12))).
+		WithSimpleAccount(userAddr2, cs(c("ukava", 1e12))).
+		WithSimpleAccount(validatorAddr1, cs(c("ukava", 1e12))).
+		WithSimpleAccount(validatorAddr2, cs(c("ukava", 1e12)))
+
+	incentBuilder := suite.incentiveBuilder()
+
+	savingsBuilder := testutil.NewSavingsGenesisBuilder().
+		WithSupportedDenoms("bkava")
+
+	earnBuilder := suite.earnBuilder().
+		WithVault(earntypes.AllowedVault{
+			Denom:             "bkava",
+			Strategies:        earntypes.StrategyTypes{earntypes.STRATEGY_TYPE_SAVINGS},
+			IsPrivateVault:    false,
+			AllowedDepositors: nil,
+		})
+
+	suite.SetupWithGenState(authBuilder, incentBuilder, earnBuilder, savingsBuilder)
+
+	err := suite.App.FundModuleAccount(suite.Ctx, distrtypes.ModuleName, cs(c("ukava", 1e12)))
+	suite.NoError(err)
+
+	// Create validators
+	err = suite.DeliverMsgCreateValidator(valAddr1, c("ukava", 1e9))
+	suite.Require().NoError(err)
+
+	err = suite.DeliverMsgCreateValidator(valAddr2, c("ukava", 1e9))
+	suite.Require().NoError(err)
+
+	// new block required to bond validator
+	suite.NextBlockAfter(7 * time.Second)
+	// Now the delegation is bonded, accumulate some delegator rewards
+	suite.NextBlockAfter(7 * time.Second)
+
+	// Create delegations from users
+	// User 1: 1e9 ukava to validator 1
+	// User 2: 99e9 ukava to validator 1 AND 2
+	err = suite.DeliverMsgDelegate(userAddr1, valAddr1, c("ukava", 1e9))
+	suite.Require().NoError(err)
+
+	err = suite.DeliverMsgDelegate(userAddr2, valAddr1, c("ukava", 99e9))
+	suite.Require().NoError(err)
+
+	err = suite.DeliverMsgDelegate(userAddr2, valAddr2, c("ukava", 99e9))
+	suite.Require().NoError(err)
+
+	// Mint liquid tokens
+	err = suite.DeliverMsgMintDerivative(userAddr1, valAddr1, c("ukava", 1e9))
+	suite.Require().NoError(err)
+
+	err = suite.DeliverMsgMintDerivative(userAddr2, valAddr1, c("ukava", 99e9))
+	suite.Require().NoError(err)
+
+	err = suite.DeliverMsgMintDerivative(userAddr2, valAddr2, c("ukava", 99e9))
+	suite.Require().NoError(err)
+
+	// Deposit liquid tokens to earn
+	err = suite.DeliverEarnMsgDeposit(userAddr1, c(bkavaDenom1, 1e9), earntypes.STRATEGY_TYPE_SAVINGS)
+	suite.Require().NoError(err)
+
+	err = suite.DeliverEarnMsgDeposit(userAddr2, c(bkavaDenom1, 99e9), earntypes.STRATEGY_TYPE_SAVINGS)
+	suite.Require().NoError(err)
+	err = suite.DeliverEarnMsgDeposit(userAddr2, c(bkavaDenom2, 99e9), earntypes.STRATEGY_TYPE_SAVINGS)
+	suite.Require().NoError(err)
+
+	// Accumulate some staking rewards
+	// _ = suite.App.EndBlocker(suite.Ctx, abci.RequestEndBlock{})
+	// suite.Ctx = suite.Ctx.WithBlockTime(time.Now().Add(1 * time.Hour))
+	// suite.App.BeginBlocker(suite.Ctx, abci.RequestBeginBlock{})
+	sk := suite.App.GetStakingKeeper()
+	dk := suite.App.GetDistrKeeper()
+	ik := suite.App.GetIncentiveKeeper()
+
+	rewardCoins := sdk.NewDecCoins(sdk.NewDecCoin("ukava", sdk.NewInt(500e6)))
+	validator1, found := sk.GetValidator(suite.Ctx, valAddr1)
+	suite.Require().True(found)
+
+	dk.AllocateTokensToValidator(suite.Ctx, validator1, rewardCoins)
+
+	liquidMacc := suite.App.GetAccountKeeper().GetModuleAccount(suite.Ctx, liquidtypes.ModuleAccountName)
+	delegation, found := sk.GetDelegation(suite.Ctx, liquidMacc.GetAddress(), valAddr1)
+	suite.Require().True(found)
+
+	suite.Ctx = suite.Ctx.WithBlockHeight(100).
+		WithBlockTime(suite.Ctx.BlockTime().Add(1 * time.Hour))
+
+	// Get amount of rewards
+	endingPeriod := dk.IncrementValidatorPeriod(suite.Ctx, validator1)
+	delegationRewards := dk.CalculateDelegationRewards(suite.Ctx, validator1, delegation, endingPeriod)
+
+	suite.T().Logf("Rewards: %s", delegationRewards.String())
+
+	// Accumulate rewards - claim rewards
+	rewardPeriod := types.NewMultiRewardPeriod(
+		true,
+		"bkava",         // reward period is set for "bkava" to apply to all vaults
+		time.Unix(0, 0), // ensure the test is within start and end times
+		distantFuture,
+		cs(), // no incentives, so only the staking rewards are distributed
+	)
+	err = ik.AccumulateEarnRewards(suite.Ctx, rewardPeriod)
+	suite.Require().NoError(err)
+
+	preClaimBal1 := suite.GetBalance(userAddr1)
+	preClaimBal2 := suite.GetBalance(userAddr2)
+
+	// Claim ukava staking rewards
+	denomsToClaim := map[string]string{"ukava": "large"}
+	selections := types.NewSelectionsFromMap(denomsToClaim)
+
+	msg1 := types.NewMsgClaimEarnReward(userAddr1.String(), selections)
+	err = suite.DeliverIncentiveMsg(&msg1)
+	suite.Require().NoError(err)
+
+	msg2 := types.NewMsgClaimEarnReward(userAddr2.String(), selections)
+	err = suite.DeliverIncentiveMsg(&msg2)
+	suite.Require().NoError(err)
+
+	// Check rewards were paid out
+	// User 1 gets 1% of rewards
+	// User 2 gets 99% of rewards
+	stakingRewards1 := delegationRewards.
+		AmountOf("ukava").
+		QuoInt64(100).
+		TruncateInt()
+	suite.BalanceEquals(userAddr1, preClaimBal1.Add(sdk.NewCoin("ukava", stakingRewards1)))
+
+	// Total * 99 / 100
+	stakingRewards2 := delegationRewards.
+		AmountOf("ukava").
+		MulInt64(99).
+		QuoInt64(100).
+		TruncateInt()
+	suite.BalanceEquals(userAddr2, preClaimBal2.Add(sdk.NewCoin("ukava", stakingRewards2)))
+
+	suite.Equal(delegationRewards.AmountOf("ukava").TruncateInt(), stakingRewards1.Add(stakingRewards2))
+
+	// Check that claimed coins have been removed from a claim's reward
+	suite.EarnRewardEquals(userAddr1, cs())
+	suite.EarnRewardEquals(userAddr2, cs())
+}
+
+// earnBuilder returns a new earn genesis builder with a genesis time and multipliers set
+func (suite *HandlerTestSuite) earnBuilder() testutil.EarnGenesisBuilder {
+	return testutil.NewEarnGenesisBuilder().
+		WithGenesisTime(suite.genesisTime)
+}

--- a/x/incentive/keeper/msg_server_earn_test.go
+++ b/x/incentive/keeper/msg_server_earn_test.go
@@ -113,8 +113,6 @@ func (suite *HandlerTestSuite) TestEarnLiquidClaim() {
 	endingPeriod := dk.IncrementValidatorPeriod(suite.Ctx, validator1)
 	delegationRewards := dk.CalculateDelegationRewards(suite.Ctx, validator1, delegation, endingPeriod)
 
-	suite.T().Logf("Rewards: %s", delegationRewards.String())
-
 	// Accumulate rewards - claim rewards
 	rewardPeriod := types.NewMultiRewardPeriod(
 		true,

--- a/x/incentive/testutil/builder.go
+++ b/x/incentive/testutil/builder.go
@@ -7,8 +7,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/app"
+	earntypes "github.com/kava-labs/kava/x/earn/types"
 	hardtypes "github.com/kava-labs/kava/x/hard/types"
 	"github.com/kava-labs/kava/x/incentive/types"
+	savingstypes "github.com/kava-labs/kava/x/savings/types"
 )
 
 const (
@@ -168,6 +170,24 @@ func (builder IncentiveGenesisBuilder) WithSimpleUSDXRewardPeriod(ctype string, 
 	))
 }
 
+// WithInitializedEarnRewardPeriod sets the genesis time as the previous accumulation time for the specified period.
+// This can be helpful in tests. With no prev time set, the first block accrues no rewards as it just sets the prev time to the current.
+func (builder IncentiveGenesisBuilder) WithInitializedEarnRewardPeriod(period types.MultiRewardPeriod) IncentiveGenesisBuilder {
+	builder.Params.EarnRewardPeriods = append(builder.Params.EarnRewardPeriods, period)
+
+	accumulationTimeForPeriod := types.NewAccumulationTime(period.CollateralType, builder.genesisTime)
+	builder.EarnRewardState.AccumulationTimes = append(
+		builder.EarnRewardState.AccumulationTimes,
+		accumulationTimeForPeriod,
+	)
+
+	return builder
+}
+
+func (builder IncentiveGenesisBuilder) WithSimpleEarnRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) IncentiveGenesisBuilder {
+	return builder.WithInitializedEarnRewardPeriod(builder.simpleRewardPeriod(ctype, rewardsPerSecond))
+}
+
 func (builder IncentiveGenesisBuilder) WithMultipliers(multipliers types.MultipliersPerDenoms) IncentiveGenesisBuilder {
 	builder.Params.ClaimMultipliers = multipliers
 
@@ -280,4 +300,76 @@ func (builder IncentiveGenesisBuilder) WithInitializedSavingsRewardPeriod(period
 
 func (builder IncentiveGenesisBuilder) WithSimpleSavingsRewardPeriod(ctype string, rewardsPerSecond sdk.Coins) IncentiveGenesisBuilder {
 	return builder.WithInitializedSavingsRewardPeriod(builder.simpleRewardPeriod(ctype, rewardsPerSecond))
+}
+
+// EarnGenesisBuilder is a tool for creating a earn genesis state.
+// Helper methods add values onto a default genesis state.
+// All methods are immutable and return updated copies of the builder.
+type EarnGenesisBuilder struct {
+	earntypes.GenesisState
+	genesisTime time.Time
+}
+
+func NewEarnGenesisBuilder() EarnGenesisBuilder {
+	return EarnGenesisBuilder{
+		GenesisState: earntypes.DefaultGenesisState(),
+	}
+}
+
+func (builder EarnGenesisBuilder) Build() earntypes.GenesisState {
+	return builder.GenesisState
+}
+
+func (builder EarnGenesisBuilder) BuildMarshalled(cdc codec.JSONCodec) app.GenesisState {
+	built := builder.Build()
+
+	return app.GenesisState{
+		earntypes.ModuleName: cdc.MustMarshalJSON(&built),
+	}
+}
+
+func (builder EarnGenesisBuilder) WithGenesisTime(genTime time.Time) EarnGenesisBuilder {
+	builder.genesisTime = genTime
+	return builder
+}
+
+func (builder EarnGenesisBuilder) WithVault(vault earntypes.AllowedVault) EarnGenesisBuilder {
+	builder.Params.AllowedVaults = append(builder.Params.AllowedVaults, vault)
+	return builder
+}
+
+// SavingsGenesisBuilder is a tool for creating a savings genesis state.
+// Helper methods add values onto a default genesis state.
+// All methods are immutable and return updated copies of the builder.
+type SavingsGenesisBuilder struct {
+	savingstypes.GenesisState
+	genesisTime time.Time
+}
+
+func NewSavingsGenesisBuilder() SavingsGenesisBuilder {
+	return SavingsGenesisBuilder{
+		GenesisState: savingstypes.DefaultGenesisState(),
+	}
+}
+
+func (builder SavingsGenesisBuilder) Build() savingstypes.GenesisState {
+	return builder.GenesisState
+}
+
+func (builder SavingsGenesisBuilder) BuildMarshalled(cdc codec.JSONCodec) app.GenesisState {
+	built := builder.Build()
+
+	return app.GenesisState{
+		savingstypes.ModuleName: cdc.MustMarshalJSON(&built),
+	}
+}
+
+func (builder SavingsGenesisBuilder) WithGenesisTime(genTime time.Time) SavingsGenesisBuilder {
+	builder.genesisTime = genTime
+	return builder
+}
+
+func (builder SavingsGenesisBuilder) WithSupportedDenoms(denoms ...string) SavingsGenesisBuilder {
+	builder.Params.SupportedDenoms = append(builder.Params.SupportedDenoms, denoms...)
+	return builder
 }

--- a/x/liquid/keeper/claim.go
+++ b/x/liquid/keeper/claim.go
@@ -26,11 +26,15 @@ func (k Keeper) CollectStakingRewards(
 
 	rewards, err := k.distributionKeeper.WithdrawDelegationRewards(ctx, macc.GetAddress(), validator)
 	if err != nil {
+		fmt.Printf("FAILED to withdraw delegation rewards %s: %s\n", destinationModAccount, err)
 		return nil, err
 	}
 
+	fmt.Printf("sending %v rewards from liquid to %s\n", rewards, destinationModAccount)
+
 	err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleAccountName, destinationModAccount, rewards)
 	if err != nil {
+		fmt.Printf("FAILED to send %v rewards from liquid to %s: %s\n", rewards, destinationModAccount, err)
 		return nil, err
 	}
 

--- a/x/liquid/keeper/claim.go
+++ b/x/liquid/keeper/claim.go
@@ -26,15 +26,11 @@ func (k Keeper) CollectStakingRewards(
 
 	rewards, err := k.distributionKeeper.WithdrawDelegationRewards(ctx, macc.GetAddress(), validator)
 	if err != nil {
-		fmt.Printf("FAILED to withdraw delegation rewards %s: %s\n", destinationModAccount, err)
 		return nil, err
 	}
 
-	fmt.Printf("sending %v rewards from liquid to %s\n", rewards, destinationModAccount)
-
 	err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleAccountName, destinationModAccount, rewards)
 	if err != nil {
-		fmt.Printf("FAILED to send %v rewards from liquid to %s: %s\n", rewards, destinationModAccount, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Tested PR by:
- [exporting genesis from a testnet-16000 node](https://kava-archives-testing.s3.us-west-1.amazonaws.com/1662674055-testnet-16000-genesis.json)
- starting a local validator with this [private key](https://kava-archives-testing.s3.us-west-1.amazonaws.com/priv_validator_key.json) and chain based off a [modified version of the current testnet-16000 genesis](https://kava-archives-testing.s3.us-west-1.amazonaws.com/kava-16-local-validator-genesis.json) using kava built from `v0.19.4-testnet` and hardcoding app.go to schedule an upgrade
- verifying chain stops at upgrade height
- restarting the local validator after re-building kava using this branch
- verifying upgrade is triggered and completes without error
```bash
4:15PM INF ABCI Handshake App Info hash="\tm!\x14��A�o�Z\x02g\"ɔ�\x18kѿ�'[\x00z��x�W�" height=1 module=consensus protocol-version=0 server=node software-version=0.19.4-testnet-24-g11255186
4:15PM INF ABCI Replay Blocks appHeight=1 module=consensus server=node stateHeight=1 storeHeight=2
4:15PM INF Replay last block using real app module=consensus server=node
4:15PM INF applying upgrade "v0.19.5-testnet" at height: 2
4:15PM INF minted coins from module account amount=15859177782358ukava from=mint module=x/bank
4:15PM INF executed block height=2 module=consensus num_invalid_txs=0 num_valid_txs=0 server=node
```
- exporting genesis after upgrade and spot checking migration paths