### PR TITLE
use axelar assets for wETH and wBTC instead of multichain

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -267,11 +267,11 @@
               "amount": "1000000000000000"
             },
             {
-              "denom": "erc20/multichain/wbtc",
+              "denom": "erc20/axelar/wbtc",
               "amount": "1000000000"
             },
             {
-              "denom": "erc20/multichain/weth",
+              "denom": "erc20/axelar/weth",
               "amount": "1000000000000000000"
             },
             {
@@ -1312,11 +1312,11 @@
           },
           {
             "kava_erc20_address": "0x818ec0A7Fe18Ff94269904fCED6AE3DaE6d6dC0b",
-            "denom": "erc20/multichain/wbtc"
+            "denom": "erc20/axelar/wbtc"
           },
           {
             "kava_erc20_address": "0xE3F5a90F9cb311505cd691a46596599aA1A0AD7D",
-            "denom": "erc20/multichain/weth"
+            "denom": "erc20/axelar/weth"
           }
         ]
       }
@@ -1502,7 +1502,7 @@
             "keeper_reward_percentage": "0.020000000000000000"
           },
           {
-            "denom": "erc20/multichain/wbtc",
+            "denom": "erc20/axelar/wbtc",
             "borrow_limit": {
               "has_max_limit": true,
               "maximum_limit": "1000000000.000000000000000000",
@@ -1520,7 +1520,7 @@
             "keeper_reward_percentage": "0.020000000000000000"
           },
           {
-            "denom": "erc20/multichain/weth",
+            "denom": "erc20/axelar/weth",
             "borrow_limit": {
               "has_max_limit": true,
               "maximum_limit": "1000000000.000000000000000000",


### PR DESCRIPTION
https://app.shortcut.com/kava-labs/story/7424/add-weth-and-wbtc-assets-to-config

## What Changes
- update internal-testnet with correct `erc20/axelar/wETH` and `erc20/axelar/wBTC` (instead of from multiChain)
  - denoms
  - hard market parameters

## Why
Originally, we were thinking these denoms would bridge over via multichain, but instead we're going forward with axelar.