### PR TITLE
fix(evmutil): register MsgConvertCosmosCoinToERC20 on amino

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -2,11 +2,17 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -61,6 +67,64 @@ func TestExport(t *testing.T) {
 	assert.Equal(t, initRequest.InitialHeight+1, exportedApp.Height) // app.Commit() increments height
 	assert.Equal(t, initRequest.ConsensusParams, exportedApp.ConsensusParams)
 	assert.Len(t, exportedApp.Validators, 1) // no validators set in default genesis
+}
+
+// TestLegacyMsgAreAminoRegistered checks if all known msg types are registered on the app's amino codec.
+// It doesn't check if they are registered on the module codecs used for signature checking.
+func TestLegacyMsgAreAminoRegistered(t *testing.T) {
+	tApp := NewTestApp()
+
+	lcdc := tApp.LegacyAmino()
+
+	// Use the proto codec as the canonical list of msg types.
+	protoCodec := tApp.AppCodec().(*codec.ProtoCodec)
+	msgProtoNames := protoCodec.InterfaceRegistry().ListImplementations(sdk.MsgInterfaceProtoName)
+
+	for i, msgName := range msgProtoNames {
+		// skip external unregistered msgs
+		if msgName == sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}) ||
+			msgName == sdk.MsgTypeURL(&vestingtypes.MsgCreatePeriodicVestingAccount{}) {
+			continue
+		}
+
+		// Create an encoded json msg, then unmarshal it to instantiate the msg type.
+		jsonMsg := []byte(fmt.Sprintf(`{"@type": "%s"}`, msgName))
+
+		var msg sdk.Msg
+		err := protoCodec.UnmarshalInterfaceJSON(jsonMsg, &msg)
+		require.NoError(t, err)
+
+		// Only check legacy msgs for amino registration.
+		// Only legacy msg can be signed with amino.
+		_, ok := msg.(legacytx.LegacyMsg)
+		if !ok {
+			continue
+		}
+
+		// Check the msg is registered in amino by checking a repeat registration call panics.
+		panicValue, ok := catchPanic(func() {
+			lcdc.RegisterConcrete(interface{}(msg), fmt.Sprintf("aUniqueRegistrationName%d", i), nil)
+		})
+		assert.True(t, ok, "registration did not panic, msg %s is not registered in amino", msgName)
+		if ok {
+			require.IsTypef(t, "", panicValue, "msg %s amino registration panicked with unexpected type", msgName)
+			aminoErrMsgPrefix := "TypeInfo already exists for"
+			require.Containsf(t, panicValue, aminoErrMsgPrefix, "msg %s amino registration panicked for unexpected reason", msgName)
+		}
+	}
+}
+
+// catchPanic returns the panic value of the passed function. The second return indicates if the function panicked.
+func catchPanic(f func()) (panicValue interface{}, didPanic bool) {
+	didPanic = true
+
+	defer func() {
+		panicValue = recover()
+	}()
+
+	f()
+	didPanic = false
+	return
 }
 
 // unmarshalJSONKeys extracts keys from the top level of a json blob.

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -78,10 +78,10 @@ func TestLegacyMsgAreAminoRegistered(t *testing.T) {
 
 	// Use the proto codec as the canonical list of msg types.
 	protoCodec := tApp.AppCodec().(*codec.ProtoCodec)
-	msgProtoNames := protoCodec.InterfaceRegistry().ListImplementations(sdk.MsgInterfaceProtoName)
+	protoRegisteredMsgs := protoCodec.InterfaceRegistry().ListImplementations(sdk.MsgInterfaceProtoName)
 
-	for i, msgName := range msgProtoNames {
-		// skip external unregistered msgs
+	for i, msgName := range protoRegisteredMsgs {
+		// Skip msgs from dependencies that were never amino registered.
 		if msgName == sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}) ||
 			msgName == sdk.MsgTypeURL(&vestingtypes.MsgCreatePeriodicVestingAccount{}) {
 			continue

--- a/x/evmutil/module.go
+++ b/x/evmutil/module.go
@@ -45,7 +45,9 @@ func (AppModuleBasic) Name() string {
 }
 
 // Registers legacy amino codec
-func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {}
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	types.RegisterLegacyAminoCodec(cdc)
+}
 
 // RegisterInterfaces registers the module's interface types
 func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {

--- a/x/evmutil/types/codec.go
+++ b/x/evmutil/types/codec.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,14 +13,17 @@ import (
 // RegisterLegacyAminoCodec registers the necessary evmutil interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgConvertCoinToERC20{}, "evmutil/MsgConvertCoinToERC20", nil)
-	cdc.RegisterConcrete(&MsgConvertERC20ToCoin{}, "evmutil/MsgConvertERC20ToCoin", nil)
+	legacy.RegisterAminoMsg(cdc, &MsgConvertCoinToERC20{}, "evmutil/MsgConvertCoinToERC20")
+	legacy.RegisterAminoMsg(cdc, &MsgConvertERC20ToCoin{}, "evmutil/MsgConvertERC20ToCoin")
+	legacy.RegisterAminoMsg(cdc, &MsgConvertCosmosCoinToERC20{}, "evmutil/MsgConvertCosmosCoinToERC20")
+
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgConvertCoinToERC20{},
 		&MsgConvertERC20ToCoin{},
+		&MsgConvertCosmosCoinToERC20{},
 	)
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Noticed the new `MsgConvertCosmosCoinToERC20` wasn't registered on amino. So added a test to help catch this in the future by checking all msgs registered on the proto codec are on amino. It's not perfect, we should ideally check `msg.GetSignBytes` returns properly encoded msgs (it uses a local amino, not the app's amino). But it did catch a pre-existing issue where we hadn't setup the registration in `module.go`.

Also added this to the list of gotchas with link to explainer. It's unlikely to cause issues but can in very particular cases mess with tx signing.

## Checklist
 - [x] Changelog has been updated as necessary.
