### PR TITLE
mint community pool inflation in x/kavamint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -644,7 +644,7 @@ func NewApp(
 		app.accountKeeper,
 		app.bankKeeper,
 		authtypes.FeeCollectorName, // same fee collector as vanilla sdk
-		// TODO: pass community module account name
+		communitytypes.ModuleAccountName,
 	)
 
 	app.incentiveKeeper = incentivekeeper.NewKeeper(

--- a/x/community/keeper/msg_server.go
+++ b/x/community/keeper/msg_server.go
@@ -37,7 +37,9 @@ func (s msgServer) FundCommunityPool(goCtx context.Context, msg *types.MsgFundCo
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
+			sdk.NewAttribute(sdk.AttributeKeyAction, types.AttributeValueFundCommunityPool),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Depositor),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
 		),
 	)
 

--- a/x/community/spec/01_concepts.md
+++ b/x/community/spec/01_concepts.md
@@ -1,0 +1,19 @@
+<!--
+order: 1
+-->
+
+# Concepts
+
+## Community Pool
+
+The community pool is the module account of the x/community module. It replaces the functionality of the community pool fee collector account of the auth module in the vanilla SDK.
+
+### Funding
+
+The community pool can be funded every block from the community pool inflation of the x/kavamint module.
+
+Additionally, the pool can be funded by any account sending a community/FundCommunityPool message.
+
+### Spending
+
+The community pool funds are spent via government proposals. The x/kavadist module includes a CommunityPoolMultiSpendProposal that, upon approval, distributes funds to a list of accounts.

--- a/x/community/spec/02_state.md
+++ b/x/community/spec/02_state.md
@@ -1,0 +1,7 @@
+<!--
+order: 2
+-->
+
+# State
+
+The x/community module has no state.

--- a/x/community/spec/03_messages.md
+++ b/x/community/spec/03_messages.md
@@ -1,0 +1,17 @@
+<!--
+order: 3
+-->
+
+# Messages
+
+## FundCommunityPool
+
+This message sends coins directly from the sender to the community module account.
+
+The transaction fails if the amount cannot be transferred from the sender to the community module account.
+
+```go
+func (k Keeper) FundCommunityPool(ctx sdk.Context, sender sdk.AccAddress, amount sdk.Coins) error {
+	return k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleAccountName, amount)
+}
+```

--- a/x/community/spec/04_events.md
+++ b/x/community/spec/04_events.md
@@ -1,0 +1,18 @@
+<!--
+order: 4
+-->
+
+# Events
+
+The community module emits the following events:
+
+## Handlers
+
+### MsgFundCommunityPool
+
+| Type    | Attribute Key | Attribute Value     |
+| ------- | ------------- | ------------------- |
+| message | module        | community           |
+| message | action        | fund_community_pool |
+| message | sender        | {senderAddress}     |
+| message | amount        | {amountCoins}       |

--- a/x/community/spec/README.md
+++ b/x/community/spec/README.md
@@ -1,0 +1,19 @@
+<!--
+order: 0
+title: "Community Overview"
+parent:
+  title: "community"
+-->
+
+# `community`
+
+<!-- TOC -->
+
+1. **[Concepts](01_concepts.md)**
+2. **[State](02_state.md)**
+3. **[Messages](03_messages.md)**
+4. **[Events](04_events.md)**
+
+## Abstract
+
+`x/community` is an implementation of a Cosmos SDK Module that provides for functionality and governance for a community pool of funds controlled by Kava DAO.

--- a/x/community/types/events.go
+++ b/x/community/types/events.go
@@ -2,8 +2,6 @@ package types
 
 // Community module event types
 const (
-	EventTypeFundCommunityPool = "fund_community_pool"
-
-	AttributeValueCategory = ModuleName
-	AttributeKeyDepositor  = "depositor"
+	AttributeValueFundCommunityPool = "fund_community_pool"
+	AttributeValueCategory          = ModuleName
 )

--- a/x/kavamint/abci.go
+++ b/x/kavamint/abci.go
@@ -11,9 +11,12 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 	if !found {
 		previousBlockTime = ctx.BlockTime()
 	}
+	// calculate totals before any minting is done to prevent new mints affecting the values
+	totalBonded := k.TotalBondedTokens(ctx)
+	totalSupply := k.TotalSupply(ctx)
 
 	// ------------- Staking Rewards -------------
-	stakingRewardCoins, err := k.AccumulateStakingRewards(ctx, previousBlockTime)
+	stakingRewardCoins, err := k.AccumulateStakingRewards(ctx, totalBonded, previousBlockTime)
 	if err != nil {
 		panic(err)
 	}
@@ -29,7 +32,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 	}
 
 	// ------------- Community Pool -------------
-	communityPoolInflation, err := k.AccumulateCommunityPoolInflation(ctx, previousBlockTime)
+	communityPoolInflation, err := k.AccumulateCommunityPoolInflation(ctx, totalSupply, previousBlockTime)
 	if err != nil {
 		panic(err)
 	}

--- a/x/kavamint/abci.go
+++ b/x/kavamint/abci.go
@@ -29,8 +29,20 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 	}
 
 	// ------------- Community Pool -------------
-	// TODO: mint tokens for community pool
-	// TODO: send tokens to community pool
+	communityPoolInflation, err := k.AccumulateCommunityPoolInflation(ctx, previousBlockTime)
+	if err != nil {
+		panic(err)
+	}
+
+	// mint community pool inflation
+	if err := k.MintCoins(ctx, communityPoolInflation); err != nil {
+		panic(err)
+	}
+
+	// send inflation coins to the community pool (x/community module account)
+	if err := k.FundCommunityPool(ctx, communityPoolInflation); err != nil {
+		panic(err)
+	}
 
 	// ------------- Bookkeeping -------------
 	// bookkeep the previous block time

--- a/x/kavamint/abci_test.go
+++ b/x/kavamint/abci_test.go
@@ -62,13 +62,63 @@ func (suite *abciTestSuite) TestBeginBlockerMintsExpectedTokens() {
 			blockTime:               6,
 			communityPoolInflation:  sdk.ZeroDec(),
 			stakingRewardsApy:       sdk.NewDecWithPrec(20, 2),
-			bondedRatio:             sdk.OneDec(),
+			bondedRatio:             sdk.NewDecWithPrec(40, 2),
 			expCommunityPoolBalance: sdk.ZeroInt(),
 			// 20% APY for 6 seconds
-			// bond ratio is 100%, so total supply = bonded supply = 1e10
-			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.20%2C31536000%5D%5C%2841%29%2C6%5D-1%5C%2841%29*1e10
-			// => 346.88 => truncated to 346 tokens.
-			expFeeCollectorBalance: sdk.NewInt(346),
+			// bond ratio is 40%, so total supply * ratio = 1e10 * .4
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.20%2C31536000%5D%5C%2841%29%2C6%5D-1%5C%2841%29*1e10*.4
+			// => 138.75 => truncated to 138 tokens.
+			expFeeCollectorBalance: sdk.NewInt(138),
+		},
+		{
+			name:                   "mints community pool inflation, handles 0 staking rewards",
+			blockTime:              6,
+			communityPoolInflation: sdk.NewDecWithPrec(80, 2),
+			stakingRewardsApy:      sdk.ZeroDec(),
+			bondedRatio:            sdk.NewDecWithPrec(40, 2),
+			// 80% APY for 6 seconds
+			// total supply = 1e10
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.80%2C31536000%5D%5C%2841%29%2C6%5D-1%5C%2841%29*1e10
+			// => 1118.32 => truncated to 1118 tokens.
+			expCommunityPoolBalance: sdk.NewInt(1118),
+			expFeeCollectorBalance:  sdk.ZeroInt(),
+		},
+		{
+			name:                    "mints no tokens if all inflation is zero",
+			blockTime:               6,
+			communityPoolInflation:  sdk.ZeroDec(),
+			stakingRewardsApy:       sdk.ZeroDec(),
+			bondedRatio:             sdk.NewDecWithPrec(40, 2),
+			expCommunityPoolBalance: sdk.ZeroInt(),
+			expFeeCollectorBalance:  sdk.ZeroInt(),
+		},
+		{
+			name:                   "mints community pool inflation and staking rewards",
+			blockTime:              6,
+			communityPoolInflation: sdk.NewDecWithPrec(50, 2),
+			stakingRewardsApy:      sdk.NewDecWithPrec(20, 2),
+			bondedRatio:            sdk.NewDecWithPrec(35, 2),
+			// 50% APY for 6 seconds
+			// total supply = 1e10
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.5%2C31536000%5D%5C%2841%29%2C6%5D-1%5C%2841%29*1e10
+			// => 771.43 => truncated to 771 tokens.
+			expCommunityPoolBalance: sdk.NewInt(771),
+			// 20% APY for 6 seconds
+			// total bonded = 1e10 * 35%
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.20%2C31536000%5D%5C%2841%29%2C6%5D-1%5C%2841%29*1e10*.35
+			// => 121.41 => truncated to 121 tokens.
+			expFeeCollectorBalance: sdk.NewInt(121),
+		},
+		{
+			name:                   "handles extra long block time",
+			blockTime:              60, // like if we're upgrading the network takes an hour to get back up
+			communityPoolInflation: sdk.NewDecWithPrec(50, 2),
+			stakingRewardsApy:      sdk.NewDecWithPrec(20, 2),
+			bondedRatio:            sdk.NewDecWithPrec(35, 2),
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.5%2C31536000%5D%5C%2841%29%2C60%5D-1%5C%2841%29*1e10
+			expCommunityPoolBalance: sdk.NewInt(7714),
+			// https://www.wolframalpha.com/input?i2d=true&i=%5C%2840%29Power%5B%5C%2840%29Surd%5B1.20%2C31536000%5D%5C%2841%29%2C60%5D-1%5C%2841%29*1e10*.35
+			expFeeCollectorBalance: sdk.NewInt(1214),
 		},
 	}
 

--- a/x/kavamint/abci_test.go
+++ b/x/kavamint/abci_test.go
@@ -111,7 +111,7 @@ func (suite *abciTestSuite) TestBeginBlockerMintsExpectedTokens() {
 		},
 		{
 			name:                   "handles extra long block time",
-			blockTime:              60, // like if we're upgrading the network takes an hour to get back up
+			blockTime:              60, // like if we're upgrading the network & it takes an hour to get back up
 			communityPoolInflation: sdk.NewDecWithPrec(50, 2),
 			stakingRewardsApy:      sdk.NewDecWithPrec(20, 2),
 			bondedRatio:            sdk.NewDecWithPrec(35, 2),

--- a/x/kavamint/abci_test.go
+++ b/x/kavamint/abci_test.go
@@ -12,6 +12,7 @@ import (
 
 	communitytypes "github.com/kava-labs/kava/x/community/types"
 	"github.com/kava-labs/kava/x/kavamint"
+	"github.com/kava-labs/kava/x/kavamint/keeper"
 	"github.com/kava-labs/kava/x/kavamint/testutil"
 	"github.com/kava-labs/kava/x/kavamint/types"
 )
@@ -57,6 +58,17 @@ func (suite *abciTestSuite) TestBeginBlockerMintsExpectedTokens() {
 		expCommunityPoolBalance sdk.Int
 		expFeeCollectorBalance  sdk.Int
 	}{
+		{
+			name:                   "sanity check: a year of seconds mints total yearly inflation",
+			blockTime:              keeper.SecondsPerYear,
+			communityPoolInflation: sdk.NewDecWithPrec(20, 2),
+			stakingRewardsApy:      sdk.NewDecWithPrec(20, 2),
+			bondedRatio:            sdk.NewDecWithPrec(50, 2),
+			// 20% inflation on 1e10 tokens -> 2e9 minted
+			expCommunityPoolBalance: sdk.NewInt(2e9),
+			// 20% APY, 50% bonded (5e9) -> 1e9 minted
+			expFeeCollectorBalance: sdk.NewInt(1e9),
+		},
 		{
 			name:                    "mints staking rewards, handles 0 community pool inflation",
 			blockTime:               6,

--- a/x/kavamint/abci_test.go
+++ b/x/kavamint/abci_test.go
@@ -10,6 +10,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 
+	communitytypes "github.com/kava-labs/kava/x/community/types"
 	"github.com/kava-labs/kava/x/kavamint"
 	"github.com/kava-labs/kava/x/kavamint/keeper"
 	"github.com/kava-labs/kava/x/kavamint/testutil"
@@ -36,6 +37,10 @@ func (suite *abciTestSuite) CheckFeeCollectorBalance(ctx sdk.Context, expectedAm
 
 func (suite *abciTestSuite) CheckKavamintBalance(ctx sdk.Context, expectedAmount sdk.Int) {
 	suite.CheckModuleBalance(ctx, types.ModuleName, expectedAmount)
+}
+
+func (suite *abciTestSuite) CheckCommunityPoolBalance(ctx sdk.Context, expectedAmount sdk.Int) {
+	suite.CheckModuleBalance(ctx, communitytypes.ModuleAccountName, expectedAmount)
 }
 
 func TestGRPCQueryTestSuite(t *testing.T) {
@@ -67,6 +72,8 @@ func (suite *abciTestSuite) TestBeginBlockerMintsStakingRewards() {
 	suite.CheckFeeCollectorBalance(ctx, sdk.ZeroInt())
 	// expect nothing in kavamint module
 	suite.CheckKavamintBalance(ctx, sdk.ZeroInt())
+	// expect nothing in community module
+	suite.CheckCommunityPoolBalance(ctx, sdk.ZeroInt())
 
 	// expect block time set
 	startBlockTime, startTimeFound := kavamintKeeper.GetPreviousBlockTime(ctx)
@@ -89,6 +96,8 @@ func (suite *abciTestSuite) TestBeginBlockerMintsStakingRewards() {
 
 	// kavamint balance should still be 0 because 100% was transferred out
 	suite.CheckKavamintBalance(ctx2, sdk.ZeroInt())
+	// community inflation is 0 so community pool should still be empty
+	suite.CheckCommunityPoolBalance(ctx, sdk.ZeroInt())
 
 	// expect time to be updated
 	endBlockTime, endTimeFound := kavamintKeeper.GetPreviousBlockTime(ctx)

--- a/x/kavamint/genesis.go
+++ b/x/kavamint/genesis.go
@@ -12,10 +12,10 @@ import (
 func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, ak types.AccountKeeper, data *types.GenesisState) {
 	keeper.SetParams(ctx, data.Params)
 
-	// only set the previous block time if it's different than default
-	if !data.PreviousBlockTime.Equal(types.DefaultPreviousBlockTime) {
-		keeper.SetPreviousBlockTime(ctx, data.PreviousBlockTime)
+	if data.PreviousBlockTime.IsZero() {
+		panic(fmt.Sprintf("No previous_block_time set in genesis state of %s module", types.ModuleName))
 	}
+	keeper.SetPreviousBlockTime(ctx, data.PreviousBlockTime)
 
 	if macc := ak.GetModuleAccount(ctx, types.ModuleName); macc == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))

--- a/x/kavamint/keeper/inflation.go
+++ b/x/kavamint/keeper/inflation.go
@@ -16,7 +16,11 @@ const (
 // The amount is the total_bonded_tokens * spy
 // where spy is the staking_rewards_apy converted to a compound-per-second rate over a period of
 // seconds_since_last_accumulation.
-func (k Keeper) AccumulateStakingRewards(ctx sdk.Context, since time.Time) (sdk.Coins, error) {
+func (k Keeper) AccumulateStakingRewards(
+	ctx sdk.Context,
+	totalBonded sdk.Int,
+	since time.Time,
+) (sdk.Coins, error) {
 	params := k.GetParams(ctx)
 	bondDenom := k.BondDenom(ctx)
 
@@ -30,7 +34,6 @@ func (k Keeper) AccumulateStakingRewards(ctx sdk.Context, since time.Time) (sdk.
 		return sdk.NewCoins(), err
 	}
 
-	totalBonded := k.TotalBondedTokens(ctx)
 	stakingRewardsAmount := stakingRewardsRate.MulInt(totalBonded).TruncateInt()
 
 	return sdk.NewCoins(sdk.NewCoin(bondDenom, stakingRewardsAmount)), nil
@@ -41,7 +44,11 @@ func (k Keeper) AccumulateStakingRewards(ctx sdk.Context, since time.Time) (sdk.
 // The amount is the total_supply * spy * seconds_since_last_accumulation
 // where spy is the community_pool_inflation converted to a compound-per-second rate over a period
 // of seconds_since_last_accumulation.
-func (k Keeper) AccumulateCommunityPoolInflation(ctx sdk.Context, since time.Time) (sdk.Coins, error) {
+func (k Keeper) AccumulateCommunityPoolInflation(
+	ctx sdk.Context,
+	totalSupply sdk.Int,
+	since time.Time,
+) (sdk.Coins, error) {
 	params := k.GetParams(ctx)
 	bondDenom := k.BondDenom(ctx)
 
@@ -58,7 +65,6 @@ func (k Keeper) AccumulateCommunityPoolInflation(ctx sdk.Context, since time.Tim
 		return sdk.NewCoins(), err
 	}
 
-	totalSupply := k.TotalSupply(ctx)
 	communityInflationAmount := communityInflationRate.MulInt(totalSupply).TruncateInt()
 
 	return sdk.NewCoins(sdk.NewCoin(bondDenom, communityInflationAmount)), nil

--- a/x/kavamint/keeper/inflation.go
+++ b/x/kavamint/keeper/inflation.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"time"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -11,63 +9,26 @@ const (
 	SecondsPerYear = uint64(31536000)
 )
 
-// AccumulateStakingRewards calculates the number of coins that should be minted for staking rewards
-// given the staking rewards APY and the time of last accumulation.
-// The amount is the total_bonded_tokens * spy
-// where spy is the staking_rewards_apy converted to a compound-per-second rate over a period of
-// seconds_since_last_accumulation.
-func (k Keeper) AccumulateStakingRewards(
+// AccumulateInflation calculates the number of coins that should be minted to match a yearly `rate`
+// for interest compounded each second of the year over `secondsSinceLastMint` seconds.
+// `basis` is the base amount of coins that is inflated.
+func (k Keeper) AccumulateInflation(
 	ctx sdk.Context,
-	totalBonded sdk.Int,
-	since time.Time,
+	rate sdk.Dec,
+	basis sdk.Int,
+	secondsSinceLastMint float64,
 ) (sdk.Coins, error) {
-	params := k.GetParams(ctx)
 	bondDenom := k.BondDenom(ctx)
 
-	// determine seconds passed since this block time
-	// truncate the float with uint64(). remaining fraction of second will be picked up in next block.
-	secondsSinceLastBlock := ctx.BlockTime().Sub(since).Seconds()
-
 	// calculate the rate factor based on apy & seconds passed since last block
-	stakingRewardsRate, err := CalculateInflationRate(params.StakingRewardsApy, uint64(secondsSinceLastBlock))
+	inflationRate, err := CalculateInflationRate(rate, uint64(secondsSinceLastMint))
 	if err != nil {
 		return sdk.NewCoins(), err
 	}
 
-	stakingRewardsAmount := stakingRewardsRate.MulInt(totalBonded).TruncateInt()
+	amount := inflationRate.MulInt(basis).TruncateInt()
 
-	return sdk.NewCoins(sdk.NewCoin(bondDenom, stakingRewardsAmount)), nil
-}
-
-// AccumulateCommunityPoolInflation calculates the number of coins that should be minted for community pool
-// inflation.
-// The amount is the total_supply * spy * seconds_since_last_accumulation
-// where spy is the community_pool_inflation converted to a compound-per-second rate over a period
-// of seconds_since_last_accumulation.
-func (k Keeper) AccumulateCommunityPoolInflation(
-	ctx sdk.Context,
-	totalSupply sdk.Int,
-	since time.Time,
-) (sdk.Coins, error) {
-	params := k.GetParams(ctx)
-	bondDenom := k.BondDenom(ctx)
-
-	// determine seconds passed since this block time
-	// truncate the float with uint64(). remaining fraction of second will be picked up in next block.
-	secondsSinceLastBlock := ctx.BlockTime().Sub(since).Seconds()
-
-	// calculate the rate factor based on apy & seconds passed since last block
-	communityInflationRate, err := CalculateInflationRate(
-		params.CommunityPoolInflation,
-		uint64(secondsSinceLastBlock),
-	)
-	if err != nil {
-		return sdk.NewCoins(), err
-	}
-
-	communityInflationAmount := communityInflationRate.MulInt(totalSupply).TruncateInt()
-
-	return sdk.NewCoins(sdk.NewCoin(bondDenom, communityInflationAmount)), nil
+	return sdk.NewCoins(sdk.NewCoin(bondDenom, amount)), nil
 }
 
 // CalculateInflationRate converts an APY into the factor corresponding with that APY's accumulation

--- a/x/kavamint/keeper/inflation_test.go
+++ b/x/kavamint/keeper/inflation_test.go
@@ -99,7 +99,7 @@ func (suite *InflationTestSuite) TestCalculateInflationFactor() {
 			preciseToDecimal: 16,
 		},
 		{
-			name:             "example: 10,000 percent for 10 seconds, precise to 15 decimals",
+			name:             "example: 10,000 percent for 10 seconds, precise to 13 decimals",
 			apy:              sdk.NewDecWithPrec(10000, 2),
 			secondsPassed:    10,
 			expectedRate:     sdk.MustNewDecFromStr("0.000001463446186527"),

--- a/x/kavamint/keeper/keeper.go
+++ b/x/kavamint/keeper/keeper.go
@@ -15,20 +15,20 @@ import (
 
 // Keeper of the kavamint store
 type Keeper struct {
-	cdc               codec.BinaryCodec
-	storeKey          sdk.StoreKey
-	paramSpace        paramtypes.Subspace
-	stakingKeeper     types.StakingKeeper
-	bankKeeper        types.BankKeeper
-	feeCollectorName  string
-	communityPoolName string
+	cdc                            codec.BinaryCodec
+	storeKey                       sdk.StoreKey
+	paramSpace                     paramtypes.Subspace
+	stakingKeeper                  types.StakingKeeper
+	bankKeeper                     types.BankKeeper
+	stakingRewardsFeeCollectorName string
+	communityPoolModuleAccountName string
 }
 
 // NewKeeper creates a new kavamint Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	sk types.StakingKeeper, ak types.AccountKeeper, bk types.BankKeeper,
-	feeCollectorName string, communityPoolName string,
+	stakingRewardsFeeCollectorName string, communityPoolModuleAccountName string,
 ) Keeper {
 	// ensure kavamint module account is set
 	if addr := ak.GetModuleAddress(types.ModuleName); addr == nil {
@@ -41,13 +41,13 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:               cdc,
-		storeKey:          key,
-		paramSpace:        paramSpace,
-		stakingKeeper:     sk,
-		bankKeeper:        bk,
-		feeCollectorName:  feeCollectorName,
-		communityPoolName: communityPoolName,
+		cdc:                            cdc,
+		storeKey:                       key,
+		paramSpace:                     paramSpace,
+		stakingKeeper:                  sk,
+		bankKeeper:                     bk,
+		stakingRewardsFeeCollectorName: stakingRewardsFeeCollectorName,
+		communityPoolModuleAccountName: communityPoolModuleAccountName,
 	}
 }
 
@@ -92,13 +92,13 @@ func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
 // AddCollectedFees implements an alias call to the underlying supply keeper's
 // AddCollectedFees to be used in BeginBlocker.
 func (k Keeper) AddCollectedFees(ctx sdk.Context, fees sdk.Coins) error {
-	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.feeCollectorName, fees)
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.stakingRewardsFeeCollectorName, fees)
 }
 
 // FundCommunityPool implements an alias call to the underlying supply keeper's
 // FundCommunityPool to be used in BeginBlocker.
 func (k Keeper) FundCommunityPool(ctx sdk.Context, funds sdk.Coins) error {
-	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.communityPoolName, funds)
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.communityPoolModuleAccountName, funds)
 }
 
 // TotalSupply implements an alias call to the underlying supply keeper's

--- a/x/kavamint/keeper/keeper.go
+++ b/x/kavamint/keeper/keeper.go
@@ -15,19 +15,20 @@ import (
 
 // Keeper of the kavamint store
 type Keeper struct {
-	cdc              codec.BinaryCodec
-	storeKey         sdk.StoreKey
-	paramSpace       paramtypes.Subspace
-	stakingKeeper    types.StakingKeeper
-	bankKeeper       types.BankKeeper
-	feeCollectorName string
+	cdc               codec.BinaryCodec
+	storeKey          sdk.StoreKey
+	paramSpace        paramtypes.Subspace
+	stakingKeeper     types.StakingKeeper
+	bankKeeper        types.BankKeeper
+	feeCollectorName  string
+	communityPoolName string
 }
 
 // NewKeeper creates a new kavamint Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	sk types.StakingKeeper, ak types.AccountKeeper, bk types.BankKeeper,
-	feeCollectorName string,
+	feeCollectorName string, communityPoolName string,
 ) Keeper {
 	// ensure kavamint module account is set
 	if addr := ak.GetModuleAddress(types.ModuleName); addr == nil {
@@ -40,12 +41,13 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:              cdc,
-		storeKey:         key,
-		paramSpace:       paramSpace,
-		stakingKeeper:    sk,
-		bankKeeper:       bk,
-		feeCollectorName: feeCollectorName,
+		cdc:               cdc,
+		storeKey:          key,
+		paramSpace:        paramSpace,
+		stakingKeeper:     sk,
+		bankKeeper:        bk,
+		feeCollectorName:  feeCollectorName,
+		communityPoolName: communityPoolName,
 	}
 }
 
@@ -91,6 +93,12 @@ func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
 // AddCollectedFees to be used in BeginBlocker.
 func (k Keeper) AddCollectedFees(ctx sdk.Context, fees sdk.Coins) error {
 	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.feeCollectorName, fees)
+}
+
+// FundCommunityPool implements an alias call to the underlying supply keeper's
+// FundCommunityPool to be used in BeginBlocker.
+func (k Keeper) FundCommunityPool(ctx sdk.Context, funds sdk.Coins) error {
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.communityPoolName, funds)
 }
 
 // TotalSupply implements an alias call to the underlying supply keeper's

--- a/x/kavamint/spec/04_events.md
+++ b/x/kavamint/spec/04_events.md
@@ -8,9 +8,10 @@ The kavamint module emits the following events:
 
 ## BeginBlocker
 
-| Type     | Attribute Key   | Attribute Value      |
-| -------- | --------------- | -------------------- |
-| kavamint | total_supply    | {totalSupply}        |
-| kavamint | bonded_ratio    | {bondedRatio}        |
-| kavamint | community_pool  | {communityPoolCoins} |
-| kavamint | staking_rewards | {stakingRewardCoins} |
+| Type     | Attribute Key                   | Attribute Value          |
+| -------- | ------------------------------- | ------------------------ |
+| kavamint | total_supply                    | {totalSupply}            |
+| kavamint | bonded_ratio                    | {bondedRatio}            |
+| kavamint | seconds_since_last_mint         | {secondsPassed}          |
+| kavamint | minted_community_pool_inflation | {communityPoolInflation} |
+| kavamint | minted_staking_rewards          | {stakingRewardCoins}     |

--- a/x/kavamint/spec/06_begin_block.md
+++ b/x/kavamint/spec/06_begin_block.md
@@ -9,31 +9,41 @@ At the start of each block, new KAVA tokens are minted and distributed
 ```go
 // BeginBlocker mints & distributes new tokens for the previous block.
 func BeginBlocker(ctx sdk.Context, k Keeper) {
+  params := k.GetParams(ctx)
   // fetch the last block time from state
-	previousBlockTime, found := k.GetPreviousBlockTime(ctx)
+  previousBlockTime, found := k.GetPreviousBlockTime(ctx)
+  secondsPassed := ctx.BlockTime().Sub(previousBlockTime).Seconds()
 
   // determine totals before any new mints
-	totalSupply := k.TotalSupply(ctx)
+  totalSupply := k.TotalSupply(ctx)
   totalBonded := k.TotalBondedTokens(ctx)
 
-	// ------------- Staking Rewards -------------
+  // ------------- Staking Rewards -------------
   // determine amount of the bond denom to mint for staking rewards
-	stakingRewardCoins, err := k.AccumulateStakingRewards(ctx, totalBonded, previousBlockTime)
+  stakingRewardCoins, err := k.AccumulateInflation(
+    ctx, params.StakingRewardsApy, totalBonded, secondsPassed,
+  )
   // mint the staking rewards
   k.MintCoins(ctx, stakingRewardCoins)
   // distribute them to the fee pool for distribution by x/distribution
   k.AddCollectedFees(ctx, stakingRewardCoins)
 
-	// ------------- Community Pool -------------
+  // ------------- Community Pool -------------
   // determine amount of the bond denom to mint for community pool inflation
-	communityPoolCoins, err := k.AccumulateCommunityPoolInflation(ctx, totalSupply, previousBlockTime)
+  communityPoolInflation, err := k.AccumulateInflation(
+    ctx, params.CommunityPoolInflation, totalSupply, secondsPassed,
+  )
   // mint the community pool tokens
   k.MintCoins(ctx, communityPoolCoins)
   // send them to the community module account (the community pool)
   k.AddCommunityPoolFunds(ctx, communityPoolCoins)
 
-	// ------------- Bookkeeping -------------
+  // ------------- Bookkeeping -------------
   // set block time for next iteration's minting
-	k.SetPreviousBlockTime(ctx, ctx.BlockTime())
+  k.SetPreviousBlockTime(ctx, ctx.BlockTime())
 }
 ```
+
+`AccumulateInflation` determines the effective rate of the yearly interest rate assuming it is
+compounded once per second, for the number of seconds since the previous mint. See concepts for
+more details.

--- a/x/kavamint/spec/06_begin_block.md
+++ b/x/kavamint/spec/06_begin_block.md
@@ -12,21 +12,27 @@ func BeginBlocker(ctx sdk.Context, k Keeper) {
   // fetch the last block time from state
 	previousBlockTime, found := k.GetPreviousBlockTime(ctx)
 
+  // determine totals before any new mints
+	totalSupply := k.TotalSupply(ctx)
+  totalBonded := k.TotalBondedTokens(ctx)
+
 	// ------------- Staking Rewards -------------
   // determine amount of the bond denom to mint for staking rewards
-	stakingRewardCoins, err := k.AccumulateStakingRewards(ctx, previousBlockTime)
+	stakingRewardCoins, err := k.AccumulateStakingRewards(ctx, totalBonded, previousBlockTime)
   // mint the staking rewards
   k.MintCoins(ctx, stakingRewardCoins)
   // distribute them to the fee pool for distribution by x/distribution
   k.AddCollectedFees(ctx, stakingRewardCoins)
 
 	// ------------- Community Pool -------------
-	communityPoolCoins, err := k.AccumulateCommunityPoolInflation(ctx, previousBlockTime)
+  // determine amount of the bond denom to mint for community pool inflation
+	communityPoolCoins, err := k.AccumulateCommunityPoolInflation(ctx, totalSupply, previousBlockTime)
   // mint the community pool tokens
   k.MintCoins(ctx, communityPoolCoins)
   // send them to the community module account (the community pool)
   k.AddCommunityPoolFunds(ctx, communityPoolCoins)
 
+	// ------------- Bookkeeping -------------
   // set block time for next iteration's minting
 	k.SetPreviousBlockTime(ctx, ctx.BlockTime())
 }

--- a/x/kavamint/testutil/suite.go
+++ b/x/kavamint/testutil/suite.go
@@ -20,7 +20,7 @@ type KavamintTestSuite struct {
 	Keeper        keeper.Keeper
 	StakingKeeper stakingkeeper.Keeper
 
-	bondDenom string
+	BondDenom string
 }
 
 func (suite *KavamintTestSuite) SetupTest() {
@@ -31,7 +31,7 @@ func (suite *KavamintTestSuite) SetupTest() {
 	suite.Keeper = suite.App.GetKavamintKeeper()
 	suite.StakingKeeper = suite.App.GetStakingKeeper()
 
-	suite.bondDenom = suite.Keeper.BondDenom(suite.Ctx)
+	suite.BondDenom = suite.Keeper.BondDenom(suite.Ctx)
 }
 
 // SetBondedTokenRatio mints the total supply to an account and creates a validator with a self
@@ -42,7 +42,7 @@ func (suite *KavamintTestSuite) SetBondedTokenRatio(ratio sdk.Dec) sdk.Coins {
 	address := app.RandomAddress()
 
 	supplyAmount := sdk.NewInt(1e10)
-	totalSupply := sdk.NewCoins(sdk.NewCoin(suite.bondDenom, supplyAmount))
+	totalSupply := sdk.NewCoins(sdk.NewCoin(suite.BondDenom, supplyAmount))
 	amountToBond := ratio.MulInt(supplyAmount).TruncateInt()
 
 	// fund account that will create validator with total supply

--- a/x/kavamint/types/events.go
+++ b/x/kavamint/types/events.go
@@ -4,7 +4,9 @@ package types
 const (
 	EventTypeMint = ModuleName
 
-	AttributeKeyBondedRatio      = "bonded_ratio"
-	AttributeKeyInflation        = "inflation"
-	AttributeKeyAnnualProvisions = "annual_provisions"
+	AttributeKeyTotalSupply       = "total_supply"
+	AttributeKeyTotalBonded       = "total_bonded"
+	AttributeSecondsPassed        = "seconds_since_last_mint"
+	AttributeKeyCommunityPoolMint = "minted_community_pool_inflation"
+	AttributeKeyStakingRewardMint = "minted_staking_rewards"
 )

--- a/x/kavamint/types/expected_keepers.go
+++ b/x/kavamint/types/expected_keepers.go
@@ -14,9 +14,6 @@ type StakingKeeper interface {
 // AccountKeeper defines the contract required for account APIs.
 type AccountKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
-
-	// TODO remove with genesis 2-phases refactor https://github.com/cosmos/cosmos-sdk/issues/2862
-	SetModuleAccount(sdk.Context, types.ModuleAccountI)
 	GetModuleAccount(ctx sdk.Context, moduleName string) types.ModuleAccountI
 }
 
@@ -24,7 +21,6 @@ type AccountKeeper interface {
 // dependencies.
 type BankKeeper interface {
 	GetSupply(ctx sdk.Context, denom string) sdk.Coin
-	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 }

--- a/x/kavamint/types/params.go
+++ b/x/kavamint/types/params.go
@@ -15,8 +15,8 @@ var (
 	KeyStakingRewardsApy      = []byte("StakingRewardsApy")
 
 	DefaultPreviousBlockTime      = tmtime.Canonical(time.Unix(1, 0))
-	DefaultCommunityPoolInflation = sdk.MustNewDecFromStr("0.900000000000000000")
-	DefaultStakingRewardsApy      = sdk.MustNewDecFromStr("0.200000000000000000")
+	DefaultCommunityPoolInflation = sdk.ZeroDec()
+	DefaultStakingRewardsApy      = sdk.ZeroDec()
 
 	// rates larger than 17,650% are out of bounds
 	// this is due to the necessary conversion of yearly rate to per second rate


### PR DESCRIPTION
Implements and tests `x/kavamint`'s `CommunityPoolInflation` parameter. Inflation is compounded for the number of seconds since the last block, and then coins are minted and transferred to the community pool (the module account of `x/community`)

Slightly modified staking reward implementation to ensure newly minted coins don't contribute the basis. (ie. if we mint coins and _then_ find the total supply, we'll be inflating more than expected because the total supply now includes the newly minted tokens.