### PR TITLE
Add source adapter interface definition

### DIFF
--- a/x/incentive/types/adapter.go
+++ b/x/incentive/types/adapter.go
@@ -1,0 +1,17 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// SourceAdapter provides source shares from an external module.
+type SourceAdapter interface {
+	// GetShares returns source shares owned by one address.
+	//
+	// For example, the shares a user owns in the kava:usdx and bnb:usdx swap pools.
+	// It returns the shares for several sources at once, in the same order as the sourceIDs. Specifying no sourceIDS will return no shares.
+	GetShares(ctx sdk.Context, owner sdk.AccAddress, sourceIDs []string) []sdk.Dec
+
+	// GetTotalShares returns the sum of all shares for a source (across all users).
+	//
+	// For example, the total number of shares in the kava:usdx swap pool for all users.
+	GetTotalShares(ctx sdk.Context, sourceID string) sdk.Dec
+}

--- a/x/incentive/types/adapter.go
+++ b/x/incentive/types/adapter.go
@@ -2,16 +2,16 @@ package types
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
-// SourceAdapter provides source shares from an external module.
+// SourceAdapter queries source shares from an external module.
 type SourceAdapter interface {
-	// GetShares returns source shares owned by one address.
+	// OwnerSharesBySource returns source shares owned by one address.
 	//
 	// For example, the shares a user owns in the kava:usdx and bnb:usdx swap pools.
 	// It returns the shares for several sources at once, in the same order as the sourceIDs. Specifying no sourceIDS will return no shares.
-	GetShares(ctx sdk.Context, owner sdk.AccAddress, sourceIDs []string) []sdk.Dec
+	OwnerSharesBySource(ctx sdk.Context, owner sdk.AccAddress, sourceIDs []string) []sdk.Dec
 
-	// GetTotalShares returns the sum of all shares for a source (across all users).
+	// TotalSharesBySource returns the sum of all shares for a source (across all users).
 	//
 	// For example, the total number of shares in the kava:usdx swap pool for all users.
-	GetTotalShares(ctx sdk.Context, sourceID string) sdk.Dec
+	TotalSharesBySource(ctx sdk.Context, sourceID string) sdk.Dec
 }

--- a/x/incentive/types/adapter.go
+++ b/x/incentive/types/adapter.go
@@ -7,8 +7,9 @@ type SourceAdapter interface {
 	// OwnerSharesBySource returns source shares owned by one address.
 	//
 	// For example, the shares a user owns in the kava:usdx and bnb:usdx swap pools.
-	// It returns the shares for several sources at once, in the same order as the sourceIDs. Specifying no sourceIDS will return no shares.
-	OwnerSharesBySource(ctx sdk.Context, owner sdk.AccAddress, sourceIDs []string) []sdk.Dec
+	// It returns the shares for several sources at once, in a map of sourceIDs to shares. Specifying no sourceIDS will return no shares.
+	// Note the returned map does not have a deterministic order.
+	OwnerSharesBySource(ctx sdk.Context, owner sdk.AccAddress, sourceIDs []string) map[string]sdk.Dec
 
 	// TotalSharesBySource returns the sum of all shares for a source (across all users).
 	//


### PR DESCRIPTION
Adds the interface definition for `SourceAdapter`s - the abstraction connecting the keeper sync and accumulate methods to external modules.

I added a spike of use in swap and earn here: #1378

Only difference to spike doc is `GetShares` requries a list of `sourceID`s, returning the shares for all of them at once. Most external modules store user's shares for different denoms in the same object (eg earn `VaultShareRecord`). So if the method was `GetShares(ctx, owner, sourceID)` it would need to fetch and unmarshal the whole object every time it's called. In the case of earn, this would be called for every bkava denom.

Another option would be `GetShares(ctx, owner) map[string]sdk.Dec` that returns all shares owned by a user. But this kind of has the opposite problem of forcing the adapter to fetch all shares when only one may be needed. eg in the case of swap, a users's pool shares are stored in separate objects. Also it returns a map, which introduces indeterminism if iterated over incorrectly (it could return a determinsitic type, but that's more work to create).

Open to thoughts on naming. `SourceShareFetcher` might be a bit clearer, but this object may be expanded to include hooks as in #1370.
I've been trying standardize on "source" being a single rewarded activity, like a single earn deposit, or single swap pool deposit.