### PR TITLE
Remove mainnet upgrade handler

### DIFF
--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -17,7 +17,7 @@ E2E_SKIP_SHUTDOWN=false
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
 E2E_INCLUDE_AUTOMATED_UPGRADE=true
 # E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
-E2E_KAVA_UPGRADE_NAME=v0.22.0
+E2E_KAVA_UPGRADE_NAME=v0.22.0-alpha.0
 # E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.
 # If IBC tests are enabled this should be >50. Otherwise, this should be >10.
 E2E_KAVA_UPGRADE_HEIGHT=53

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -29,7 +29,7 @@ func (suite IntegrationTestSuite) TestUpgradeHandler() {
 
 	// check stability committee permissions before upgrade to ensure it starts without them
 	res, err := suite.Kava.Committee.Committee(
-		beforeUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.MainnetStabilityCommitteeId},
+		beforeUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.TestnetStabilityCommitteeId},
 	)
 	suite.NoError(err)
 	var beforeCommittee committeetypes.Committee
@@ -42,7 +42,7 @@ func (suite IntegrationTestSuite) TestUpgradeHandler() {
 
 	// check stability committee permission after upgrade to ensure it gets them
 	res, err = suite.Kava.Committee.Committee(
-		afterUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.MainnetStabilityCommitteeId},
+		afterUpgradeCtx, &committeetypes.QueryCommitteeRequest{CommitteeId: app.TestnetStabilityCommitteeId},
 	)
 	suite.NoError(err)
 	var afterCommittee committeetypes.Committee


### PR DESCRIPTION
## Description
Removes the mainnet upgrade handler. This will be re-added in the v0.23.x release along with the other ethermint fixes.

## Checklist
 - ~~[ ] Changelog has been updated as necessary.~~
