### PR TITLE
add ci action for build & publish to docker hub

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,45 @@
+name: Build & Publish Docker Images
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+# runs in ci-master after successful checks
+# you can use images built by this action in future jobs.
+# https://docs.docker.com/build/ci/github-actions/examples/#share-built-image-between-jobs
+jobs:
+  docker:
+    # https://github.com/marketplace/actions/build-and-push-docker-images
+    runs-on: ubuntu-latest
+    steps:
+      # ensure working with latest code
+      - name: Checkout
+        uses: actions/checkout@v3
+      # generate a git commit hash to be used as image tag
+      - name: Generate short hash
+        id: commit-hash
+        run: echo "short=$( git rev-parse --short $GITHUB_SHA )" >> $GITHUB_OUTPUT
+      # qemu is used to emulate different platform architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      # cross-platform build of the image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # authenticate for publish to docker hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # publish to docker hub, tag with short git hash
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: kava/kava:${{ steps.commit-hash.outputs.short }},kava/kava:master

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -2,10 +2,12 @@ name: Build & Publish Docker Images
 
 on:
   workflow_call:
-    secrets:
-      DOCKERHUB_USERNAME:
+    inputs:
+      dockerhub-username:
         required: true
-      DOCKERHUB_TOKEN:
+        type: string
+    secrets:
+      CI_DOCKERHUB_TOKEN:
         required: true
 
 # runs in ci-master after successful checks
@@ -33,8 +35,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ inputs.dockerhub-username }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
       # publish to docker hub, tag with short git hash
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -39,6 +39,10 @@ jobs:
           AWS_REGION: us-east-1
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_KEY_SECRET }}
+  docker:
+    # only run if all checks pass
+    needs: [lint-checks, default-checks]
+    uses: ./.github/workflows/ci-docker.yml
   post-pipeline-metrics:
     uses: ./.github/workflows/metric-pipeline.yml
     if: always() # always run so we metric failures and successes

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -43,6 +43,8 @@ jobs:
     # only run if all checks pass
     needs: [lint-checks, default-checks]
     uses: ./.github/workflows/ci-docker.yml
+    with:
+      dockerhub-username: pirtleshell
   post-pipeline-metrics:
     uses: ./.github/workflows/metric-pipeline.yml
     if: always() # always run so we metric failures and successes


### PR DESCRIPTION
Adds an action to the master branch's CI workflow to cross-platform build & publish docker containers to docker hub.

After successful pass on lint & default checks, any commit added to master will trigger a docker container build. The container is then published to docker hub with the tags `kava/kava:$GIT_SHORT_HASH` (example: [`kava/kava:c46d70de`](https://hub.docker.com/layers/kava/kava/c46d70de/images/sha256-dcf935db8ef28090bcf5a4f646e43ec077e8cf6672174b743bf8ca688ee505f2?context=explore)) and `kava/kava:master`.

Images are built for `linux/amd64` & `linux/arm64` platforms.

Tested with a run locally, but will need to add docker auth username & access token to secrets.

