### PR TITLE
Update DockerIgnore to include build makefiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-build/
+out/
 **/node_modules/
 .git/
 docs/

--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,9 @@ all: install
 
 build: go.sum
 ifeq ($(OS), Windows_NT)
-	go build -mod=readonly $(BUILD_FLAGS) -o build/$(shell go env GOOS)/kava.exe ./cmd/kava
+	go build -mod=readonly $(BUILD_FLAGS) -o out/$(shell go env GOOS)/kava.exe ./cmd/kava
 else
-	go build -mod=readonly $(BUILD_FLAGS) -o build/$(shell go env GOOS)/kava ./cmd/kava
+	go build -mod=readonly $(BUILD_FLAGS) -o out/$(shell go env GOOS)/kava ./cmd/kava
 endif
 
 build-linux: go.sum


### PR DESCRIPTION
This fixes an errors when calling make from the docker build context.