### PR TITLE
feat(evmutil): add ERC20KavaWrappedNativeCoinContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Features
 - (evmutil) [#1590] Add allow list param of sdk native denoms that can be transferred to evm
+- (evmutil) [#1591] Configure module to support deploying ERC20KavaWrappedNativeCoin contracts
 
 ## [v0.23.0]
 
@@ -240,6 +241,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1591]: https://github.com/Kava-Labs/kava/pull/1591
 [#1590]: https://github.com/Kava-Labs/kava/pull/1590
 [#1568]: https://github.com/Kava-Labs/kava/pull/1568
 [#1567]: https://github.com/Kava-Labs/kava/pull/1567

--- a/x/evmutil/testutil/suite.go
+++ b/x/evmutil/testutil/suite.go
@@ -72,12 +72,10 @@ func (suite *Suite) SetupTest() {
 	suite.EvmModuleAddr = suite.AccountKeeper.GetModuleAddress(evmtypes.ModuleName)
 
 	// test evm user keys that have no minting permissions
-	key1, err := ethsecp256k1.GenerateKey()
-	suite.Require().NoError(err)
-	suite.Key1 = key1
-	suite.Key1Addr = types.NewInternalEVMAddress(common.BytesToAddress(suite.Key1.PubKey().Address()))
-	suite.Key2, err = ethsecp256k1.GenerateKey()
-	suite.Require().NoError(err)
+	addr, privKey := suite.RandomAccount()
+	suite.Key1 = privKey
+	suite.Key1Addr = types.NewInternalEVMAddress(addr)
+	_, suite.Key2 = suite.RandomAccount()
 
 	_, addrs := app.GeneratePrivKeyAddressPairs(4)
 	suite.Addrs = addrs
@@ -180,6 +178,13 @@ func (suite *Suite) Commit() {
 
 	// update ctx
 	suite.Ctx = suite.App.NewContext(false, header)
+}
+
+func (suite *Suite) RandomAccount() (common.Address, *ethsecp256k1.PrivKey) {
+	privKey, err := ethsecp256k1.GenerateKey()
+	suite.NoError(err)
+	addr := common.BytesToAddress(privKey.PubKey().Address())
+	return addr, privKey
 }
 
 func (suite *Suite) FundAccountWithKava(addr sdk.AccAddress, coins sdk.Coins) {

--- a/x/evmutil/types/contract.go
+++ b/x/evmutil/types/contract.go
@@ -32,6 +32,12 @@ var (
 
 	// ERC20MintableBurnableAddress is the erc20 module address
 	ERC20MintableBurnableAddress common.Address
+
+	//go:embed ethermint_json/ERC20KavaWrappedNativeCoin.json
+	ERC20KavaWrappedNativeCoinJSON []byte
+
+	// ERC20KavaWrappedNativeCoinContract is the compiled erc20 contract
+	ERC20KavaWrappedNativeCoinContract evmtypes.CompiledContract
 )
 
 func init() {
@@ -44,5 +50,14 @@ func init() {
 
 	if len(ERC20MintableBurnableContract.Bin) == 0 {
 		panic("load contract failed")
+	}
+
+	err = json.Unmarshal(ERC20KavaWrappedNativeCoinJSON, &ERC20KavaWrappedNativeCoinContract)
+	if err != nil {
+		panic(err)
+	}
+
+	if len(ERC20KavaWrappedNativeCoinContract.Bin) == 0 {
+		panic("loading ERC20KavaWrappedNativeCoin contract failed")
 	}
 }

--- a/x/evmutil/types/contract.go
+++ b/x/evmutil/types/contract.go
@@ -18,6 +18,7 @@ import (
 	// Embed ERC20 JSON files
 	_ "embed"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
@@ -45,16 +46,16 @@ func init() {
 
 	err := json.Unmarshal(ERC20MintableBurnableJSON, &ERC20MintableBurnableContract)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to unmarshal ERC20MintableBurnableJSON: %s. %s", err, string(ERC20MintableBurnableJSON)))
 	}
 
 	if len(ERC20MintableBurnableContract.Bin) == 0 {
-		panic("load contract failed")
+		panic("loading ERC20MintableBurnable contract failed")
 	}
 
 	err = json.Unmarshal(ERC20KavaWrappedNativeCoinJSON, &ERC20KavaWrappedNativeCoinContract)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to unmarshal ERC20KavaWrappedNativeCoinJSON: %s. %s", err, string(ERC20KavaWrappedNativeCoinJSON)))
 	}
 
 	if len(ERC20KavaWrappedNativeCoinContract.Bin) == 0 {


### PR DESCRIPTION
## Description
* adds the contract ABI & bytecode for an Ownable ERC20 with the following:
  * customizable decimals on deploy -> requires overriding decimals() view
  * mint() exposed for the contract owner which will be the evmutil module
  * burn() exposed for the contract owner which will be the evmutil module
* sets up keeper to deploy above token based on details from an AllowedNativeCoinERC20Token
* tests basic queries and permissions of deployed contract

The chain does not use this new deploy method yet. I intend to add `MsgConvertNativeCoinToERC20` in my next PR. It will use this deployment code upon first conversion of tokens defined in the `allowed_native_denoms` param.

See contract code here: #1594 (this branch is based on that pr)

## Checklist
 - [x] Changelog has been updated as necessary.
