### PR TITLE
Document kavadist infra rewards in the module spec

### DIFF
--- a/x/kavadist/spec/01_concepts.md
+++ b/x/kavadist/spec/01_concepts.md
@@ -5,3 +5,5 @@ order: 1
 # Concepts
 
 The minting mechanism in this module is designed to allow governance to determine a set of inflationary periods and the APR rate of inflation for each period. This module mints coins each block according to the schedule such that after 1 year the APR inflation worth of coins will have been minted. Governance can alter the APR inflation using a parameter change proposal. Parameter change proposals that change the APR will take effect in the block after they pass.
+
+Additionally this module has parameters defining an inflationary period for minting rewards to a governance-specified list of infrastructure partners. Governance can alter the inflationary period and infrastructure reward distribution using a parameter change proposal. Parameter changes that change the distribution or inflationary period take effect the block after they pass.

--- a/x/kavadist/spec/05_params.md
+++ b/x/kavadist/spec/05_params.md
@@ -6,14 +6,38 @@ order: 5
 
 The kavadist module has the following parameters:
 
-| Key        | Type           | Example       | Description                                      |
-|------------|----------------|---------------|--------------------------------------------------|
-| Periods    | array (Period) | [{see below}] | array of params for each inflationary period     |
+| Key                  | Type                 | Example       | Description                                              |
+| -------------------- | -------------------- | ------------- | -------------------------------------------------------- |
+| Active               | bool                 | true          | an all-or-nothing toggle of token minting in this module |
+| Periods              | array (Period)       | [{see below}] | array of params for each inflationary period             |
+| InfrastructureParams | InfrastructureParams | [{see below}] | object containing infrastructure partner payout params   |
+
+`InfrastructureParams` has the following parameters
+
+| Key                   | Type                  | Example       | Description                                                 |
+| --------------------- | --------------------- | ------------- | ----------------------------------------------------------- |
+| InfrastructurePeriods | array (Period)        | [{see below}] | array of params for each inflationary period                |
+| CoreRewards           | array (CoreReward)    | [{see below}] | array of params for reward weights for core infra providers |
+| PartnerRewards        | array (PartnerReward) | [{see below}] | array of params for infrastructure partner reward schedules |
 
 Each `Period` has the following parameters
 
-| Key        | Type               | Example                  | Description                                                    |
-|------------|--------------------|--------------------------|----------------------------------------------------------------|
-| Start      | time.Time          | "2020-03-01T15:20:00Z"   | the time when the period will start                            |
-| End        | time.Time          | "2020-06-01T15:20:00Z"   | the time when the period will end                              |
-| Inflation  | sdk.Dec            | "1.000000003022265980"   | the per-second inflation for the period                        |
+| Key       | Type      | Example                | Description                             |
+| --------- | --------- | ---------------------- | --------------------------------------- |
+| Start     | time.Time | "2020-03-01T15:20:00Z" | the time when the period will start     |
+| End       | time.Time | "2020-06-01T15:20:00Z" | the time when the period will end       |
+| Inflation | sdk.Dec   | "1.000000003022265980" | the per-second inflation for the period |
+
+Each `CoreReward` has the following properties
+
+| Key     | Type           | Example                                       | Description                                              |
+| ------- | -------------- | --------------------------------------------- | -------------------------------------------------------- |
+| Address | sdk.AccAddress | "kava1x07eng0q9027j7wayap8nvqegpf625uu0w90tq" | address of core infrastructure provider                  |
+| Weight  | sdk.Dec        | "0.912345678907654321"                        | % of remaining minted rewards allocated to this provider |
+
+Each `PartnerReward` has the following properties
+
+| Key              | Type           | Example                                       | Description                        |
+| ---------------- | -------------- | --------------------------------------------- | ---------------------------------- |
+| Address          | sdk.AccAddress | "kava1x0cztstumgcfrw69s5nd5qtu9vdcg7alqtyhgr" | address of infrastructure partner  |
+| RewardsPerSecond | object (coin)  | {"denom": "ukava", "amount": "1285" }         | per second reward for this partner |

--- a/x/kavadist/spec/06_begin_block.md
+++ b/x/kavadist/spec/06_begin_block.md
@@ -14,3 +14,17 @@ At the start of each block, the inflationary coins for the ongoing period, if an
     }
   }
 ```
+
+## Inflationary Coin Minting
+
+The `MintPeriodInflation` method mints inflationary coins for the two schedules defined in the parameters when `params.Active` is `true`. Coins are minted based off the number of seconds passed since the last block. When `params.Active` is `false`, the method is a no-op.
+
+Firstly, it mints coins at a per second rate derived from `params.Periods`. The coins are minted into `x/kavadist`'s module account.
+
+Next, it mints coins for infrastructure partner rewards at a per second rate derived from `params.InfrastructureParams.InfrastructurePeriods`. The coins are minted to the module account but are then immediately distributed to the infrastructure partners.
+
+## Infrastructure Partner Reward Distribution
+
+The coins minted for the `InfrastructurePeriods` are distributed as follows:
+* A distribution is made to each of the infrastructure partners based on the number of seconds since the last distribution for each of the defined `params.InfrastructureParams.PartnerRewards`.
+* The remaining coins are distributed to the core infrastructure providers by the weights defined in `params.InfrastructureParams.CoreRewards`.

--- a/x/kavadist/spec/README.md
+++ b/x/kavadist/spec/README.md
@@ -17,4 +17,4 @@ parent:
 
 ## Abstract
 
-`x/kavadist` is an implementation of a Cosmos SDK Module that allows for governance controlled minting of coins into a module account. Coins are minted during inflationary periods, which each period have a governance specified APR and duration. This module does not provide functionality for spending or distributing the minted coins.
+`x/kavadist` is an implementation of a Cosmos SDK Module that allows for governance controlled minting of coins into a module account. Coins are minted during inflationary periods, for which each period has a governance specified APR and duration. Additionally, coin rewards for governance specified infrastructure partners are minted and distributed.


### PR DESCRIPTION
adds some missing parameters and documentation to the `x/kavadist` module spec.