### PR TITLE
Update Migration Doc and Ethermint for v0.23.x

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -520,9 +520,8 @@ func NewApp(
 
 	evmBankKeeper := evmutilkeeper.NewEvmBankKeeper(app.evmutilKeeper, app.bankKeeper, app.accountKeeper)
 	app.evmKeeper = evmkeeper.NewKeeper(
-		appCodec, legacyAmino,
+		appCodec,
 		keys[evmtypes.StoreKey], tkeys[evmtypes.TransientKey],
-		keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey],
 		// Authority
 		authtypes.NewModuleAddress(govtypes.ModuleName),
 		app.accountKeeper, evmBankKeeper, app.stakingKeeper, app.feeMarketKeeper,

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ replace (
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v22-4
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v23-1
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	// Use the cosmos modified protobufs

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ github.com/kava-labs/cometbft-db v0.7.0-rocksdb-v7.9.2-kava.1 h1:EZnZAkZ+dqK+1OM
 github.com/kava-labs/cometbft-db v0.7.0-rocksdb-v7.9.2-kava.1/go.mod h1:mI/4J4IxRzPrXvMiwefrt0fucGwaQ5Hm9IKS7HnoJeI=
 github.com/kava-labs/cosmos-sdk v0.46.11-kava.1 h1:3VRpm4zf/gQgmpRVd1p99/2P8ZecAu2FVAXHru5caIo=
 github.com/kava-labs/cosmos-sdk v0.46.11-kava.1/go.mod h1:bG4AkW9bqc8ycrryyKGQEl3YV9BY2wr6HggGq8kvcgM=
-github.com/kava-labs/ethermint v0.21.0-kava-v22-4 h1:cUoR87HsoVJlahy99X1+cKkQK3JPtmLyWLnNtfcQRag=
-github.com/kava-labs/ethermint v0.21.0-kava-v22-4/go.mod h1:rdm6AinxZ4dzPEv/cjH+/AGyTbKufJ3RE7M2MDyklH0=
+github.com/kava-labs/ethermint v0.21.0-kava-v23-1 h1:5TSyCtPvFdMuSe8p2iMVqXmFBlK3lHyjaT9EqN752aI=
+github.com/kava-labs/ethermint v0.21.0-kava-v23-1/go.mod h1:rdm6AinxZ4dzPEv/cjH+/AGyTbKufJ3RE7M2MDyklH0=
 github.com/kava-labs/tm-db v0.6.7-kava.1 h1:7cVYlvWx1yP+gGdaAWcfm6NwMLzf4z6DxXguWn3+O3w=
 github.com/kava-labs/tm-db v0.6.7-kava.1/go.mod h1:HVZfZzWXuqWseXQVplxsWXK6kLHLkk3kQB6c+nuSZvk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/migrate/v0_23/migrate.md
+++ b/migrate/v0_23/migrate.md
@@ -2,8 +2,8 @@
 
 ## Software Version and Key Dates
 
-- The version of `kava` for Kava 13 is v0.22.0
-- The Kava 12 chain will be shutdown with a `SoftwareUpgradeProposal` that activates at approximately 15:00 UTC on May, 10th 2023.
+- The version of `kava` for Kava 13 is v0.23.0
+- The Kava 12 chain will be shutdown with a `SoftwareUpgradeProposal` that activates at approximately 15:00 UTC on May, 17th 2023.
 
 ### On the day of the upgrade
 
@@ -13,7 +13,7 @@
 
 **Ensure you are using golang 1.20.x and not aa different version.** Golang 1.19 and below may cause app hash mismatches!
 
-1. Update to v0.22.0
+1. Update to v0.23.0
 
 ```sh
   # check go version - look for 1.20!
@@ -22,7 +22,7 @@
 
   # in the `kava` folder
   git fetch
-  git checkout v0.22.0
+  git checkout v0.23.0
 
   # Note: Golang 1.20 must be installed before this step
   make install
@@ -31,7 +31,7 @@
   kava version --long
   # name: kava
   # server_name: kava
-  # version: 0.21.0
+  # version: 0.23.0
   # commit: <commit placeholder>
   # build_tags: netgo ledger,
   # go: go version go1.20.3 linux/arm64


### PR DESCRIPTION
- Updates migration doc to reflect new v0.23.0 version and May 17th mainnet date
- Updates ethermint for full state-breaking fix to legacy param handling