### PR TITLE
Fix old bep3 tests

### DIFF
--- a/x/bep3/genesis.go
+++ b/x/bep3/genesis.go
@@ -56,7 +56,7 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, accountKeeper types.Acco
 		// Atomic swap assets must be both supported and active
 		err := keeper.ValidateLiveAsset(ctx, swap.Amount[0])
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("swap has invalid asset: %s", err))
 		}
 
 		keeper.SetAtomicSwap(ctx, swap)
@@ -110,7 +110,7 @@ func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, accountKeeper types.Acco
 		}
 		limit, err := keeper.GetSupplyLimit(ctx, supply.GetDenom())
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("asset's supply limit not found: %s", err))
 		}
 		if supply.CurrentSupply.Amount.GT(limit.Limit) {
 			panic(fmt.Sprintf("asset's current supply %s is over the supply limit %s", supply.CurrentSupply, limit.Limit))

--- a/x/bep3/types/supply.go
+++ b/x/bep3/types/supply.go
@@ -31,7 +31,7 @@ func (a AssetSupply) Validate() error {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "current supply %s", a.CurrentSupply)
 	}
 	if !a.TimeLimitedCurrentSupply.IsValid() {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "time-limited current supply %s", a.CurrentSupply)
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "time-limited current supply %s", a.TimeLimitedCurrentSupply)
 	}
 	denom := a.CurrentSupply.Denom
 	if (a.IncomingSupply.Denom != denom) ||


### PR DESCRIPTION
Fixes #721
The bep3 InitGenesis tests were checking for panics, but not checking for the right panics. Some tests were panicking during test setup.