### PR TITLE
use new comm pool in kavadist multispend proposal

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -524,13 +524,17 @@ func NewApp(
 
 	app.evmutilKeeper.SetEvmKeeper(app.evmKeeper)
 
+	app.communityKeeper = communitykeeper.NewKeeper(
+		app.accountKeeper,
+		app.bankKeeper,
+	)
 	app.kavadistKeeper = kavadistkeeper.NewKeeper(
 		appCodec,
 		keys[kavadisttypes.StoreKey],
 		kavadistSubspace,
 		app.bankKeeper,
 		app.accountKeeper,
-		app.distrKeeper,
+		app.communityKeeper,
 		app.loadBlockedMaccAddrs(),
 	)
 
@@ -631,10 +635,6 @@ func NewApp(
 		&hardKeeper,
 		&savingsKeeper,
 		app.distrKeeper,
-	)
-	app.communityKeeper = communitykeeper.NewKeeper(
-		app.accountKeeper,
-		app.bankKeeper,
 	)
 	app.kavamintKeeper = kavamintkeeper.NewKeeper(
 		appCodec,

--- a/x/community/keeper/keeper.go
+++ b/x/community/keeper/keeper.go
@@ -43,3 +43,8 @@ func (k Keeper) GetModuleAccountBalance(ctx sdk.Context) sdk.Coins {
 func (k Keeper) FundCommunityPool(ctx sdk.Context, sender sdk.AccAddress, amount sdk.Coins) error {
 	return k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleAccountName, amount)
 }
+
+// DistributeFromCommunityPool transfers coins from the community pool to recipient.
+func (k Keeper) DistributeFromCommunityPool(ctx sdk.Context, recipient sdk.AccAddress, amount sdk.Coins) error {
+	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, recipient, amount)
+}

--- a/x/community/types/expected_keepers.go
+++ b/x/community/types/expected_keepers.go
@@ -16,4 +16,5 @@ type BankKeeper interface {
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }

--- a/x/kavadist/keeper/keeper.go
+++ b/x/kavadist/keeper/keeper.go
@@ -13,12 +13,12 @@ import (
 
 // Keeper keeper for the cdp module
 type Keeper struct {
-	key           sdk.StoreKey
-	cdc           codec.BinaryCodec
-	paramSubspace paramtypes.Subspace
-	bankKeeper    types.BankKeeper
-	distKeeper    types.DistKeeper
-	accountKeeper types.AccountKeeper
+	key             sdk.StoreKey
+	cdc             codec.BinaryCodec
+	paramSubspace   paramtypes.Subspace
+	bankKeeper      types.BankKeeper
+	accountKeeper   types.AccountKeeper
+	communityKeeper types.CommunityKeeper
 
 	blacklistedAddrs map[string]bool
 }
@@ -26,7 +26,7 @@ type Keeper struct {
 // NewKeeper creates a new keeper
 func NewKeeper(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramstore paramtypes.Subspace, bk types.BankKeeper, ak types.AccountKeeper,
-	dk types.DistKeeper, blacklistedAddrs map[string]bool,
+	ck types.CommunityKeeper, blacklistedAddrs map[string]bool,
 ) Keeper {
 	if !paramstore.HasKeyTable() {
 		paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
@@ -37,8 +37,8 @@ func NewKeeper(
 		cdc:              cdc,
 		paramSubspace:    paramstore,
 		bankKeeper:       bk,
-		distKeeper:       dk,
 		accountKeeper:    ak,
+		communityKeeper:  ck,
 		blacklistedAddrs: blacklistedAddrs,
 	}
 }

--- a/x/kavadist/keeper/proposal_handler.go
+++ b/x/kavadist/keeper/proposal_handler.go
@@ -13,7 +13,7 @@ func HandleCommunityPoolMultiSpendProposal(ctx sdk.Context, k Keeper, p *types.C
 		if k.blacklistedAddrs[receiverInfo.Address] {
 			return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is blacklisted from receiving external funds", receiverInfo.Address)
 		}
-		err := k.distKeeper.DistributeFromFeePool(ctx, receiverInfo.Amount, receiverInfo.GetAddress())
+		err := k.communityKeeper.DistributeFromCommunityPool(ctx, receiverInfo.GetAddress(), receiverInfo.Amount)
 		if err != nil {
 			return err
 		}

--- a/x/kavadist/keeper/proposal_handler_test.go
+++ b/x/kavadist/keeper/proposal_handler_test.go
@@ -3,21 +3,22 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	communitytypes "github.com/kava-labs/kava/x/community/types"
 	"github.com/kava-labs/kava/x/kavadist/keeper"
 	"github.com/kava-labs/kava/x/kavadist/types"
 )
 
 func (suite *keeperTestSuite) TestHandleCommunityPoolMultiSpendProposal() {
-	addr, distrKeeper, ctx := suite.Addrs[0], suite.App.GetDistrKeeper(), suite.Ctx
+	addr, communityKeeper, ctx := suite.Addrs[0], suite.App.GetCommunityKeeper(), suite.Ctx
 	initBalances := suite.BankKeeper.GetAllBalances(ctx, addr)
 
-	// add coins to the module account and fund fee pool
-	macc := distrKeeper.GetDistributionAccount(ctx)
-	fundAmount := sdk.NewCoins(sdk.NewInt64Coin("ukava", 1000000))
-	suite.Require().NoError(suite.App.FundModuleAccount(ctx, macc.GetName(), fundAmount))
-	feePool := distrKeeper.GetFeePool(ctx)
-	feePool.CommunityPool = sdk.NewDecCoinsFromCoins(fundAmount...)
-	distrKeeper.SetFeePool(ctx, feePool)
+	// add coins to the module account and fund community pool
+	initialFunds := int64(1000000)
+	fundAmount := sdk.NewCoins(sdk.NewInt64Coin("ukava", initialFunds))
+	suite.Require().NoError(suite.App.FundModuleAccount(ctx, communitytypes.ModuleAccountName, fundAmount))
+	// expect funds to start in community pool
+	commPoolFunds := communityKeeper.GetModuleAccountBalance(ctx)
+	suite.Require().True(fundAmount.IsEqual(commPoolFunds))
 
 	proposalAmount1 := int64(1100)
 	proposalAmount2 := int64(1200)
@@ -35,6 +36,12 @@ func (suite *keeperTestSuite) TestHandleCommunityPoolMultiSpendProposal() {
 	suite.Require().Nil(err)
 
 	balances := suite.BankKeeper.GetAllBalances(ctx, addr)
+
+	// expect funds to be transferred to recipient
 	expected := initBalances.AmountOf("ukava").Add(sdk.NewInt(proposalAmount1 + proposalAmount2))
 	suite.Require().Equal(expected, balances.AmountOf("ukava"))
+
+	// expect funds to be deducted from community pool
+	expectedCommPool := commPoolFunds.AmountOf("ukava").SubRaw(proposalAmount1 + proposalAmount2)
+	suite.Require().Equal(expectedCommPool, communityKeeper.GetModuleAccountBalance(ctx).AmountOf("ukava"))
 }

--- a/x/kavadist/types/expected_keepers.go
+++ b/x/kavadist/types/expected_keepers.go
@@ -5,9 +5,9 @@ import (
 	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-// DistKeeper defines the expected distribution keeper interface
-type DistKeeper interface {
-	DistributeFromFeePool(ctx sdk.Context, amount sdk.Coins, receiveAddr sdk.AccAddress) error
+// CommunityKeeper defines the expected community keeper interface
+type CommunityKeeper interface {
+	DistributeFromCommunityPool(ctx sdk.Context, sender sdk.AccAddress, amount sdk.Coins) error
 }
 
 // AccountKeeper defines the expected account keeper interface


### PR DESCRIPTION
the x/community module houses the new community pool. this commit points the CommunityPoolMultiSpendProposal at the new community pool so that multispend proposals can continue to be processed once original fee pool funds are move to x/community

adds the DistributeFromCommunityPool method to community keeper in order to send community funds to account addresses. the x/community spec has already been updated to reflect that this kavadist proposal is one (currently the only) place community pool spends can occur.