### PR TITLE
feat: add upgrade handlers for v0.24.x

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"fmt"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -9,6 +12,8 @@ import (
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	committeekeeper "github.com/kava-labs/kava/x/committee/keeper"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
 	evmutilkeeper "github.com/kava-labs/kava/x/evmutil/keeper"
 	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
 )
@@ -19,9 +24,18 @@ const (
 
 	MainnetAtomDenom = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
 	TestnetHardDenom = "hard"
+
+	MainnetStabilityCommitteeId = uint64(1)
+	TestnetStabilityCommitteeId = uint64(1)
 )
 
 var (
+	// Committee permission for changing AllowedCosmosDenoms param
+	AllowedParamsChangeAllowedCosmosDenoms = committeetypes.AllowedParamsChange{
+		Subspace: evmutiltypes.ModuleName,
+		Key:      "AllowedCosmosDenoms",
+	}
+
 	// EIP712 allowed message for MsgConvertCosmosCoinToERC20
 	EIP712AllowedMsgConvertCosmosCoinToERC20 = evmtypes.EIP712AllowedMsg{
 		MsgTypeUrl:       "/kava.evmutil.v1beta1.MsgConvertCosmosCoinToERC20",
@@ -104,10 +118,18 @@ func MainnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 				Decimals: 6,
 			},
 		}
-		InitializeEvmutilAllowedCosmosDenoms(ctx, app.evmutilKeeper, allowedDenoms)
+		InitializeEvmutilAllowedCosmosDenoms(ctx, &app.evmutilKeeper, allowedDenoms)
 
 		app.Logger().Info("allowing cosmos coin conversion messaged in EIP712 signing")
 		AllowEip712SigningForConvertMessages(ctx, app.evmKeeper)
+
+		app.Logger().Info("allowing stability committee to update x/evmutil AllowedCosmosDenoms param")
+		AddAllowedCosmosDenomsParamChangeToStabilityCommittee(
+			ctx,
+			app.interfaceRegistry,
+			&app.committeeKeeper,
+			MainnetStabilityCommitteeId,
+		)
 
 		return toVM, nil
 	}
@@ -133,10 +155,18 @@ func TestnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 				Decimals: 6,
 			},
 		}
-		InitializeEvmutilAllowedCosmosDenoms(ctx, app.evmutilKeeper, allowedDenoms)
+		InitializeEvmutilAllowedCosmosDenoms(ctx, &app.evmutilKeeper, allowedDenoms)
 
 		app.Logger().Info("allowing cosmos coin conversion messaged in EIP712 signing")
 		AllowEip712SigningForConvertMessages(ctx, app.evmKeeper)
+
+		app.Logger().Info("allowing stability committee to update x/evmutil AllowedCosmosDenoms param")
+		AddAllowedCosmosDenomsParamChangeToStabilityCommittee(
+			ctx,
+			app.interfaceRegistry,
+			&app.committeeKeeper,
+			TestnetStabilityCommitteeId,
+		)
 
 		return toVM, nil
 	}
@@ -146,13 +176,13 @@ func TestnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 // This new parameter controls what cosmos denoms are allowed to be converted to ERC20 tokens.
 func InitializeEvmutilAllowedCosmosDenoms(
 	ctx sdk.Context,
-	evmutilKeeper evmutilkeeper.Keeper,
+	evmutilKeeper *evmutilkeeper.Keeper,
 	allowedCoins []evmutiltypes.AllowedCosmosCoinERC20Token,
 ) {
 	params := evmutilKeeper.GetParams(ctx)
 	params.AllowedCosmosDenoms = allowedCoins
 	if err := params.Validate(); err != nil {
-		panic("x/evmutil params are not valid")
+		panic(fmt.Sprintf("x/evmutil params are not valid: %s", err))
 	}
 	evmutilKeeper.SetParams(ctx, params)
 }
@@ -170,7 +200,52 @@ func AllowEip712SigningForConvertMessages(ctx sdk.Context, evmKeeper *evmkeeper.
 		EIP712AllowedMsgConvertCosmosCoinFromERC20,
 	)
 	if err := params.Validate(); err != nil {
-		panic("x/evm params are not valid")
+		panic(fmt.Sprintf("x/evm params are not valid: %s", err))
 	}
 	evmKeeper.SetParams(ctx, params)
+}
+
+// AddAllowedCosmosDenomsParamChangeToStabilityCommittee enables the stability committee
+// to update the AllowedCosmosDenoms parameter of x/evmutil.
+func AddAllowedCosmosDenomsParamChangeToStabilityCommittee(
+	ctx sdk.Context,
+	cdc codectypes.InterfaceRegistry,
+	committeeKeeper *committeekeeper.Keeper,
+	committeeId uint64,
+) {
+	// get committee
+	committee, foundCommittee := committeeKeeper.GetCommittee(ctx, committeeId)
+	if !foundCommittee {
+		panic(fmt.Sprintf("expected to find committee with id %d but found none", committeeId))
+	}
+
+	permissions := committee.GetPermissions()
+
+	// find & update the ParamsChangePermission
+	foundPermission := false
+	for i, permission := range permissions {
+		if paramsChangePermission, ok := permission.(*committeetypes.ParamsChangePermission); ok {
+			foundPermission = true
+			paramsChangePermission.AllowedParamsChanges = append(
+				paramsChangePermission.AllowedParamsChanges,
+				AllowedParamsChangeAllowedCosmosDenoms,
+			)
+			permissions[i] = paramsChangePermission
+			break
+		}
+	}
+
+	// error if permission was not found & updated
+	if !foundPermission {
+		panic(fmt.Sprintf("no ParamsChangePermission found on committee with id %d", committeeId))
+	}
+
+	// update permissions
+	committee.SetPermissions(permissions)
+	if err := committee.Validate(); err != nil {
+		panic(fmt.Sprintf("stability committee (id=%d) is invalid: %s", committeeId, err))
+	}
+
+	// save permission changes
+	committeeKeeper.SetCommittee(ctx, committee)
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -5,6 +5,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	evmutilkeeper "github.com/kava-labs/kava/x/evmutil/keeper"
 	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
@@ -13,11 +16,52 @@ import (
 const (
 	MainnetUpgradeName = "v0.24.0"
 	TestnetUpgradeName = "v0.24.0-alpha.0"
+
+	MainnetAtomDenom = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+	TestnetHardDenom = "hard"
 )
 
 var (
-	MainnetAtomDenom = "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
-	TestnetHardDenom = "hard"
+	// EIP712 allowed message for MsgConvertCosmosCoinToERC20
+	EIP712AllowedMsgConvertCosmosCoinToERC20 = evmtypes.EIP712AllowedMsg{
+		MsgTypeUrl:       "/kava.evmutil.v1beta1.MsgConvertCosmosCoinToERC20",
+		MsgValueTypeName: "MsgConvertCosmosCoinToERC20",
+		ValueTypes: []evmtypes.EIP712MsgAttrType{
+			{
+				Name: "initiator",
+				Type: "string",
+			},
+			{
+				Name: "receiver",
+				Type: "string",
+			},
+			{
+				Name: "amount",
+				Type: "Coin",
+			},
+		},
+		NestedTypes: nil,
+	}
+	// EIP712 allowed message for MsgConvertCosmosCoinFromERC20
+	EIP712AllowedMsgConvertCosmosCoinFromERC20 = evmtypes.EIP712AllowedMsg{
+		MsgTypeUrl:       "/kava.evmutil.v1beta1.MsgConvertCosmosCoinFromERC20",
+		MsgValueTypeName: "MsgConvertCosmosCoinFromERC20",
+		ValueTypes: []evmtypes.EIP712MsgAttrType{
+			{
+				Name: "initiator",
+				Type: "string",
+			},
+			{
+				Name: "receiver",
+				Type: "string",
+			},
+			{
+				Name: "amount",
+				Type: "Coin",
+			},
+		},
+		NestedTypes: nil,
+	}
 )
 
 func (app App) RegisterUpgradeHandlers() {
@@ -62,6 +106,9 @@ func MainnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 		}
 		InitializeEvmutilAllowedCosmosDenoms(ctx, app.evmutilKeeper, allowedDenoms)
 
+		app.Logger().Info("allowing cosmos coin conversion messaged in EIP712 signing")
+		AllowEip712SigningForConvertMessages(ctx, app.evmKeeper)
+
 		return toVM, nil
 	}
 }
@@ -75,6 +122,7 @@ func TestnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 			return toVM, err
 		}
 
+		app.Logger().Info("initializing allowed_cosmos_denoms param of x/evmutil")
 		// on testnet, IBC is not enabled. we initialize HARD tokens for conversion to EVM.
 		allowedDenoms := []evmutiltypes.AllowedCosmosCoinERC20Token{
 			{
@@ -86,6 +134,9 @@ func TestnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
 			},
 		}
 		InitializeEvmutilAllowedCosmosDenoms(ctx, app.evmutilKeeper, allowedDenoms)
+
+		app.Logger().Info("allowing cosmos coin conversion messaged in EIP712 signing")
+		AllowEip712SigningForConvertMessages(ctx, app.evmKeeper)
 
 		return toVM, nil
 	}
@@ -100,5 +151,26 @@ func InitializeEvmutilAllowedCosmosDenoms(
 ) {
 	params := evmutilKeeper.GetParams(ctx)
 	params.AllowedCosmosDenoms = allowedCoins
+	if err := params.Validate(); err != nil {
+		panic("x/evmutil params are not valid")
+	}
 	evmutilKeeper.SetParams(ctx, params)
+}
+
+// AllowEip712SigningForConvertMessages adds the cosmos coin conversion messages to the
+// allowed message types for EIP712 signing.
+// The newly allowed messages are:
+// - MsgConvertCosmosCoinToERC20
+// - MsgConvertCosmosCoinFromERC20
+func AllowEip712SigningForConvertMessages(ctx sdk.Context, evmKeeper *evmkeeper.Keeper) {
+	params := evmKeeper.GetParams(ctx)
+	params.EIP712AllowedMsgs = append(
+		params.EIP712AllowedMsgs,
+		EIP712AllowedMsgConvertCosmosCoinToERC20,
+		EIP712AllowedMsgConvertCosmosCoinFromERC20,
+	)
+	if err := params.Validate(); err != nil {
+		panic("x/evm params are not valid")
+	}
+	evmKeeper.SetParams(ctx, params)
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,3 +1,60 @@
 package app
 
-func (app App) RegisterUpgradeHandlers() {}
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const (
+	MainnetUpgradeName = "v0.24.0"
+	TestnetUpgradeName = "v0.24.0-alpha.0"
+)
+
+func (app App) RegisterUpgradeHandlers() {
+	// register upgrade handler for mainnet
+	app.upgradeKeeper.SetUpgradeHandler(MainnetUpgradeName, MainnetUpgradeHandler(app))
+
+	// register upgrade handler for testnet
+	app.upgradeKeeper.SetUpgradeHandler(TestnetUpgradeName, TestnetUpgradeHandler(app))
+
+	upgradeInfo, err := app.upgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	doUpgrade := upgradeInfo.Name == MainnetUpgradeName || upgradeInfo.Name == TestnetUpgradeName
+	if doUpgrade && !app.upgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+}
+
+func MainnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		app.Logger().Info("running mainnet upgrade handler")
+
+		toVM, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		return toVM, nil
+	}
+}
+
+func TestnetUpgradeHandler(app App) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		app.Logger().Info("running testnet upgrade handler")
+
+		toVM, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		if err != nil {
+			return toVM, err
+		}
+
+		return toVM, nil
+	}
+}

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -11,7 +11,7 @@ E2E_INCLUDE_IBC_TESTS=true
 
 # E2E_SKIP_SHUTDOWN when true will keep the networks running after tests complete (pass or fail)
 # This is useful for debugging chain state when writing tests.
-E2E_SKIP_SHUTDOWN=true
+E2E_SKIP_SHUTDOWN=false
 
 # The following variables should be defined to run an upgrade.
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -15,7 +15,7 @@ E2E_SKIP_SHUTDOWN=false
 
 # The following variables should be defined to run an upgrade.
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
-E2E_INCLUDE_AUTOMATED_UPGRADE=false
+E2E_INCLUDE_AUTOMATED_UPGRADE=true
 # E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
 E2E_KAVA_UPGRADE_NAME=v0.24.0
 # E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -11,7 +11,7 @@ E2E_INCLUDE_IBC_TESTS=true
 
 # E2E_SKIP_SHUTDOWN when true will keep the networks running after tests complete (pass or fail)
 # This is useful for debugging chain state when writing tests.
-E2E_SKIP_SHUTDOWN=false
+E2E_SKIP_SHUTDOWN=true
 
 # The following variables should be defined to run an upgrade.
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -4,7 +4,7 @@ E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe no
 
 # E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
 # Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
-E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
+E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="v0.23"
 
 # E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
 E2E_INCLUDE_IBC_TESTS=true
@@ -17,12 +17,12 @@ E2E_SKIP_SHUTDOWN=false
 # E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
 E2E_INCLUDE_AUTOMATED_UPGRADE=false
 # E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
-E2E_KAVA_UPGRADE_NAME=
+E2E_KAVA_UPGRADE_NAME=v0.24.0
 # E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.
 # If IBC tests are enabled this should be >30. Otherwise, this should be >10.
-E2E_KAVA_UPGRADE_HEIGHT=
+E2E_KAVA_UPGRADE_HEIGHT=35
 # E2E_KAVA_UPGRADE_BASE_IMAGE_TAG is the tag of the docker image the chain should upgrade from.
-E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=
+E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=v0.23.1
 
 # E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token.
 # The E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC account should have a balance.

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -16,3 +16,8 @@ func (suite *IntegrationTestSuite) TestUpgradeHandler() {
 	// beforeUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight - 1)
 	// afterUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight)
 }
+
+// Thorough testing of the upgrade handler for v0.24 depends on:
+// - chain starting from v0.23 template
+//   - no allowed cosmos denoms
+// - EIP712 not allowing cosmos coin conversion messages

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -2,6 +2,16 @@ package e2e_test
 
 import (
 	"fmt"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+
+	"github.com/kava-labs/kava/app"
+	"github.com/kava-labs/kava/tests/util"
+	committeetypes "github.com/kava-labs/kava/x/committee/types"
+	evmutiltypes "github.com/kava-labs/kava/x/evmutil/types"
 )
 
 // TestUpgradeHandler can be used to run tests post-upgrade. If an upgrade is enabled, all tests
@@ -12,17 +22,110 @@ func (suite *IntegrationTestSuite) TestUpgradeHandler() {
 	fmt.Println("An upgrade has run!")
 	suite.True(true)
 
+	// Thorough testing of the upgrade handler for v0.24 depends on:
+	// - chain starting from v0.23 template
+	// - funded account has ibc denom for ATOM
+	// - Stability committee existing with committee id 1
+
 	// Uncomment & use these contexts to compare chain state before & after the upgrade occurs.
-	// beforeUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight - 1)
-	// afterUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight)
+	beforeUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight - 1)
+	afterUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight)
+
+	// check x/evmutil module consensus version has been updated
+	suite.Run("x/evmutil consensus version 1 -> 2", func() {
+		before, err := suite.Kava.Upgrade.ModuleVersions(
+			beforeUpgradeCtx,
+			&upgradetypes.QueryModuleVersionsRequest{
+				ModuleName: evmutiltypes.ModuleName,
+			},
+		)
+		suite.NoError(err)
+		suite.Equal(uint64(1), before.ModuleVersions[0].Version)
+
+		after, err := suite.Kava.Upgrade.ModuleVersions(
+			afterUpgradeCtx,
+			&upgradetypes.QueryModuleVersionsRequest{
+				ModuleName: evmutiltypes.ModuleName,
+			},
+		)
+		suite.NoError(err)
+		suite.Equal(uint64(2), after.ModuleVersions[0].Version)
+	})
+
+	// check evmutil params before & after upgrade
+	suite.Run("x/evmutil AllowedCosmosDenoms updated", func() {
+		before, err := suite.Kava.Evmutil.Params(beforeUpgradeCtx, &evmutiltypes.QueryParamsRequest{})
+		suite.NoError(err)
+		suite.Len(before.Params.AllowedCosmosDenoms, 0)
+
+		after, err := suite.Kava.Evmutil.Params(afterUpgradeCtx, &evmutiltypes.QueryParamsRequest{})
+		suite.NoError(err)
+		suite.Len(after.Params.AllowedCosmosDenoms, 1)
+		tokenInfo := after.Params.AllowedCosmosDenoms[0]
+		suite.Equal(app.MainnetAtomDenom, tokenInfo.CosmosDenom)
+	})
+
+	// check x/evm param for allowed eip712 messages
+	// use of these messages is performed in e2e_convert_cosmos_coins_test.go
+	suite.Run("EIP712 signing allowed for new messages", func() {
+		before, err := suite.Kava.Evm.Params(
+			beforeUpgradeCtx,
+			&evmtypes.QueryParamsRequest{},
+		)
+		suite.NoError(err)
+		suite.NotContains(before.Params.EIP712AllowedMsgs, app.EIP712AllowedMsgConvertCosmosCoinToERC20)
+		suite.NotContains(before.Params.EIP712AllowedMsgs, app.EIP712AllowedMsgConvertCosmosCoinFromERC20)
+
+		after, err := suite.Kava.Evm.Params(
+			afterUpgradeCtx,
+			&evmtypes.QueryParamsRequest{},
+		)
+		suite.NoError(err)
+		suite.Contains(after.Params.EIP712AllowedMsgs, app.EIP712AllowedMsgConvertCosmosCoinToERC20)
+		suite.Contains(after.Params.EIP712AllowedMsgs, app.EIP712AllowedMsgConvertCosmosCoinFromERC20)
+	})
+
+	// check stability committee permissions were updated
+	suite.Run("stability committee ParamsChangePermission adds AllowedCosmosDenoms", func() {
+		before, err := suite.Kava.Committee.Committee(
+			beforeUpgradeCtx,
+			&committeetypes.QueryCommitteeRequest{
+				CommitteeId: app.MainnetStabilityCommitteeId,
+			},
+		)
+		suite.NoError(err)
+		fmt.Println("BEFORE: ", before.Committee)
+		suite.NotContains(
+			suite.getParamsChangePerm(before.Committee),
+			app.AllowedParamsChangeAllowedCosmosDenoms,
+		)
+
+		after, err := suite.Kava.Committee.Committee(
+			afterUpgradeCtx,
+			&committeetypes.QueryCommitteeRequest{
+				CommitteeId: app.MainnetStabilityCommitteeId,
+			},
+		)
+		suite.NoError(err)
+		fmt.Println("AFTER: ", after.Committee)
+		suite.Contains(
+			suite.getParamsChangePerm(after.Committee),
+			app.AllowedParamsChangeAllowedCosmosDenoms,
+		)
+	})
 }
 
-// Thorough testing of the upgrade handler for v0.24 depends on:
-// - chain starting from v0.23 template
-//   - no allowed cosmos denoms
-// - EIP712 not allowing cosmos coin conversion messages
-
-// NOTE:
-// e2e_convert_cosmos_coins_test.go test confirm the following:
-// - AllowedCosmosDenom gets initialized
-// - Convert messages can be signed via EIP712
+func (suite *IntegrationTestSuite) getParamsChangePerm(anyComm *codectypes.Any) []committeetypes.AllowedParamsChange {
+	var committee committeetypes.Committee
+	err := suite.Kava.EncodingConfig.Marshaler.UnpackAny(anyComm, &committee)
+	if err != nil {
+		panic(err)
+	}
+	permissions := committee.GetPermissions()
+	for _, perm := range permissions {
+		if paramsChangePerm, ok := perm.(*committeetypes.ParamsChangePermission); ok {
+			return paramsChangePerm.AllowedParamsChanges
+		}
+	}
+	panic("no ParamsChangePermission found for stability committee")
+}

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -21,3 +21,8 @@ func (suite *IntegrationTestSuite) TestUpgradeHandler() {
 // - chain starting from v0.23 template
 //   - no allowed cosmos denoms
 // - EIP712 not allowing cosmos coin conversion messages
+
+// NOTE:
+// e2e_convert_cosmos_coins_test.go test confirm the following:
+// - AllowedCosmosDenom gets initialized
+// - Convert messages can be signed via EIP712


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Adds mainnet & testnet upgrade handlers to initialize state for cosmos coin conversion functionality. Includes automated e2e tests for mainnet upgrade handler.

## Checklist
 - [x] ~~Changelog has been updated as necessary.~~
