### PR TITLE
ci: Use rocksdb v7.10.2 and go 1.19

### DIFF
--- a/.github/workflows/cd-reset-internal-testnet.yml
+++ b/.github/workflows/cd-reset-internal-testnet.yml
@@ -10,14 +10,14 @@ on:
         required: true
         type: string
       ssm-document-name:
-          required: true
-          type: string
+        required: true
+        type: string
       playbook-name:
-          required: true
-          type: string
+        required: true
+        type: string
       playbook-infrastructure-branch:
-          required: true
-          type: string
+        required: true
+        type: string
     secrets:
       CI_AWS_KEY_ID:
         required: true
@@ -38,7 +38,7 @@ jobs:
       - name: checkout repo from current commit
         uses: actions/checkout@v3
       - name: take the chain offline
-        run:  bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
+        run: bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
         env:
           CHAIN_ID: ${{ inputs.chain-id }}
           AWS_REGION: ${{ inputs.aws-region }}
@@ -54,11 +54,11 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: build kava node updater
-        run:  cd infrastructure/cli/kava-node-updater && make install && cd ../../../
+        run: cd infrastructure/cli/kava-node-updater && make install && cd ../../../
       - name: run reset playbook on all chain nodes
         run: |
           kava-node-updater \

--- a/.github/workflows/cd-seed-chain.yml
+++ b/.github/workflows/cd-seed-chain.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: build kava binary

--- a/.github/workflows/cd-start-chain.yml
+++ b/.github/workflows/cd-start-chain.yml
@@ -10,14 +10,14 @@ on:
         required: true
         type: string
       ssm-document-name:
-          required: true
-          type: string
+        required: true
+        type: string
       playbook-name:
-          required: true
-          type: string
+        required: true
+        type: string
       playbook-infrastructure-branch:
-          required: true
-          type: string
+        required: true
+        type: string
     secrets:
       CI_AWS_KEY_ID:
         required: true
@@ -34,7 +34,7 @@ jobs:
       - name: checkout repo from current commit
         uses: actions/checkout@v3
       - name: take the chain offline
-        run:  bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
+        run: bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
         env:
           CHAIN_ID: ${{ inputs.chain-id }}
           AWS_REGION: ${{ inputs.aws-region }}
@@ -50,11 +50,11 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: build kava node updater
-        run:  cd infrastructure/cli/kava-node-updater && make install && cd ../../../
+        run: cd infrastructure/cli/kava-node-updater && make install && cd ../../../
       - name: run start-chain playbook on all chain nodes
         run: |
           kava-node-updater \
@@ -77,4 +77,4 @@ jobs:
           AWS_SDK_LOAD_CONFIG: 1
           PLAYBOOK_INFRASTRUCTURE_BRANCH: ${{ inputs.playbook-infrastructure-branch }}
       - name: bring the chain online
-        run:  bash ${GITHUB_WORKSPACE}/.github/scripts/exit-standby-all-chain-nodes.sh
+        run: bash ${GITHUB_WORKSPACE}/.github/scripts/exit-standby-all-chain-nodes.sh

--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: build application
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: run unit tests
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: build kava cli

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: set build tag
@@ -31,7 +31,7 @@ jobs:
       - name: build rocksdb dependency
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/install-rocksdb.sh
         env:
-          ROCKSDB_VERSION: v7.7.3
+          ROCKSDB_VERSION: v7.9.2
       - name: Build and upload release artifacts
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/publish-internal-release-artifacts.sh
         env:

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -31,7 +31,7 @@ jobs:
       - name: build rocksdb dependency
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/install-rocksdb.sh
         env:
-          ROCKSDB_VERSION: v7.9.2
+          ROCKSDB_VERSION: v7.10.2
       - name: Build and upload release artifacts
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/publish-internal-release-artifacts.sh
         env:


### PR DESCRIPTION
Use rocksdb v7.10.2 for possible fix for failing build in https://github.com/Kava-Labs/kava/actions/runs/4623472451/jobs/8177504392

This version matches the other rocksdb workflow that is passing

Go 1.19 just to match the updated version in go.mod.