### PR TITLE
fix: update kvtool & reenable ibc tests

### DIFF
--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -6,8 +6,7 @@ E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe no
 E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
 
 # E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
-# TODO: re-enable me!
-E2E_INCLUDE_IBC_TESTS=false
+E2E_INCLUDE_IBC_TESTS=true
 
 # E2E_SKIP_SHUTDOWN when true will keep the networks running after tests complete (pass or fail)
 # This is useful for debugging chain state when writing tests.


### PR DESCRIPTION
IBC tests are back in action after an update to the relayer used by kvtool.