### PR TITLE
Fix: install protoc-gen-doc

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -15,6 +15,7 @@ protoc_gen_gocosmos() {
 
 protoc_gen_doc() {
   go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc 2>/dev/null
+  go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 }
 
 cp go.mod go.mod.bak


### PR DESCRIPTION
After the recent update to proto generation https://github.com/Kava-Labs/kava/pull/1362, `Make proto-all` didn't work for me locally.
Looks like the newly added `protoc-gen-doc` tool wasn't being installed.
I think the problem is with go 1.18 `go get` not longer builds or installs anything (mentioned at the bottom of this section: https://go.dev/ref/mod#go-get).
I added a `go install ...` line to install the package. Without a version suffix this uses the local go.mod for decide dependency versions. If we don't care about that I think we can remove the `go get` line and add a version suffix to `go install`.