### PR TITLE
Add finalized support and evm param fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ replace (
 	// Use rocksdb 7.1.2
 	github.com/tendermint/tm-db => github.com/kava-labs/tm-db v0.6.7-kava.1
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/tharsis/ethermint => github.com/kava-labs/ethermint v0.14.0-kava-v19.3
+	github.com/tharsis/ethermint => github.com/kava-labs/ethermint v0.14.0-kava-v20.1
 	// Make sure that we use grpc compatible with cosmos
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJo
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kava-labs/cosmos-sdk v0.45.9-kava.4 h1:nOsUMvY9qWvPyORBSV3k7G7D7Lc5JjzYqZE8ohuxskQ=
 github.com/kava-labs/cosmos-sdk v0.45.9-kava.4/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
-github.com/kava-labs/ethermint v0.14.0-kava-v19.3 h1:Vok1ED1rcev+dmj6X9Mj4kssxo7sTFY+yfbv7jctbYk=
-github.com/kava-labs/ethermint v0.14.0-kava-v19.3/go.mod h1:+/TXGhi6XwF9B8h2NrYZCKrrv0+pC3RkpM0950lYyJg=
+github.com/kava-labs/ethermint v0.14.0-kava-v20.1 h1:4ZM/SFPU7RLmioHICs9j+c4hzDZ9Rxb/b+Hs/guAyN4=
+github.com/kava-labs/ethermint v0.14.0-kava-v20.1/go.mod h1:+/TXGhi6XwF9B8h2NrYZCKrrv0+pC3RkpM0950lYyJg=
 github.com/kava-labs/tm-db v0.6.7-kava.1 h1:7cVYlvWx1yP+gGdaAWcfm6NwMLzf4z6DxXguWn3+O3w=
 github.com/kava-labs/tm-db v0.6.7-kava.1/go.mod h1:HVZfZzWXuqWseXQVplxsWXK6kLHLkk3kQB6c+nuSZvk=
 github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d h1:Z+RDyXzjKE0i2sTjZ/b1uxiGtPhFy34Ou/Tk0qwN0kM=


### PR DESCRIPTION
- Allows 'finalized' to be used on eth json rpc calls
- Fixes eth_call for old heights (prevent panic on GetParams before allowed eip messages were set)

https://github.com/kava-Labs/ethermint/compare/v0.14.0-kava-v19.3...v0.14.0-kava-v20.1

The most important change here is the stake breaking change of GetParamSet to GetParamSetIfExists - https://github.com/kava-Labs/ethermint/compare/v0.14.0-kava-v19.3...v0.14.0-kava-v20.1#diff-452a9790ad3bc5d0d09a116ab1bcaa241ea0f01c221709c7a65cbaf1dd91457aL11