### PR TITLE
EVM Lend markets update

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1506,24 +1506,6 @@
             "keeper_reward_percentage": "0.020000000000000000"
           },
           {
-            "denom": "erc20/axelar/btc",
-            "borrow_limit": {
-              "has_max_limit": true,
-              "maximum_limit": "1000000000.000000000000000000",
-              "loan_to_value": "0.500000000000000000"
-            },
-            "spot_market_id": "btc:usd:30",
-            "conversion_factor": "100000000",
-            "interest_rate_model": {
-              "base_rate_apy": "0.000000000000000000",
-              "base_multiplier": "0.050000000000000000",
-              "kink": "0.800000000000000000",
-              "jump_multiplier": "5.000000000000000000"
-            },
-            "reserve_factor": "0.025000000000000000",
-            "keeper_reward_percentage": "0.020000000000000000"
-          },
-          {
             "denom": "erc20/axelar/usdc",
             "borrow_limit": {
               "has_max_limit": true,
@@ -1532,24 +1514,6 @@
             },
             "spot_market_id": "usdc:usd:30",
             "conversion_factor": "1000000",
-            "interest_rate_model": {
-              "base_rate_apy": "0.000000000000000000",
-              "base_multiplier": "0.050000000000000000",
-              "kink": "0.800000000000000000",
-              "jump_multiplier": "5.000000000000000000"
-            },
-            "reserve_factor": "0.025000000000000000",
-            "keeper_reward_percentage": "0.020000000000000000"
-          },
-          {
-            "denom": "erc20/axelar/eth",
-            "borrow_limit": {
-              "has_max_limit": true,
-              "maximum_limit": "1000000000.000000000000000000",
-              "loan_to_value": "0.500000000000000000"
-            },
-            "spot_market_id": "eth:usd:30",
-            "conversion_factor": "1000000000000000000",
             "interest_rate_model": {
               "base_rate_apy": "0.000000000000000000",
               "base_multiplier": "0.050000000000000000",


### PR DESCRIPTION
- remove axlBTC and axlETH money markets until they are slated for development