### PR TITLE
Setup CLI for x/community lend proposals

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -104,6 +104,7 @@ import (
 	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
 	committeetypes "github.com/kava-labs/kava/x/committee/types"
 	"github.com/kava-labs/kava/x/community"
+	communityclient "github.com/kava-labs/kava/x/community/client"
 	communitykeeper "github.com/kava-labs/kava/x/community/keeper"
 	communitytypes "github.com/kava-labs/kava/x/community/types"
 	earn "github.com/kava-labs/kava/x/earn"
@@ -176,6 +177,7 @@ var (
 			committeeclient.ProposalHandler,
 			earnclient.DepositProposalHandler,
 			earnclient.WithdrawProposalHandler,
+			communityclient.LendDepositProposalHandler,
 		),
 		params.AppModuleBasic{},
 		crisis.AppModuleBasic{},

--- a/app/app.go
+++ b/app/app.go
@@ -178,6 +178,7 @@ var (
 			earnclient.DepositProposalHandler,
 			earnclient.WithdrawProposalHandler,
 			communityclient.LendDepositProposalHandler,
+			communityclient.LendWithdrawProposalHandler,
 		),
 		params.AppModuleBasic{},
 		crisis.AppModuleBasic{},

--- a/x/community/client/cli/tx.go
+++ b/x/community/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -10,8 +11,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
+	"github.com/kava-labs/kava/x/community/client/utils"
 	"github.com/kava-labs/kava/x/community/types"
+)
+
+const (
+	flagDeposit = "deposit"
 )
 
 // GetTxCmd returns the transaction commands for this module
@@ -63,4 +70,73 @@ func getCmdFundCommunityPool() *cobra.Command {
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},
 	}
+}
+
+// NewCmdSubmitCommunityPoolLendDepositProposal implements the command to submit a community-pool lend deposit proposal
+func NewCmdSubmitCommunityPoolLendDepositProposal() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "community-pool-lend-deposit [proposal-file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Submit a community pool lend deposit proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a community pool lend deposit proposal along with an initial deposit.
+The proposal details must be supplied via a JSON file.
+Note that --deposit below is the initial proposal deposit submitted along with the proposal.
+Example:
+$ %s tx gov submit-proposal community-pool-lend-deposit <path/to/proposal.json> --deposit 1000000000ukava --from=<key_or_address>
+Where proposal.json contains:
+{
+  "title": "Community Pool Deposit",
+  "description": "Deposit some KAVA from community pool!",
+  "amount": [
+    {
+      "denom": "ukava",
+      "amount": "100000000000"
+    }
+  ]
+}
+`,
+				version.AppName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			// parse proposal
+			proposal, err := utils.ParseCommunityPoolLendDepositProposal(clientCtx.Codec, args[0])
+			if err != nil {
+				return err
+			}
+
+			// parse initial deposit
+			depositStr, err := cmd.Flags().GetString(flagDeposit)
+			if err != nil {
+				return fmt.Errorf("no initial deposit found. did you set --deposit? %s", err)
+			}
+			deposit, err := sdk.ParseCoinsNormalized(depositStr)
+			if err != nil {
+				return fmt.Errorf("unable to parse deposit: %s", err)
+			}
+			if !deposit.IsValid() || deposit.IsZero() {
+				return fmt.Errorf("no initial deposit set, use --deposit flag")
+			}
+
+			from := clientCtx.GetFromAddress()
+			msg, err := govtypes.NewMsgSubmitProposal(&proposal, deposit, from)
+			if err != nil {
+				return err
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagDeposit, "", "Initial deposit for the proposal")
+
+	return cmd
 }

--- a/x/community/client/cli/tx.go
+++ b/x/community/client/cli/tx.go
@@ -110,17 +110,9 @@ Where proposal.json contains:
 				return err
 			}
 
-			// parse initial deposit
-			depositStr, err := cmd.Flags().GetString(flagDeposit)
+			deposit, err := parseInitialDeposit(cmd)
 			if err != nil {
-				return fmt.Errorf("no initial deposit found. did you set --deposit? %s", err)
-			}
-			deposit, err := sdk.ParseCoinsNormalized(depositStr)
-			if err != nil {
-				return fmt.Errorf("unable to parse deposit: %s", err)
-			}
-			if !deposit.IsValid() || deposit.IsZero() {
-				return fmt.Errorf("no initial deposit set, use --deposit flag")
+				return err
 			}
 
 			from := clientCtx.GetFromAddress()
@@ -139,4 +131,80 @@ Where proposal.json contains:
 	cmd.Flags().String(flagDeposit, "", "Initial deposit for the proposal")
 
 	return cmd
+}
+
+// NewCmdSubmitCommunityPoolLendWithdrawProposal implements the command to submit a community-pool lend withdraw proposal
+func NewCmdSubmitCommunityPoolLendWithdrawProposal() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "community-pool-lend-withdraw [proposal-file]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Submit a community pool lend withdraw proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a community pool lend withdraw proposal along with an initial deposit.
+The proposal details must be supplied via a JSON file.
+Note that --deposit below is the initial proposal deposit submitted along with the proposal.
+Example:
+$ %s tx gov submit-proposal community-pool-lend-withdraw <path/to/proposal.json> --deposit 1000000000ukava --from=<key_or_address>
+Where proposal.json contains:
+{
+  "title": "Community Pool Withdrawal",
+  "description": "Withdraw some KAVA from community pool!",
+  "amount": [
+    {
+      "denom": "ukava",
+      "amount": "100000000000"
+    }
+  ]
+}
+`,
+				version.AppName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			// parse proposal
+			proposal, err := utils.ParseCommunityPoolLendWithdrawProposal(clientCtx.Codec, args[0])
+			if err != nil {
+				return err
+			}
+
+			deposit, err := parseInitialDeposit(cmd)
+			if err != nil {
+				return err
+			}
+			from := clientCtx.GetFromAddress()
+			msg, err := govtypes.NewMsgSubmitProposal(&proposal, deposit, from)
+			if err != nil {
+				return err
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagDeposit, "", "Initial deposit for the proposal")
+
+	return cmd
+}
+
+func parseInitialDeposit(cmd *cobra.Command) (sdk.Coins, error) {
+	// parse initial deposit
+	depositStr, err := cmd.Flags().GetString(flagDeposit)
+	if err != nil {
+		return nil, fmt.Errorf("no initial deposit found. did you set --deposit? %s", err)
+	}
+	deposit, err := sdk.ParseCoinsNormalized(depositStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse deposit: %s", err)
+	}
+	if !deposit.IsValid() || deposit.IsZero() {
+		return nil, fmt.Errorf("no initial deposit set, use --deposit flag")
+	}
+	return deposit, nil
 }

--- a/x/community/client/proposal_handler.go
+++ b/x/community/client/proposal_handler.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+
+	"github.com/kava-labs/kava/x/community/client/cli"
+)
+
+// community-pool deposit/withdraw lend proposal handlers
+var (
+	LendDepositProposalHandler = govclient.NewProposalHandler(cli.NewCmdSubmitCommunityPoolLendDepositProposal, nil)
+)

--- a/x/community/client/proposal_handler.go
+++ b/x/community/client/proposal_handler.go
@@ -1,12 +1,35 @@
 package client
 
 import (
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client"
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+	govrest "github.com/cosmos/cosmos-sdk/x/gov/client/rest"
 
 	"github.com/kava-labs/kava/x/community/client/cli"
+	"github.com/kava-labs/kava/x/community/types"
 )
 
 // community-pool deposit/withdraw lend proposal handlers
 var (
-	LendDepositProposalHandler = govclient.NewProposalHandler(cli.NewCmdSubmitCommunityPoolLendDepositProposal, nil)
+	LendDepositProposalHandler = govclient.NewProposalHandler(
+		cli.NewCmdSubmitCommunityPoolLendDepositProposal,
+		notImplementedRestHandler(types.ProposalTypeCommunityPoolLendDeposit),
+	)
+	LendWithdrawProposalHandler = govclient.NewProposalHandler(
+		cli.NewCmdSubmitCommunityPoolLendWithdrawProposal,
+		notImplementedRestHandler(types.ProposalTypeCommunityPoolLendDeposit),
+	)
 )
+
+func notImplementedRestHandler(subRoute string) govclient.RESTHandlerFn {
+	return func(ctx client.Context) govrest.ProposalRESTHandler {
+		return govrest.ProposalRESTHandler{
+			SubRoute: subRoute,
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "Unimplemented", http.StatusNotImplemented)
+			},
+		}
+	}
+}

--- a/x/community/client/utils/utils.go
+++ b/x/community/client/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/kava-labs/kava/x/community/types"
+)
+
+func ParseCommunityPoolLendDepositProposal(
+	cdc codec.JSONCodec,
+	proposalFile string,
+) (types.CommunityPoolLendDepositProposal, error) {
+	proposal := types.CommunityPoolLendDepositProposal{}
+	contents, err := os.ReadFile(proposalFile)
+	if err != nil {
+		return proposal, err
+	}
+
+	err = cdc.UnmarshalJSON(contents, &proposal)
+	return proposal, err
+}

--- a/x/community/client/utils/utils.go
+++ b/x/community/client/utils/utils.go
@@ -8,11 +8,27 @@ import (
 	"github.com/kava-labs/kava/x/community/types"
 )
 
+// ParseCommunityPoolLendDepositProposal reads a JSON file and parses it to a CommunityPoolLendDepositProposal
 func ParseCommunityPoolLendDepositProposal(
 	cdc codec.JSONCodec,
 	proposalFile string,
 ) (types.CommunityPoolLendDepositProposal, error) {
 	proposal := types.CommunityPoolLendDepositProposal{}
+	contents, err := os.ReadFile(proposalFile)
+	if err != nil {
+		return proposal, err
+	}
+
+	err = cdc.UnmarshalJSON(contents, &proposal)
+	return proposal, err
+}
+
+// ParseCommunityPoolLendWithdrawProposal reads a JSON file and parses it to a CommunityPoolLendWithdrawProposal
+func ParseCommunityPoolLendWithdrawProposal(
+	cdc codec.JSONCodec,
+	proposalFile string,
+) (types.CommunityPoolLendWithdrawProposal, error) {
+	proposal := types.CommunityPoolLendWithdrawProposal{}
 	contents, err := os.ReadFile(proposalFile)
 	if err != nil {
 		return proposal, err

--- a/x/community/client/utils/utils_test.go
+++ b/x/community/client/utils/utils_test.go
@@ -36,3 +36,28 @@ func TestParseDepositProposal(t *testing.T) {
 	require.Equal(t, "Deposit some KAVA from community pool to Lend!", proposal.Description)
 	require.Equal(t, expectedAmount, proposal.Amount)
 }
+
+func TestParseWithdrawProposal(t *testing.T) {
+	cdc := codec.NewAminoCodec(codec.NewLegacyAmino())
+	okJSON := testutil.WriteToNewTempFile(t, `
+{
+  "title": "Community Pool Lend Withdraw",
+  "description": "Withdraw some KAVA from community pool to Lend!",
+  "amount": [
+    {
+      "denom": "ukava",
+      "amount": "100000000000"
+    }
+  ]
+}
+`)
+	proposal, err := utils.ParseCommunityPoolLendWithdrawProposal(cdc, okJSON.Name())
+	require.NoError(t, err)
+
+	expectedAmount, err := sdk.ParseCoinsNormalized("100000000000ukava")
+	require.NoError(t, err)
+
+	require.Equal(t, "Community Pool Lend Withdraw", proposal.Title)
+	require.Equal(t, "Withdraw some KAVA from community pool to Lend!", proposal.Description)
+	require.Equal(t, expectedAmount, proposal.Amount)
+}

--- a/x/community/client/utils/utils_test.go
+++ b/x/community/client/utils/utils_test.go
@@ -1,0 +1,38 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kava-labs/kava/x/community/client/utils"
+)
+
+func TestParseDepositProposal(t *testing.T) {
+	cdc := codec.NewAminoCodec(codec.NewLegacyAmino())
+	okJSON := testutil.WriteToNewTempFile(t, `
+{
+  "title": "Community Pool Lend Deposit",
+  "description": "Deposit some KAVA from community pool to Lend!",
+  "amount": [
+    {
+      "denom": "ukava",
+      "amount": "100000000000"
+    }
+  ]
+}
+`)
+	proposal, err := utils.ParseCommunityPoolLendDepositProposal(cdc, okJSON.Name())
+	require.NoError(t, err)
+
+	expectedAmount, err := sdk.ParseCoinsNormalized("100000000000ukava")
+	require.NoError(t, err)
+
+	require.Equal(t, "Community Pool Lend Deposit", proposal.Title)
+	require.Equal(t, "Deposit some KAVA from community pool to Lend!", proposal.Description)
+	require.Equal(t, expectedAmount, proposal.Amount)
+}


### PR DESCRIPTION
adds cli support for the `CommunityPoolLendDepositProposal` & `CommunityPoolLendWithdrawProposal`

the cli command is, respectively, `kava tx gov community-pool-lend-deposit` & `community-pool-lend-withdraw`

rather than include proto defs for JSON proposals that include a `deposit` field for the initial deposit, i setup the command to have a `--deposit` flag that takes the initial proposal deposit to send with the proposal.

in place of the REST handlers, i simple return a 501, not implemented error.