### PR TITLE
Add contract address for axlUSDC

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1352,6 +1352,10 @@
           },
           {
             "kava_erc20_address": "0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d",
+            "denom": "erc20/axelar/usdc"
+          },
+          {
+            "kava_erc20_address": "0x7d2Ee2914324d5D4dC33A5c295E720659D5F3fA7",
             "denom": "erc20/axelar/btc"
           },
           {

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1351,7 +1351,7 @@
             "denom": "erc20/multichain/usdc"
           },
           {
-            "kava_erc20_address": "0x7d2Ee2914324d5D4dC33A5c295E720659D5F3fA7",
+            "kava_erc20_address": "0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d",
             "denom": "erc20/axelar/btc"
           },
           {


### PR DESCRIPTION
Adds contract address from the logs from #1499

```
 AXLUSD_CONTRACT_DEPLOY='Signing with account 0x6767114FFAA17c6439D7aEA480738b982ce63A02
args { name: '\''USD Coin'\'', symbol: '\''USDC'\'', decimals: '\''6'\'' }
deployed erc20:  0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d'
+ AXLUSD_CONTRACT_ADDRESS=0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d
+ npx hardhat --network internal_testnet mint-erc20 0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d 0x6767114FFAA17C6439D7AEA480738B982CE63A02 1000000000000
Signing with account 0x6767114FFAA17c6439D7aEA480738b982ce63A02
args {
  contractAddress: '0x7a5DBf8e6ac1F6aCCF14f5B4E88b21EAA04c983d',
  to: '0x6767114FFAA17C6439D7AEA480738B982CE63A02',
  amount: '1000000000000'
}
```