### PR TITLE
Remove x/evm AllowedParamsChange from stability committee

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -51,13 +51,13 @@ func (app App) RegisterUpgradeHandlers() {
 
 			app.Logger().Info(fmt.Sprintf(
 				"adding lend & cdp committee permissions to stability committee (id=%d)",
-				TestnetStabilityCommitteeId,
+				MainnetStabilityCommitteeId,
 			))
-			AddNewPermissionsToStabilityCommittee(ctx, app.committeeKeeper, TestnetStabilityCommitteeId)
+			AddNewPermissionsToStabilityCommittee(ctx, app.committeeKeeper, MainnetStabilityCommitteeId)
 
 			app.Logger().Info(fmt.Sprintf(
 				"removing x/evm AllowedParamsChange from stability committee (id=%d)",
-				TestnetStabilityCommitteeId,
+				MainntStabilityCommitteeId,
 			))
 			RemoveEVMCommitteePermissions(ctx, app.committeeKeeper, MainnetStabilityCommitteeId)
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -57,7 +57,7 @@ func (app App) RegisterUpgradeHandlers() {
 
 			app.Logger().Info(fmt.Sprintf(
 				"removing x/evm AllowedParamsChange from stability committee (id=%d)",
-				MainntStabilityCommitteeId,
+				MainnetStabilityCommitteeId,
 			))
 			RemoveEVMCommitteePermissions(ctx, app.committeeKeeper, MainnetStabilityCommitteeId)
 

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,0 +1,111 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	"github.com/kava-labs/kava/app"
+	cdptypes "github.com/kava-labs/kava/x/cdp/types"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
+	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestUpdateStabilityCommitteePermissions(t *testing.T) {
+	tapp := app.NewTestApp()
+	tapp.InitializeFromGenesisStates()
+	genesisTime := time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx := tapp.NewContext(false, tmproto.Header{Height: 1, Time: genesisTime})
+
+	ck := tapp.GetCommitteeKeeper()
+
+	testCommittee, err := committeetypes.NewMemberCommittee(
+		1,
+		"Kava Stability Committee",
+		[]sdk.AccAddress{
+			sdk.AccAddress([]byte("addr1")),
+		},
+		[]committeetypes.Permission{
+			&committeetypes.ParamsChangePermission{
+				AllowedParamsChanges: committeetypes.AllowedParamsChanges{
+					{
+						Subspace:                   cdptypes.ModuleName,
+						Key:                        string(cdptypes.KeyGlobalDebtLimit),
+						SingleSubparamAllowedAttrs: nil,
+						MultiSubparamsRequirements: nil,
+					},
+					{
+						Subspace:                   cdptypes.ModuleName,
+						Key:                        string(cdptypes.KeySurplusLot),
+						SingleSubparamAllowedAttrs: nil,
+						MultiSubparamsRequirements: nil,
+					},
+					{
+						Subspace:                   evmtypes.ModuleName,
+						Key:                        "EIP712AllowedMsgs",
+						SingleSubparamAllowedAttrs: nil,
+						MultiSubparamsRequirements: nil,
+					},
+					{
+						Subspace:                   evmutiltypes.ModuleName,
+						Key:                        string(evmutiltypes.KeyEnabledConversionPairs),
+						SingleSubparamAllowedAttrs: nil,
+						MultiSubparamsRequirements: nil,
+					},
+				},
+			},
+		},
+		sdk.NewDecWithPrec(5, 1),
+		604800*time.Second,
+		committeetypes.TALLY_OPTION_FIRST_PAST_THE_POST,
+	)
+	require.NoError(t, err)
+
+	ck.SetCommittee(ctx, testCommittee)
+
+	app.UpdateStabilityCommitteePermissions(
+		ctx,
+		ck,
+		1,
+	)
+
+	committee, found := ck.GetCommittee(ctx, 1)
+	require.True(t, found)
+
+	require.Equal(t, "Kava Stability Committee", committee.GetDescription())
+
+	permissions := committee.GetPermissions()
+
+	require.Len(t, permissions, 4, "should have 4 total after adding 3 in update")
+
+	allowedParams := permissions[0].(*committeetypes.ParamsChangePermission).AllowedParamsChanges
+	require.Len(t, allowedParams, 3, "should have 3 allowed params after removing x/")
+	require.Equal(
+		t,
+		committeetypes.AllowedParamsChanges{
+			{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeyGlobalDebtLimit),
+				SingleSubparamAllowedAttrs: nil,
+				MultiSubparamsRequirements: nil,
+			},
+			{
+				Subspace:                   cdptypes.ModuleName,
+				Key:                        string(cdptypes.KeySurplusLot),
+				SingleSubparamAllowedAttrs: nil,
+				MultiSubparamsRequirements: nil,
+			},
+			{
+				Subspace:                   evmutiltypes.ModuleName,
+				Key:                        string(evmutiltypes.KeyEnabledConversionPairs),
+				SingleSubparamAllowedAttrs: nil,
+				MultiSubparamsRequirements: nil,
+			},
+		},
+		allowedParams,
+		"x/evm should be removed from allowed params",
+	)
+}


### PR DESCRIPTION
## Description
Updates the existing migration to remove the x/evm AllowedParamsChange from the permission as the x/evm module no longer uses the params module.

Also adds a test to ensure it works as expected.

## Checklist
- ~~[ ] Changelog has been updated as necessary.~~
