### PR TITLE
Update protonet json earn vaults

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -1112,6 +1112,22 @@
             "strategies": [
               "STRATEGY_TYPE_SAVINGS"
             ]
+          },
+          {
+            "denom": "bnb",
+            "strategies": [
+              "STRATEGY_TYPE_SAVINGS"
+            ],
+            "is_private_vault": false,
+            "allowed_depositors": []
+          },
+          {
+            "denom": "erc20/multichain/usdt",
+            "strategies": [
+              "STRATEGY_TYPE_SAVINGS"
+            ],
+            "is_private_vault": false,
+            "allowed_depositors": []
           }
         ]
       },

--- a/ci/env/kava-protonet/genesis.json
+++ b/ci/env/kava-protonet/genesis.json
@@ -1135,6 +1135,22 @@
             "strategies": [
               "STRATEGY_TYPE_SAVINGS"
             ]
+          },
+          {
+            "denom": "bnb",
+            "strategies": [
+              "STRATEGY_TYPE_SAVINGS"
+            ],
+            "is_private_vault": false,
+            "allowed_depositors": []
+          },
+          {
+            "denom": "erc20/multichain/usdt",
+            "strategies": [
+              "STRATEGY_TYPE_SAVINGS"
+            ],
+            "is_private_vault": false,
+            "allowed_depositors": []
           }
         ]
       },


### PR DESCRIPTION
Currently our `/kava/incentive/v1beta1/apy` endpoint is expecting there to be an earn vault for each `earn_reward_period` returned by `kava/incentive/v1beta1/params`. Right now, the genesis state for testnet (and protonet) aren't providing all the vaults as options.

Our two choices are:
1. Remove the incentive params for the vaults not included 2 Add the vaults so there is a vault for each incentive param

Going with option 2 here because mainnet has vaults for the denoms which are currently missing
