### PR TITLE
Add text proposal to internal testnet seed script

### DIFF
--- a/.github/scripts/seed-internal-testnet.sh
+++ b/.github/scripts/seed-internal-testnet.sh
@@ -59,3 +59,6 @@ for validator in "${GENTX_VALIDATORS[@]}"
 do
   kava tx staking delegate "${validator}" 300000000ukava --from dev-wallet --gas-prices 0.5ukava -y
 done
+
+# create a text proposal
+kava tx gov submit-proposal --deposit 1000000000ukava --type "Text" --title "Example Proposal" --description "This is an example proposal" --gas auto --gas-adjustment 1.2 --from dev-wallet --gas-prices 0.01ukava


### PR DESCRIPTION
As a Kava Labs developer, I would like internal testnet to be deployed with a proposal so it's easier to work on voting and for acceptance testing.