### PR TITLE
fix ci & sort denoms in internal testnet genesis coins

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -36,34 +36,34 @@ jobs:
   validate-internal-testnet-genesis:
     runs-on: ubuntu-latest
     steps:
-        - name: checkout repo from current commit
-          uses: actions/checkout@v3
-          with:
-            submodules: true
-        - name: save version of kava that will be deployed if this pr is merged
-          id: kava-version
-          run: |
-            echo "KAVA_VERSION=$(cat ./ci/env/kava-internal-testnet/KAVA.VERSION)" >> $GITHUB_OUTPUT
-        - name: checkout repo from master
-          uses: actions/checkout@v3
-          with:
-              ref: master
-        - name: checkout version of kava that will be deployed if this pr is merged
-          run: |
-                git pull -p
-                git checkout $KAVA_VERSION
-          env:
-                KAVA_VERSION: ${{ steps.kava-version.outputs.KAVA_VERSION }}
-        - name: Set up Go
-          uses: actions/setup-go@v3
-          with:
-            go-version: "1.19"
-            check-latest: true
-            cache: true
-        - name: build kava cli
-          run: make install
-        - name: validate testnet genesis
-          run: kava validate-genesis ci/env/kava-internal-testnet/genesis.json
+      - name: checkout repo from current commit
+        uses: actions/checkout@v3
+      - name: save version of kava that will be deployed if this pr is merged
+        id: kava-version
+        run: |
+          echo "KAVA_VERSION=$(cat ./ci/env/kava-internal-testnet/KAVA.VERSION)" >> $GITHUB_OUTPUT
+      - name: checkout repo from master
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: checkout version of kava that will be deployed if this pr is merged
+        run: |
+          git pull -p
+          git checkout $KAVA_VERSION
+        env:
+          KAVA_VERSION: ${{ steps.kava-version.outputs.KAVA_VERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
+          check-latest: true
+          cache: true
+      - name: build kava cli
+        run: make install
+      - name: checkout repo from current commit to validate current branch's genesis
+        uses: actions/checkout@v3
+      - name: validate testnet genesis
+        run: kava validate-genesis ci/env/kava-internal-testnet/genesis.json
   validate-protonet-genesis:
     runs-on: ubuntu-latest
     steps:

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -300,16 +300,16 @@
               "amount": "10000000000"
             },
             {
-              "denom": "erc20/multichain/wbtc",
-              "amount": "1000000000"
-            },
-            {
               "denom": "erc20/multichain/usdc",
               "amount": "1000000000000000000"
             },
             {
               "denom": "erc20/multichain/usdt",
               "amount": "10000000000"
+            },
+            {
+              "denom": "erc20/multichain/wbtc",
+              "amount": "1000000000"
             },
             {
               "denom": "hard",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Fixes CI for internal testnet genesis validation (CI was validating the genesis already merged to master).

Denoms in genesis must be sorted to be valid.

before:
```
$ kava validate-genesis ci/env/kava-internal-testnet/genesis.json 
Error: error validating genesis file ci/env/kava-internal-testnet/genesis.json: denomination erc20/multichain/usdc is not sorted
```

after:
```
$ kava validate-genesis ci/env/kava-internal-testnet/genesis.json
File at ci/env/kava-internal-testnet/genesis.json is a valid genesis file
```

## Checklist
 - [x] ~~Changelog has been updated as necessary.~~
