### PR TITLE
Remove axlBTC money market

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1953,24 +1953,6 @@
             "keeper_reward_percentage": "0.020000000000000000"
           },
           {
-            "denom": "erc20/axelar/btc",
-            "borrow_limit": {
-              "has_max_limit": true,
-              "maximum_limit": "0.000000000000000000",
-              "loan_to_value": "0.000000000000000000"
-            },
-            "spot_market_id": "btc:usd:30",
-            "conversion_factor": "1000000",
-            "interest_rate_model": {
-              "base_rate_apy": "0.000000000000000000",
-              "base_multiplier": "0.050000000000000000",
-              "kink": "0.800000000000000000",
-              "jump_multiplier": "5.000000000000000000"
-            },
-            "reserve_factor": "0.025000000000000000",
-            "keeper_reward_percentage": "0.020000000000000000"
-          },
-          {
             "denom": "erc20/multichain/btc",
             "borrow_limit": {
               "has_max_limit": true,


### PR DESCRIPTION
Removing this market to align internal testnet markets with upcoming release.

We had been developing towards axelar wBTC, but are now pivoting to multichain
