### PR TITLE
Add incentive migrations for hard claims

### DIFF
--- a/x/incentive/migrations/v3/keys.go
+++ b/x/incentive/migrations/v3/keys.go
@@ -8,17 +8,22 @@ import (
 
 // Legacy store key prefixes
 var (
-	EarnClaimKeyPrefix                     = []byte{0x18} // prefix for keys that store earn claims
-	EarnRewardIndexesKeyPrefix             = []byte{0x19} // prefix for key that stores earn reward indexes
-	PreviousEarnRewardAccrualTimeKeyPrefix = []byte{0x20} // prefix for key that stores the previous time earn rewards accrued
+	HardLiquidityClaimKeyPrefix                  = []byte{0x04} // prefix for keys that store Hard liquidity claims
+	HardSupplyRewardIndexesKeyPrefix             = []byte{0x05} // prefix for key that stores Hard supply reward indexes
+	PreviousHardSupplyRewardAccrualTimeKeyPrefix = []byte{0x06} // prefix for key that stores the previous time Hard supply rewards accrued
+	HardBorrowRewardIndexesKeyPrefix             = []byte{0x07} // prefix for key that stores Hard borrow reward indexes
+	PreviousHardBorrowRewardAccrualTimeKeyPrefix = []byte{0x08} // prefix for key that stores the previous time Hard borrow rewards accrued
+	EarnClaimKeyPrefix                           = []byte{0x18} // prefix for keys that store earn claims
+	EarnRewardIndexesKeyPrefix                   = []byte{0x19} // prefix for key that stores earn reward indexes
+	PreviousEarnRewardAccrualTimeKeyPrefix       = []byte{0x20} // prefix for key that stores the previous time earn rewards accrued
 )
 
 func LegacyAccrualTimeKeyFromClaimType(claimType types.ClaimType) []byte {
 	switch claimType {
 	case types.CLAIM_TYPE_HARD_BORROW:
-		panic("todo")
+		return PreviousHardBorrowRewardAccrualTimeKeyPrefix
 	case types.CLAIM_TYPE_HARD_SUPPLY:
-		panic("todo")
+		return PreviousHardSupplyRewardAccrualTimeKeyPrefix
 	case types.CLAIM_TYPE_EARN:
 		return PreviousEarnRewardAccrualTimeKeyPrefix
 	case types.CLAIM_TYPE_SAVINGS:
@@ -35,9 +40,9 @@ func LegacyAccrualTimeKeyFromClaimType(claimType types.ClaimType) []byte {
 func LegacyRewardIndexesKeyFromClaimType(claimType types.ClaimType) []byte {
 	switch claimType {
 	case types.CLAIM_TYPE_HARD_BORROW:
-		panic("todo")
+		return HardBorrowRewardIndexesKeyPrefix
 	case types.CLAIM_TYPE_HARD_SUPPLY:
-		panic("todo")
+		return HardSupplyRewardIndexesKeyPrefix
 	case types.CLAIM_TYPE_EARN:
 		return EarnRewardIndexesKeyPrefix
 	case types.CLAIM_TYPE_SAVINGS:

--- a/x/incentive/migrations/v3/store.go
+++ b/x/incentive/migrations/v3/store.go
@@ -11,6 +11,12 @@ import (
 	"github.com/kava-labs/kava/x/incentive/types"
 )
 
+var MigrateClaimTypes = []types.ClaimType{
+	types.CLAIM_TYPE_HARD_BORROW,
+	types.CLAIM_TYPE_HARD_SUPPLY,
+	types.CLAIM_TYPE_EARN,
+}
+
 // MigrateStore performs in-place migrations from incentive ConsensusVersion 2 to 3.
 func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
 	store := ctx.KVStore(storeKey)
@@ -23,13 +29,7 @@ func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.Binar
 		return err
 	}
 
-	migrateClaimTypes := []types.ClaimType{
-		types.CLAIM_TYPE_HARD_BORROW,
-		types.CLAIM_TYPE_HARD_SUPPLY,
-		types.CLAIM_TYPE_EARN,
-	}
-
-	for _, claimType := range migrateClaimTypes {
+	for _, claimType := range MigrateClaimTypes {
 		if err := MigrateAccrualTimes(store, cdc, claimType); err != nil {
 			return err
 		}

--- a/x/incentive/migrations/v3/store.go
+++ b/x/incentive/migrations/v3/store.go
@@ -117,7 +117,7 @@ func MigrateHardClaims(store sdk.KVStore, cdc codec.BinaryCodec) error {
 
 			newSupplyStore.Set(c.Owner, cdc.MustMarshal(&newSupplyClaim))
 
-			// Empty reward coins as to not duplicate rewards
+			// Empty reward coins as to not duplicate rewards if there are borrow indexes
 			rewardCoins = sdk.NewCoins()
 		}
 


### PR DESCRIPTION
This migration splits up existing hard claims to two separate hard supply/borrow claims.

* Supply claims are created if `SupplyRewardIndexes` exists OR if there are `Reward` coins and no supply/borrow reward indexes.
* Borrow claims are created if `BorrowRewardIndexes` exists.