### PR TITLE
Add LegacyCommunityPool query to x/community

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -614,6 +614,7 @@ func NewApp(
 	app.communityKeeper = communitykeeper.NewKeeper(
 		app.accountKeeper,
 		app.bankKeeper,
+		app.distrKeeper,
 		hardKeeper,
 	)
 	app.kavadistKeeper = kavadistkeeper.NewKeeper(

--- a/docs/core/proto-docs.md
+++ b/docs/core/proto-docs.md
@@ -185,6 +185,8 @@
 - [kava/community/v1beta1/query.proto](#kava/community/v1beta1/query.proto)
     - [QueryBalanceRequest](#kava.community.v1beta1.QueryBalanceRequest)
     - [QueryBalanceResponse](#kava.community.v1beta1.QueryBalanceResponse)
+    - [QueryLegacyCommunityPoolRequest](#kava.community.v1beta1.QueryLegacyCommunityPoolRequest)
+    - [QueryLegacyCommunityPoolResponse](#kava.community.v1beta1.QueryLegacyCommunityPoolResponse)
   
     - [Query](#kava.community.v1beta1.Query)
   
@@ -2923,6 +2925,32 @@ QueryBalanceResponse defines the response type for querying x/community balance.
 
 
 
+
+<a name="kava.community.v1beta1.QueryLegacyCommunityPoolRequest"></a>
+
+### QueryLegacyCommunityPoolRequest
+QueryLegacyCommunityPoolRequest defines the request type for querying the legacy community pool balance.
+
+
+
+
+
+
+<a name="kava.community.v1beta1.QueryLegacyCommunityPoolResponse"></a>
+
+### QueryLegacyCommunityPoolResponse
+QueryLegacyCommunityPoolResponse defines the response type for querying legacy community pool.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `address` | [string](#string) |  |  |
+| `balance` | [cosmos.base.v1beta1.DecCoin](#cosmos.base.v1beta1.DecCoin) | repeated |  |
+
+
+
+
+
  <!-- end messages -->
 
  <!-- end enums -->
@@ -2938,6 +2966,7 @@ Query defines the gRPC querier service for x/community.
 | Method Name | Request Type | Response Type | Description | HTTP Verb | Endpoint |
 | ----------- | ------------ | ------------- | ------------| ------- | -------- |
 | `Balance` | [QueryBalanceRequest](#kava.community.v1beta1.QueryBalanceRequest) | [QueryBalanceResponse](#kava.community.v1beta1.QueryBalanceResponse) | Balance queries the balance of all coins of x/community module. | GET|/kava/community/v1beta1/balance|
+| `LegacyCommunityPool` | [QueryLegacyCommunityPoolRequest](#kava.community.v1beta1.QueryLegacyCommunityPoolRequest) | [QueryLegacyCommunityPoolResponse](#kava.community.v1beta1.QueryLegacyCommunityPoolResponse) | LegacyCommunityPool queries the balance of all coins of the legacy community pool. The legacy community pool is a subaccount of the fee pool and has been replaced by x/community. | GET|/kava/community/v1beta1/legacy_community_pool|
 
  <!-- end services -->
 

--- a/proto/kava/community/v1beta1/query.proto
+++ b/proto/kava/community/v1beta1/query.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package kava.community.v1beta1;
 
 import "cosmos/base/v1beta1/coin.proto";
+import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 
@@ -13,6 +14,12 @@ service Query {
   rpc Balance(QueryBalanceRequest) returns (QueryBalanceResponse) {
     option (google.api.http).get = "/kava/community/v1beta1/balance";
   }
+
+  // LegacyCommunityPool queries the balance of all coins of the legacy community pool.
+  // The legacy community pool is a subaccount of the fee pool and has been replaced by x/community.
+  rpc LegacyCommunityPool(QueryLegacyCommunityPoolRequest) returns (QueryLegacyCommunityPoolResponse) {
+    option (google.api.http).get = "/kava/community/v1beta1/legacy_community_pool";
+  }
 }
 
 // QueryBalanceRequest defines the request type for querying x/community balance.
@@ -23,5 +30,17 @@ message QueryBalanceResponse {
   repeated cosmos.base.v1beta1.Coin coins = 1 [
     (gogoproto.nullable) = false,
     (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// QueryLegacyCommunityPoolRequest defines the request type for querying the legacy community pool balance.
+message QueryLegacyCommunityPoolRequest {}
+
+// QueryLegacyCommunityPoolResponse defines the response type for querying legacy community pool.
+message QueryLegacyCommunityPoolResponse {
+  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  repeated cosmos.base.v1beta1.DecCoin balance = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.DecCoins"
   ];
 }

--- a/x/community/client/cli/query.go
+++ b/x/community/client/cli/query.go
@@ -20,6 +20,7 @@ func GetQueryCmd() *cobra.Command {
 
 	commands := []*cobra.Command{
 		GetCmdQueryBalance(),
+		LegacyCommunityPoolCmd(),
 	}
 
 	for _, cmd := range commands {
@@ -45,6 +46,29 @@ func GetCmdQueryBalance() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			res, err := queryClient.Balance(cmd.Context(), &types.QueryBalanceRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+}
+
+// LegacyCommunityPoolCmd implements a command to return the legacy community pool balance.
+func LegacyCommunityPoolCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "legacy-community-pool",
+		Short: "Query the current balance of the legacy community pool",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.LegacyCommunityPool(cmd.Context(), &types.QueryLegacyCommunityPoolRequest{})
 			if err != nil {
 				return err
 			}

--- a/x/community/keeper/grpc_query.go
+++ b/x/community/keeper/grpc_query.go
@@ -27,6 +27,11 @@ func (s queryServer) Balance(c context.Context, _ *types.QueryBalanceRequest) (*
 }
 
 // LegacyCommunityPool implements the gRPC service handler for querying the legacy community pool balance.
-func (s queryServer) LegacyCommunityPool(_ context.Context, _ *types.QueryLegacyCommunityPoolRequest) (*types.QueryLegacyCommunityPoolResponse, error) {
-	panic("not implemented") // TODO implement me
+func (s queryServer) LegacyCommunityPool(c context.Context, _ *types.QueryLegacyCommunityPoolRequest) (*types.QueryLegacyCommunityPoolResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	balance := s.keeper.distrKeeper.GetFeePoolCommunityCoins(ctx)
+	return &types.QueryLegacyCommunityPoolResponse{
+		Address: s.keeper.legacyCommunityPoolAddress.String(),
+		Balance: balance,
+	}, nil
 }

--- a/x/community/keeper/grpc_query.go
+++ b/x/community/keeper/grpc_query.go
@@ -18,9 +18,15 @@ func NewQueryServerImpl(k Keeper) types.QueryServer {
 	return &queryServer{keeper: k}
 }
 
+// Balance implements the gRPC service handler for querying x/community balance.
 func (s queryServer) Balance(c context.Context, _ *types.QueryBalanceRequest) (*types.QueryBalanceResponse, error) {
 	ctx := sdk.UnwrapSDKContext(c)
 	return &types.QueryBalanceResponse{
 		Coins: s.keeper.GetModuleAccountBalance(ctx),
 	}, nil
+}
+
+// LegacyCommunityPool implements the gRPC service handler for querying the legacy community pool balance.
+func (s queryServer) LegacyCommunityPool(_ context.Context, _ *types.QueryLegacyCommunityPoolRequest) (*types.QueryLegacyCommunityPoolResponse, error) {
+	panic("not implemented") // TODO implement me
 }

--- a/x/community/keeper/keeper.go
+++ b/x/community/keeper/keeper.go
@@ -12,12 +12,13 @@ import (
 // Keeper of the community store
 type Keeper struct {
 	bankKeeper    types.BankKeeper
+	distrKeeper   types.DistributionKeeper
 	hardKeeper    types.HardKeeper
 	moduleAddress sdk.AccAddress
 }
 
 // NewKeeper creates a new community Keeper instance
-func NewKeeper(ak types.AccountKeeper, bk types.BankKeeper, hk types.HardKeeper) Keeper {
+func NewKeeper(ak types.AccountKeeper, bk types.BankKeeper, dk types.DistributionKeeper, hk types.HardKeeper) Keeper {
 	// ensure community module account is set
 	addr := ak.GetModuleAddress(types.ModuleAccountName)
 	if addr == nil {
@@ -26,6 +27,7 @@ func NewKeeper(ak types.AccountKeeper, bk types.BankKeeper, hk types.HardKeeper)
 
 	return Keeper{
 		bankKeeper:    bk,
+		distrKeeper:   dk,
 		hardKeeper:    hk,
 		moduleAddress: addr,
 	}

--- a/x/community/keeper/keeper.go
+++ b/x/community/keeper/keeper.go
@@ -15,6 +15,8 @@ type Keeper struct {
 	distrKeeper   types.DistributionKeeper
 	hardKeeper    types.HardKeeper
 	moduleAddress sdk.AccAddress
+
+	legacyCommunityPoolAddress sdk.AccAddress
 }
 
 // NewKeeper creates a new community Keeper instance
@@ -24,12 +26,18 @@ func NewKeeper(ak types.AccountKeeper, bk types.BankKeeper, dk types.Distributio
 	if addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleAccountName))
 	}
+	legacyAddr := ak.GetModuleAddress(types.LegacyCommunityPoolModuleName)
+	if addr == nil {
+		panic("legacy community pool address not found")
+	}
 
 	return Keeper{
 		bankKeeper:    bk,
 		distrKeeper:   dk,
 		hardKeeper:    hk,
 		moduleAddress: addr,
+
+		legacyCommunityPoolAddress: legacyAddr,
 	}
 }
 

--- a/x/community/types/expected_keepers.go
+++ b/x/community/types/expected_keepers.go
@@ -24,3 +24,8 @@ type HardKeeper interface {
 	Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coins) error
 	Withdraw(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coins) error
 }
+
+// DistributionKeeper defines the contract needed to be fulfilled for distribution dependencies.
+type DistributionKeeper interface {
+	GetFeePoolCommunityCoins(ctx sdk.Context) sdk.DecCoins
+}

--- a/x/community/types/keys.go
+++ b/x/community/types/keys.go
@@ -12,4 +12,8 @@ const (
 
 	// Query endpoints supported by community
 	QueryBalance = "balance"
+
+	// LegacyCommunityPoolModuleName is the module account name used by the legacy community pool
+	// It is used to determine the address of the old community pool to be returned with the legacy balance.
+	LegacyCommunityPoolModuleName = "distribution"
 )

--- a/x/community/types/query.pb.go
+++ b/x/community/types/query.pb.go
@@ -6,6 +6,7 @@ package types
 import (
 	context "context"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/gogo/protobuf/gogoproto"
@@ -113,9 +114,101 @@ func (m *QueryBalanceResponse) GetCoins() github_com_cosmos_cosmos_sdk_types.Coi
 	return nil
 }
 
+// QueryLegacyCommunityPoolRequest defines the request type for querying the legacy community pool balance.
+type QueryLegacyCommunityPoolRequest struct {
+}
+
+func (m *QueryLegacyCommunityPoolRequest) Reset()         { *m = QueryLegacyCommunityPoolRequest{} }
+func (m *QueryLegacyCommunityPoolRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryLegacyCommunityPoolRequest) ProtoMessage()    {}
+func (*QueryLegacyCommunityPoolRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f236f06c43149273, []int{2}
+}
+func (m *QueryLegacyCommunityPoolRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryLegacyCommunityPoolRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryLegacyCommunityPoolRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryLegacyCommunityPoolRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryLegacyCommunityPoolRequest.Merge(m, src)
+}
+func (m *QueryLegacyCommunityPoolRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryLegacyCommunityPoolRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryLegacyCommunityPoolRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryLegacyCommunityPoolRequest proto.InternalMessageInfo
+
+// QueryLegacyCommunityPoolResponse defines the response type for querying legacy community pool.
+type QueryLegacyCommunityPoolResponse struct {
+	Address string                                      `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Balance github_com_cosmos_cosmos_sdk_types.DecCoins `protobuf:"bytes,2,rep,name=balance,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.DecCoins" json:"balance"`
+}
+
+func (m *QueryLegacyCommunityPoolResponse) Reset()         { *m = QueryLegacyCommunityPoolResponse{} }
+func (m *QueryLegacyCommunityPoolResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryLegacyCommunityPoolResponse) ProtoMessage()    {}
+func (*QueryLegacyCommunityPoolResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_f236f06c43149273, []int{3}
+}
+func (m *QueryLegacyCommunityPoolResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryLegacyCommunityPoolResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryLegacyCommunityPoolResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryLegacyCommunityPoolResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryLegacyCommunityPoolResponse.Merge(m, src)
+}
+func (m *QueryLegacyCommunityPoolResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryLegacyCommunityPoolResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryLegacyCommunityPoolResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryLegacyCommunityPoolResponse proto.InternalMessageInfo
+
+func (m *QueryLegacyCommunityPoolResponse) GetAddress() string {
+	if m != nil {
+		return m.Address
+	}
+	return ""
+}
+
+func (m *QueryLegacyCommunityPoolResponse) GetBalance() github_com_cosmos_cosmos_sdk_types.DecCoins {
+	if m != nil {
+		return m.Balance
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryBalanceRequest)(nil), "kava.community.v1beta1.QueryBalanceRequest")
 	proto.RegisterType((*QueryBalanceResponse)(nil), "kava.community.v1beta1.QueryBalanceResponse")
+	proto.RegisterType((*QueryLegacyCommunityPoolRequest)(nil), "kava.community.v1beta1.QueryLegacyCommunityPoolRequest")
+	proto.RegisterType((*QueryLegacyCommunityPoolResponse)(nil), "kava.community.v1beta1.QueryLegacyCommunityPoolResponse")
 }
 
 func init() {
@@ -123,28 +216,36 @@ func init() {
 }
 
 var fileDescriptor_f236f06c43149273 = []byte{
-	// 325 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x51, 0x4f, 0x4a, 0xf3, 0x40,
-	0x14, 0x4f, 0xbe, 0x8f, 0x2a, 0xc4, 0x5d, 0xac, 0xa2, 0x45, 0xa6, 0x9a, 0x8d, 0x85, 0xda, 0x19,
-	0x5b, 0x6f, 0x50, 0xf1, 0x00, 0x76, 0xe9, 0x6e, 0x26, 0x0e, 0x71, 0x68, 0x3b, 0x2f, 0xed, 0x9b,
-	0x14, 0xb3, 0x75, 0x2f, 0x08, 0x2e, 0xbc, 0x83, 0x27, 0xe9, 0xb2, 0xe0, 0xc6, 0x95, 0x4a, 0xeb,
-	0x41, 0x64, 0x32, 0xb1, 0x54, 0xa8, 0xe0, 0x2a, 0x8f, 0x97, 0xdf, 0xdf, 0x37, 0x41, 0xd4, 0xe7,
-	0x13, 0xce, 0x62, 0x18, 0x0e, 0x33, 0xad, 0x4c, 0xce, 0x26, 0x6d, 0x21, 0x0d, 0x6f, 0xb3, 0x51,
-	0x26, 0xc7, 0x39, 0x4d, 0xc7, 0x60, 0x20, 0xdc, 0xb5, 0x18, 0xba, 0xc4, 0xd0, 0x12, 0x53, 0x23,
-	0x31, 0xe0, 0x10, 0x90, 0x09, 0x8e, 0x72, 0x49, 0x8c, 0x41, 0x69, 0xc7, 0xab, 0x55, 0x13, 0x48,
-	0xa0, 0x18, 0x99, 0x9d, 0xca, 0xed, 0x41, 0x02, 0x90, 0x0c, 0x24, 0xe3, 0xa9, 0x62, 0x5c, 0x6b,
-	0x30, 0xdc, 0x28, 0xd0, 0xe8, 0xfe, 0x46, 0x3b, 0xc1, 0xf6, 0xa5, 0xb5, 0xee, 0xf2, 0x01, 0xd7,
-	0xb1, 0xec, 0xc9, 0x51, 0x26, 0xd1, 0x44, 0x79, 0x50, 0xfd, 0xb9, 0xc6, 0x14, 0x34, 0xca, 0x90,
-	0x07, 0x15, 0x6b, 0x88, 0x7b, 0xfe, 0xe1, 0xff, 0xc6, 0x56, 0x67, 0x9f, 0xba, 0x48, 0xd4, 0x46,
-	0xfa, 0xce, 0x49, 0xcf, 0x41, 0xe9, 0xee, 0xe9, 0xf4, 0xad, 0xee, 0x3d, 0xbf, 0xd7, 0x1b, 0x89,
-	0x32, 0x37, 0x99, 0xb0, 0x75, 0x58, 0x99, 0xdf, 0x7d, 0x5a, 0x78, 0xdd, 0x67, 0x26, 0x4f, 0x25,
-	0x16, 0x04, 0xec, 0x39, 0xe5, 0xce, 0x93, 0x1f, 0x54, 0x0a, 0xef, 0xf0, 0xde, 0x0f, 0x36, 0xcb,
-	0x00, 0x61, 0x93, 0xae, 0x3f, 0x0a, 0x5d, 0x93, 0xbe, 0x76, 0xf2, 0x37, 0xb0, 0xeb, 0x14, 0x1d,
-	0xdf, 0xbd, 0x7c, 0x3e, 0xfe, 0x3b, 0x0a, 0xeb, 0xec, 0x97, 0xb7, 0x11, 0x8e, 0xd0, 0xbd, 0x98,
-	0xce, 0x89, 0x3f, 0x9b, 0x13, 0xff, 0x63, 0x4e, 0xfc, 0x87, 0x05, 0xf1, 0x66, 0x0b, 0xe2, 0xbd,
-	0x2e, 0x88, 0x77, 0xd5, 0x5c, 0x29, 0x69, 0x45, 0x5a, 0x03, 0x2e, 0xd0, 0xc9, 0xdd, 0xae, 0x08,
-	0x16, 0x6d, 0xc5, 0x46, 0x71, 0xf9, 0xb3, 0xaf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x8f, 0x7f,
-	0x0d, 0x0b, 0x02, 0x00, 0x00,
+	// 463 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0xbf, 0x6f, 0xd3, 0x40,
+	0x14, 0xc7, 0x73, 0x41, 0x25, 0xe2, 0xd8, 0xae, 0x01, 0xa5, 0x51, 0xe5, 0xb4, 0x5e, 0x88, 0x54,
+	0xe2, 0xa3, 0xa9, 0x10, 0xac, 0xa4, 0xb0, 0x31, 0x40, 0xd8, 0x58, 0xa2, 0xb3, 0x73, 0x32, 0x56,
+	0x9c, 0x7b, 0xae, 0xef, 0x5c, 0xe1, 0x95, 0x1d, 0x09, 0x89, 0xff, 0x82, 0x99, 0x9d, 0x81, 0xa5,
+	0x63, 0x05, 0x0b, 0x2c, 0x80, 0x12, 0xfe, 0x10, 0x74, 0x3f, 0x1c, 0x15, 0xc9, 0x46, 0x61, 0x4a,
+	0xee, 0xde, 0xfb, 0xbe, 0xf7, 0xf9, 0xbe, 0x77, 0xc6, 0xfe, 0x82, 0x9d, 0x33, 0x1a, 0xc1, 0x72,
+	0x59, 0x88, 0x44, 0x95, 0xf4, 0xfc, 0x38, 0xe4, 0x8a, 0x1d, 0xd3, 0xb3, 0x82, 0xe7, 0x65, 0x90,
+	0xe5, 0xa0, 0x80, 0xdc, 0xd6, 0x39, 0xc1, 0x26, 0x27, 0x70, 0x39, 0x7d, 0x2f, 0x02, 0xb9, 0x04,
+	0x49, 0x43, 0x26, 0xf9, 0x46, 0x18, 0x41, 0x22, 0xac, 0xae, 0xbf, 0x67, 0xe3, 0x33, 0x73, 0xa2,
+	0xf6, 0xe0, 0x42, 0xdd, 0x18, 0x62, 0xb0, 0xf7, 0xfa, 0x9f, 0xbb, 0xdd, 0x8f, 0x01, 0xe2, 0x94,
+	0x53, 0x96, 0x25, 0x94, 0x09, 0x01, 0x8a, 0xa9, 0x04, 0x84, 0xd3, 0xf8, 0xb7, 0xf0, 0xee, 0x73,
+	0x4d, 0x35, 0x61, 0x29, 0x13, 0x11, 0x9f, 0xf2, 0xb3, 0x82, 0x4b, 0xe5, 0x97, 0xb8, 0xfb, 0xf7,
+	0xb5, 0xcc, 0x40, 0x48, 0x4e, 0x18, 0xde, 0xd1, 0x2c, 0xb2, 0x87, 0x0e, 0xae, 0x0d, 0x6f, 0x8e,
+	0xf7, 0x02, 0x07, 0xa0, 0x69, 0x2b, 0x0b, 0xc1, 0x29, 0x24, 0x62, 0x72, 0xef, 0xe2, 0xc7, 0xa0,
+	0xf5, 0xe1, 0xe7, 0x60, 0x18, 0x27, 0xea, 0x55, 0x11, 0x6a, 0xa7, 0x8e, 0xd6, 0xfd, 0x8c, 0xe4,
+	0x7c, 0x41, 0x55, 0x99, 0x71, 0x69, 0x04, 0x72, 0x6a, 0x2b, 0xfb, 0x87, 0x78, 0x60, 0x5a, 0x3f,
+	0xe5, 0x31, 0x8b, 0xca, 0xd3, 0x6a, 0x40, 0xcf, 0x00, 0xd2, 0x8a, 0xee, 0x33, 0xc2, 0x07, 0xcd,
+	0x39, 0x0e, 0x75, 0x8c, 0x3b, 0x6c, 0x3e, 0xcf, 0xb9, 0xd4, 0xb0, 0x68, 0x78, 0x63, 0xd2, 0xfb,
+	0xf2, 0x71, 0xd4, 0x75, 0xbc, 0x8f, 0x6c, 0xe4, 0x85, 0xca, 0x13, 0x11, 0x4f, 0xab, 0x44, 0xb2,
+	0xc0, 0x9d, 0xd0, 0x3a, 0xee, 0xb5, 0x8d, 0xc1, 0xfd, 0x5a, 0x83, 0x8f, 0x79, 0x64, 0x3c, 0x9e,
+	0x38, 0x8f, 0x47, 0x5b, 0x78, 0x74, 0x1a, 0x39, 0xad, 0x3a, 0x8c, 0xbf, 0xb7, 0xf1, 0x8e, 0x71,
+	0x41, 0xde, 0x22, 0xdc, 0x71, 0x93, 0x26, 0x47, 0x41, 0xfd, 0xc3, 0x08, 0x6a, 0xd6, 0xd4, 0xbf,
+	0xbb, 0x5d, 0xb2, 0x9d, 0x88, 0x7f, 0xe7, 0xcd, 0xd7, 0xdf, 0xef, 0xdb, 0x87, 0x64, 0x40, 0x1b,
+	0xde, 0xa7, 0x23, 0x23, 0x9f, 0x10, 0xde, 0xad, 0x19, 0x2d, 0x79, 0xf0, 0xcf, 0x76, 0xcd, 0x0b,
+	0xeb, 0x3f, 0xfc, 0x7f, 0xa1, 0x63, 0xbe, 0x6f, 0x98, 0x29, 0x19, 0x35, 0x31, 0xa7, 0x46, 0x3c,
+	0xdb, 0x04, 0x66, 0x19, 0x40, 0x3a, 0x79, 0x72, 0xb1, 0xf2, 0xd0, 0xe5, 0xca, 0x43, 0xbf, 0x56,
+	0x1e, 0x7a, 0xb7, 0xf6, 0x5a, 0x97, 0x6b, 0xaf, 0xf5, 0x6d, 0xed, 0xb5, 0x5e, 0x5e, 0xdd, 0x95,
+	0x2e, 0x39, 0x4a, 0x59, 0x28, 0x6d, 0xf1, 0xd7, 0x57, 0xca, 0x9b, 0xa5, 0x85, 0xd7, 0xcd, 0x47,
+	0x72, 0xf2, 0x27, 0x00, 0x00, 0xff, 0xff, 0x4d, 0x64, 0x99, 0x49, 0xd1, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -161,6 +262,9 @@ const _ = grpc.SupportPackageIsVersion4
 type QueryClient interface {
 	// Balance queries the balance of all coins of x/community module.
 	Balance(ctx context.Context, in *QueryBalanceRequest, opts ...grpc.CallOption) (*QueryBalanceResponse, error)
+	// LegacyCommunityPool queries the balance of all coins of the legacy community pool.
+	// The legacy community pool is a subaccount of the fee pool and has been replaced by x/community.
+	LegacyCommunityPool(ctx context.Context, in *QueryLegacyCommunityPoolRequest, opts ...grpc.CallOption) (*QueryLegacyCommunityPoolResponse, error)
 }
 
 type queryClient struct {
@@ -180,10 +284,22 @@ func (c *queryClient) Balance(ctx context.Context, in *QueryBalanceRequest, opts
 	return out, nil
 }
 
+func (c *queryClient) LegacyCommunityPool(ctx context.Context, in *QueryLegacyCommunityPoolRequest, opts ...grpc.CallOption) (*QueryLegacyCommunityPoolResponse, error) {
+	out := new(QueryLegacyCommunityPoolResponse)
+	err := c.cc.Invoke(ctx, "/kava.community.v1beta1.Query/LegacyCommunityPool", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Balance queries the balance of all coins of x/community module.
 	Balance(context.Context, *QueryBalanceRequest) (*QueryBalanceResponse, error)
+	// LegacyCommunityPool queries the balance of all coins of the legacy community pool.
+	// The legacy community pool is a subaccount of the fee pool and has been replaced by x/community.
+	LegacyCommunityPool(context.Context, *QueryLegacyCommunityPoolRequest) (*QueryLegacyCommunityPoolResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -192,6 +308,9 @@ type UnimplementedQueryServer struct {
 
 func (*UnimplementedQueryServer) Balance(ctx context.Context, req *QueryBalanceRequest) (*QueryBalanceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Balance not implemented")
+}
+func (*UnimplementedQueryServer) LegacyCommunityPool(ctx context.Context, req *QueryLegacyCommunityPoolRequest) (*QueryLegacyCommunityPoolResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method LegacyCommunityPool not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -216,6 +335,24 @@ func _Query_Balance_Handler(srv interface{}, ctx context.Context, dec func(inter
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_LegacyCommunityPool_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryLegacyCommunityPoolRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).LegacyCommunityPool(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/kava.community.v1beta1.Query/LegacyCommunityPool",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).LegacyCommunityPool(ctx, req.(*QueryLegacyCommunityPoolRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "kava.community.v1beta1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -223,6 +360,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Balance",
 			Handler:    _Query_Balance_Handler,
+		},
+		{
+			MethodName: "LegacyCommunityPool",
+			Handler:    _Query_LegacyCommunityPool_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -289,6 +430,73 @@ func (m *QueryBalanceResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryLegacyCommunityPoolRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryLegacyCommunityPoolRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryLegacyCommunityPoolRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryLegacyCommunityPoolResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryLegacyCommunityPoolResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryLegacyCommunityPoolResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Balance) > 0 {
+		for iNdEx := len(m.Balance) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Balance[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -317,6 +525,34 @@ func (m *QueryBalanceResponse) Size() (n int) {
 	_ = l
 	if len(m.Coins) > 0 {
 		for _, e := range m.Coins {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *QueryLegacyCommunityPoolRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *QueryLegacyCommunityPoolResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	if len(m.Balance) > 0 {
+		for _, e := range m.Balance {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
@@ -440,6 +676,172 @@ func (m *QueryBalanceResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Coins = append(m.Coins, types.Coin{})
 			if err := m.Coins[len(m.Coins)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryLegacyCommunityPoolRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryLegacyCommunityPoolRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryLegacyCommunityPoolRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryLegacyCommunityPoolResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryLegacyCommunityPoolResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryLegacyCommunityPoolResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Balance", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Balance = append(m.Balance, types.DecCoin{})
+			if err := m.Balance[len(m.Balance)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/community/types/query.pb.gw.go
+++ b/x/community/types/query.pb.gw.go
@@ -51,6 +51,24 @@ func local_request_Query_Balance_0(ctx context.Context, marshaler runtime.Marsha
 
 }
 
+func request_Query_LegacyCommunityPool_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryLegacyCommunityPoolRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.LegacyCommunityPool(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_LegacyCommunityPool_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryLegacyCommunityPoolRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.LegacyCommunityPool(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -77,6 +95,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Balance_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_LegacyCommunityPool_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_LegacyCommunityPool_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_LegacyCommunityPool_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -141,13 +182,37 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_LegacyCommunityPool_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_LegacyCommunityPool_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_LegacyCommunityPool_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
 var (
 	pattern_Query_Balance_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"kava", "community", "v1beta1", "balance"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_LegacyCommunityPool_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"kava", "community", "v1beta1", "legacy_community_pool"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_Balance_0 = runtime.ForwardResponseMessage
+
+	forward_Query_LegacyCommunityPool_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
The new query will query the balance of the vanilla sdk community pool. This will facilitate checking in on the balance of the original community pool after overriding the query to check in x/distribution (see https://github.com/Kava-Labs/kava/pull/1430)

After the migration is run, we'll be able to verify that the balance has been fully transferred to the new community pool.
We'll also be able to query the historical value of the community pool after the original query is overridden.