### PR TITLE
feat: add stability committee permission in upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -14,12 +14,17 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
 	communitytypes "github.com/kava-labs/kava/x/community/types"
 )
 
 const (
 	MainnetUpgradeName = "v0.22.0"
 	TestnetUpgradeName = "v0.22.0-alpha.0"
+
+	MainnetStabilityCommitteeId = uint64(1)
+	TestnetStabilityCommitteeId = uint64(1)
 )
 
 func (app App) RegisterUpgradeHandlers() {
@@ -38,6 +43,9 @@ func (app App) RegisterUpgradeHandlers() {
 
 			app.Logger().Info("granting x/gov module account x/community module authz messages")
 			GrantGovCommunityPoolMessages(ctx, app.authzKeeper, app.accountKeeper)
+
+			app.Logger().Info(fmt.Sprintf("adding lend & cdp committee permissions to stability committee (id=%d)", MainnetStabilityCommitteeId))
+			AddNewPermissionsToStabilityCommittee(ctx, app.committeeKeeper, MainnetStabilityCommitteeId)
 
 			return toVM, nil
 		},
@@ -58,6 +66,9 @@ func (app App) RegisterUpgradeHandlers() {
 
 			app.Logger().Info("granting x/gov module account x/community module authz messages")
 			GrantGovCommunityPoolMessages(ctx, app.authzKeeper, app.accountKeeper)
+
+			app.Logger().Info(fmt.Sprintf("adding lend & cdp committee permissions to stability committee (id=%d)", TestnetStabilityCommitteeId))
+			AddNewPermissionsToStabilityCommittee(ctx, app.committeeKeeper, TestnetStabilityCommitteeId)
 
 			return toVM, nil
 		},
@@ -127,6 +138,28 @@ func FundCommunityPoolModule(
 	feePool := distKeeper.GetFeePool(ctx)
 	feePool.CommunityPool = leftoverDust
 	distKeeper.SetFeePool(ctx, feePool)
+}
+
+// AddNewPermissionsToStabilityCommittee adds the following permissions to the committee with the passed in id:
+// - CommunityCDPRepayDebtPermission
+// - CommunityPoolLendWithdrawPermission
+// - CommunityCDPWithdrawCollateralPermission
+func AddNewPermissionsToStabilityCommittee(ctx sdk.Context, committeeKeeper committeekeeper.Keeper, committeeId uint64) {
+	// get committee
+	comm, found := committeeKeeper.GetCommittee(ctx, committeeId)
+	if !found {
+		panic(fmt.Sprintf("expected to find committee with id %d but found none", committeeId))
+	}
+	// set new permissions
+	perms := comm.GetPermissions()
+	perms = append(perms,
+		&committeetypes.CommunityCDPRepayDebtPermission{},
+		&committeetypes.CommunityPoolLendWithdrawPermission{},
+		&committeetypes.CommunityCDPWithdrawCollateralPermission{},
+	)
+	comm.SetPermissions(perms)
+	// save permission changes
+	committeeKeeper.SetCommittee(ctx, comm)
 }
 
 func GetCommunityPoolAllowedMsgs() []string {

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -4,7 +4,7 @@ E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe no
 
 # E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
 # Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
-E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
+E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="v0.21"
 
 # E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
 E2E_INCLUDE_IBC_TESTS=true
@@ -15,14 +15,14 @@ E2E_SKIP_SHUTDOWN=false
 
 # The following variables should be defined to run an upgrade.
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
-E2E_INCLUDE_AUTOMATED_UPGRADE=false
+E2E_INCLUDE_AUTOMATED_UPGRADE=true
 # E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
-E2E_KAVA_UPGRADE_NAME=
+E2E_KAVA_UPGRADE_NAME=v0.22.0
 # E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.
 # If IBC tests are enabled this should be >50. Otherwise, this should be >10.
-E2E_KAVA_UPGRADE_HEIGHT=
+E2E_KAVA_UPGRADE_HEIGHT=35
 # E2E_KAVA_UPGRADE_BASE_IMAGE_TAG is the tag of the docker image the chain should upgrade from.
-E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=
+E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=v0.21.1
 
 # E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token.
 # The E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC account should have a balance.

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -1,6 +1,12 @@
 package e2e_test
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/tests/util"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
+)
 
 // TestUpgradeHandler can be used to run tests post-upgrade. If an upgrade is enabled, all tests
 // are run against the upgraded chain. However, this file is a good place to consolidate all
@@ -9,4 +15,52 @@ func (suite IntegrationTestSuite) TestUpgradeHandler() {
 	suite.SkipIfUpgradeDisabled()
 	fmt.Println("An upgrade has run!")
 	suite.True(true)
+
+	beforeUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight - 1)
+	afterUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight)
+
+	lendWithdrawPerm := "/kava.committee.v1beta1.CommunityPoolLendWithdrawPermission"
+	cdpRepayDebtPerm := "/kava.committee.v1beta1.CommunityCDPRepayDebtPermission"
+	cdpWithdrawPerm := "/kava.committee.v1beta1.CommunityCDPWithdrawCollateralPermission"
+
+	// check stability committee permissions before upgrade to ensure it starts without them
+	res, err := suite.Kava.Committee.Committee(
+		beforeUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.MainnetStabilityCommitteeId},
+	)
+	suite.NoError(err)
+	var beforeCommittee committeetypes.Committee
+	err = suite.Kava.EncodingConfig.InterfaceRegistry.UnpackAny(res.Committee, &beforeCommittee)
+	suite.NoError(err)
+
+	suite.False(suite.committeeHasPermissionWithTypeUrl(beforeCommittee, lendWithdrawPerm))
+	suite.False(suite.committeeHasPermissionWithTypeUrl(beforeCommittee, cdpRepayDebtPerm))
+	suite.False(suite.committeeHasPermissionWithTypeUrl(beforeCommittee, cdpWithdrawPerm))
+
+	// check stability committee permission after upgrade to ensure it gets them
+	res, err = suite.Kava.Committee.Committee(
+		afterUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.MainnetStabilityCommitteeId},
+	)
+	suite.NoError(err)
+	var afterCommittee committeetypes.Committee
+	err = suite.Kava.EncodingConfig.InterfaceRegistry.UnpackAny(res.Committee, &afterCommittee)
+	suite.NoError(err)
+
+	suite.True(suite.committeeHasPermissionWithTypeUrl(afterCommittee, lendWithdrawPerm))
+	suite.True(suite.committeeHasPermissionWithTypeUrl(afterCommittee, cdpRepayDebtPerm))
+	suite.True(suite.committeeHasPermissionWithTypeUrl(afterCommittee, cdpWithdrawPerm))
+}
+
+// committeeHasPermissionWithTypeUrl iterates the permissions of the committee looking for the desired type url
+func (suite *IntegrationTestSuite) committeeHasPermissionWithTypeUrl(c committeetypes.Committee, typeUrl string) bool {
+	mc, success := c.(*committeetypes.MemberCommittee)
+	if !success {
+		panic("failed to cast committee to member committee")
+	}
+	for _, p := range mc.Permissions {
+		fmt.Println(p.TypeUrl)
+		if p.TypeUrl == typeUrl {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/e2e/testutil/chain.go
+++ b/tests/e2e/testutil/chain.go
@@ -20,6 +20,7 @@ import (
 	kavaparams "github.com/kava-labs/kava/app/params"
 	"github.com/kava-labs/kava/tests/e2e/runner"
 	"github.com/kava-labs/kava/tests/util"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
 	communitytypes "github.com/kava-labs/kava/x/community/types"
 	earntypes "github.com/kava-labs/kava/x/earn/types"
 )
@@ -39,6 +40,7 @@ type Chain struct {
 
 	Auth      authtypes.QueryClient
 	Bank      banktypes.QueryClient
+	Committee committeetypes.QueryClient
 	Community communitytypes.QueryClient
 	Earn      earntypes.QueryClient
 	Evm       evmtypes.QueryClient
@@ -72,6 +74,7 @@ func NewChain(t *testing.T, details *runner.ChainDetails, fundedAccountMnemonic 
 
 	chain.Auth = authtypes.NewQueryClient(grpcConn)
 	chain.Bank = banktypes.NewQueryClient(grpcConn)
+	chain.Committee = committeetypes.NewQueryClient(grpcConn)
 	chain.Community = communitytypes.NewQueryClient(grpcConn)
 	chain.Earn = earntypes.NewQueryClient(grpcConn)
 	chain.Evm = evmtypes.NewQueryClient(grpcConn)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!--- Describe your changes in detail -->
Adds the following permissions to the mainnet & testnet stability committees in the v0.22 upgrade handler:
* `CommunityCDPRepayDebtPermission`
* `CommunityPoolLendWithdrawPermission`
* `CommunityCDPWithdrawCollateralPermission`

Here's confirmation that the stability committees have id 1 on both networks:
```
$ curl -s https://api.kava.io/kava/committee/v1beta1/committees/1 | jq '.committee.base_committee.description'
"Kava Stability Committee"

$ curl -s https://api.testnet.kava.io/kava/committee/v1beta1/committees/1 | jq '.committee.base_committee.description' 
"Kava Stability Committee"
```

## Checklist
 - [x] ~~Changelog has been updated as necessary.~~
