### PR TITLE
update golang from 1.19 to 1.20, the recommended version for kava 13

### DIFF
--- a/.github/workflows/cd-reset-internal-testnet.yml
+++ b/.github/workflows/cd-reset-internal-testnet.yml
@@ -54,7 +54,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build kava node updater

--- a/.github/workflows/cd-seed-chain.yml
+++ b/.github/workflows/cd-seed-chain.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build kava binary

--- a/.github/workflows/cd-start-chain.yml
+++ b/.github/workflows/cd-start-chain.yml
@@ -50,7 +50,7 @@ jobs:
       - name: set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build kava node updater

--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build application
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: run unit tests
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build kava cli
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: build kava cli

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.20"
           check-latest: true
           cache: true
       - name: set build tag

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19
+golang 1.20

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build-env
+FROM golang:1.20-alpine AS build-env
 
 # Set up dependencies
 # bash, jq, curl for debugging

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kava-labs/kava
 
-go 1.19
+go 1.20
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7


### PR DESCRIPTION
We will recommend go 1.20 for mainnet.  This PR updates go.mod, CI, and .tool-versions.