### PR TITLE
add upgrade handler for v0.20.0

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	MainnetUpgradeName = "v0.20.0"
-	TestnetUpgradeName = "TESTNET-v0.20.0"
+	TestnetUpgradeName = "v0.20.0-testnet"
 )
 
 var (

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	MainnetUpgradeName = "v0.20.0"
-	TestnetUpgradeName = "v0.20.0-testnet"
+	TestnetUpgradeName = "v0.20.0-alpha.0"
 )
 
 var (

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,3 +1,173 @@
 package app
 
-func (app App) RegisterUpgradeHandlers() {}
+import (
+	"fmt"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	communitytypes "github.com/kava-labs/kava/x/community/types"
+	kavamintkeeper "github.com/kava-labs/kava/x/kavamint/keeper"
+	kavaminttypes "github.com/kava-labs/kava/x/kavamint/types"
+)
+
+const UpgradeName = "v0.20.0"
+
+var (
+	CommunityPoolInflation = sdk.NewDecWithPrec(70, 2)
+	StakingRewardsApy      = sdk.NewDecWithPrec(10, 2)
+)
+
+func (app App) RegisterUpgradeHandlers() {
+	app.upgradeKeeper.SetUpgradeHandler(UpgradeName,
+		func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			app.Logger().Info("initializing x/community module account (the new community pool)")
+			InitializeModuleAccount(ctx, communitytypes.ModuleAccountName, app.accountKeeper, app.bankKeeper, app.distrKeeper)
+
+			app.Logger().Info("initializing x/kavamint module account")
+			InitializeModuleAccount(ctx, kavaminttypes.ModuleAccountName, app.accountKeeper, app.bankKeeper, app.distrKeeper)
+
+			app.Logger().Info("transferring original community pool funds to new community pool")
+			MoveCommunityPoolFunds(ctx, app.distrKeeper, app.bankKeeper)
+
+			// min & max inflation -> 0%
+			app.Logger().Info("disabling x/mint inflation")
+			DisableMintInflation(ctx, app.mintKeeper)
+
+			// community_tax -> 0%
+			app.Logger().Info("disabling x/distribution community tax")
+			DisableCommunityTax(ctx, app.distrKeeper)
+
+			vm, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
+			if err != nil {
+				return vm, err
+			}
+
+			// initialize kavamint state after running migrations so that store exists & persists
+			app.Logger().Info("initializing x/kavamint state")
+			InitializeKavamintState(ctx, app.kavamintKeeper)
+
+			return vm, nil
+		},
+	)
+
+	upgradeInfo, err := app.upgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	if upgradeInfo.Name == UpgradeName && !app.upgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				kavaminttypes.StoreKey,
+			},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+}
+
+// InitializeModuleAccount initializes a new module account with the given moduleAccountName.
+// If a non-module account already exists with the corresponding address, its funds are transferred
+// to the CommunityPool auth fee pool.
+func InitializeModuleAccount(
+	ctx sdk.Context,
+	moduleAccountName string,
+	accountKeeper authkeeper.AccountKeeper,
+	bankKeeper bankkeeper.Keeper,
+	distKeeper distrkeeper.Keeper,
+) {
+	maccAddr, perms := accountKeeper.GetModuleAddressAndPermissions(moduleAccountName)
+	if maccAddr == nil {
+		panic(fmt.Sprintf("%s module account not configured in app", moduleAccountName))
+	}
+
+	accountI := accountKeeper.GetAccount(ctx, maccAddr)
+	// if account already exists and is a module account, return
+	_, ok := accountI.(authtypes.ModuleAccountI)
+	if ok {
+		return
+	}
+
+	// if account exists and is not a module account, transfer funds to original community pool
+	// the funds will get redistributed back to the account once MoveCommunityPoolFunds runs
+	if accountI != nil {
+		// transfer balance if it exists
+		coins := bankKeeper.GetAllBalances(ctx, maccAddr)
+		if !coins.IsZero() {
+			err := distKeeper.FundCommunityPool(ctx, coins, maccAddr)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	// instantiate new module account
+	modAcc := authtypes.NewEmptyModuleAccount(moduleAccountName, perms...)
+	modAccI := (accountKeeper.NewAccount(ctx, modAcc)).(authtypes.ModuleAccountI) // set and increment the account number
+	accountKeeper.SetModuleAccount(ctx, modAccI)
+}
+
+// MoveCommunityPoolFunds takes the full balance of the original community pool (the auth fee pool)
+// and transfers them to the new community pool (the x/community module account)
+func MoveCommunityPoolFunds(
+	ctx sdk.Context,
+	distKeeper distrkeeper.Keeper,
+	bankKeeper bankkeeper.Keeper,
+) {
+	// get balance of original community pool
+	balance, leftoverDust := distKeeper.GetFeePoolCommunityCoins(ctx).TruncateDecimal()
+
+	// the balance of the community fee pool is held by the distribution module.
+	// transfer whole pool balance from distribution module to new community pool module account
+	err := bankKeeper.SendCoinsFromModuleToModule(
+		ctx,
+		distrtypes.ModuleName,
+		communitytypes.ModuleAccountName,
+		balance,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// make sure x/distribution knows that there're no funds in the community pool.
+	// we keep the leftover decimal change in the account to ensure all funds are accounted for.
+	feePool := distKeeper.GetFeePool(ctx)
+	feePool.CommunityPool = leftoverDust
+	distKeeper.SetFeePool(ctx, feePool)
+}
+
+func DisableMintInflation(ctx sdk.Context, mintKeeper mintkeeper.Keeper) {
+	// set params to have min & max inflation of 0%
+	params := mintKeeper.GetParams(ctx)
+	params.InflationMax = sdk.ZeroDec()
+	params.InflationMin = sdk.ZeroDec()
+	mintKeeper.SetParams(ctx, params)
+
+	// set minter state to reflect 0% inflation
+	mintKeeper.SetMinter(ctx, minttypes.NewMinter(sdk.ZeroDec(), sdk.ZeroDec()))
+}
+
+func DisableCommunityTax(ctx sdk.Context, distrKeeper distrkeeper.Keeper) {
+	params := distrKeeper.GetParams(ctx)
+	params.CommunityTax = sdk.ZeroDec()
+	distrKeeper.SetParams(ctx, params)
+}
+
+func InitializeKavamintState(ctx sdk.Context, kavamintKeeper kavamintkeeper.Keeper) {
+	// init inflationary params for x/kavamint
+	params := kavaminttypes.NewParams(CommunityPoolInflation, StakingRewardsApy)
+	kavamintKeeper.SetParams(ctx, params)
+	// set previous block time to current block's time
+	kavamintKeeper.SetPreviousBlockTime(ctx, ctx.BlockTime())
+}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -21,8 +21,8 @@ const (
 )
 
 var (
-	MainnetCommunityPoolInflation = sdk.OneDec()             // 100%
-	MainnetStakingRewardsApy      = sdk.NewDecWithPrec(5, 2) // 5%
+	MainnetCommunityPoolInflation = sdk.NewDecWithPrec(75, 2) // 75%
+	MainnetStakingRewardsApy      = sdk.NewDecWithPrec(15, 2) // 15%
 
 	TestnetCommunityPoolInflation = sdk.OneDec()             // 100%
 	TestnetStakingRewardsApy      = sdk.NewDecWithPrec(5, 2) // 5%


### PR DESCRIPTION
Registers two upgrade handlers:
`v0.20.0` for mainnet upgrade
`v0.20.0-alpha.0` for testnet upgrade

* initializes x/community & x/kavamint modules
* moves original community pool funds to new community pool
* ~~turns off vanilla x/mint inflation~~ removes x/mint
* sets x/distribution community_tax to 0%
* initializes x/kavamint state

as of 1/3, the actual kavamint params set in the mainnet upgrade handler are placeholders.

i've done the following acceptance testing on the chain after the upgrade runs:
```
# kavamint params properly initialized
$ kava q kavamint params
community_pool_inflation: "0.700000000000000000"
staking_rewards_apy: "0.100000000000000000"

# vanilla minting disabled
$ kava q mint params <-------------- mint is no longer a command.

# community tax disabled
$ kava q distribution params
base_proposer_reward: "0.010000000000000000"
bonus_proposer_reward: "0.040000000000000000"
community_tax: "0.000000000000000000" # <-------------- set to zero
withdraw_addr_enabled: true

# original community balance drained
$ kava q distribution community-pool          
pool:
- amount: "0.040000000000000000" # <-------------- only decimal dust remains
  denom: ukava

# new community pool is funded
$ kava q community balance
coins:
- amount: "632169609611"
  denom: ukava
  
# validator rewards accrue every block
$ kava q distribution validator-outstanding-rewards kavavaloper1ak4pa9z2aty94ze2cs06wsdnkg9hsvfkvr4tha
rewards:
- amount: "1616045350.960000000000000000" # <-------------- growing each block
  denom: ukava
```