### PR TITLE
Add hard params to internal testnet

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1491,7 +1491,170 @@
     },
     "hard": {
       "params": {
-        "money_markets": [],
+        "money_markets": [
+          {
+            "denom": "btcb",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "1000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "btc:usd:30",
+            "conversion_factor": "100000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "bnb",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "250000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "bnb:usd:30",
+            "conversion_factor": "100000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "xrpb",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "10000000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "xrp:usd:30",
+            "conversion_factor": "100000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "busd",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "50000000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "busd:usd:30",
+            "conversion_factor": "100000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "usdx",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "0.000000000000000000",
+              "loan_to_value": "0.250000000000000000"
+            },
+            "spot_market_id": "usdx:usd:720",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "ukava",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "500000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "kava:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "hard",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "0.000000000000000000",
+              "loan_to_value": "0.000000000000000000"
+            },
+            "spot_market_id": "hard:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "200000000000.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "atom:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
+            "denom": "ibc/799FDD409719A1122586A629AE8FCA17380351A51C1F47A80A1B8E7F2A491098",
+            "borrow_limit": {
+              "has_max_limit": true,
+              "maximum_limit": "0.000000000000000000",
+              "loan_to_value": "0.000000000000000000"
+            },
+            "spot_market_id": "akt:usd:30",
+            "conversion_factor": "1000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          }
+        ],
         "minimum_borrow_usd_value": "10.000000000000000000"
       },
       "previous_accumulation_times": [],

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -2751,178 +2751,178 @@
       },
       "posted_prices": [
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "bnb:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "215.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "bnb:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "217.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "btc:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "29500.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "btc:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "28500.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "akt:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "akt:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "osmo:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "4.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "osmo:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "4.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "luna:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "92.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "luna:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "92.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "atom:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "24.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "atom:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "24.962650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "xrp:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "0.552650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "xrp:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "0.552650000000001782"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "busd:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "busd:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdx:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdx:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdx:usd:720",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "1.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "kava:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "3.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "kava:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "3.000000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "hard:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "0.500000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "hard:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "0.500000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "swp:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "2.150000000000000000"
         },
         {
-          "expiry": "2022-10-20T00:00:00Z",
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "swp:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "2.150000000000000000"
         },
         {
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdt:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
-          "price": "1.000000000000000000",
-          "expiry": "2022-10-07T00:10:01Z"
+          "price": "1.000000000000000000"
         },
         {
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdc:usd",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
-          "price": "1.000000000000000000",
-          "expiry": "2022-10-07T00:10:01Z"
+          "price": "1.000000000000000000"
         },
         {
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdt:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
-          "price": "1.000000000000000000",
-          "expiry": "2022-10-07T00:10:01Z"
+          "price": "1.000000000000000000"
         },
         {
+          "expiry": "2050-01-01T00:00:00Z",
           "market_id": "usdc:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
-          "price": "1.000000000000000000",
-          "expiry": "2022-10-07T00:10:01Z"
+          "price": "1.000000000000000000"
         }
       ]
     },

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -2479,9 +2479,7 @@
       },
       "previous_block_time": "2022-05-25T17:00:00Z"
     },
-    "liquid": {
-      "params": {}
-    },
+    "liquid": {},
     "params": null,
     "pricefeed": {
       "params": {


### PR DESCRIPTION
This adds a copy of mainnet hard params to the internal testnet, and extends the price timeouts to enable hard/cdp.

In response to bug report 6573, where interest-rate endpoint was returning empty rates.