### PR TITLE
test(e2e): refactor NodeRunner in prep for live networks

### DIFF
--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -2,6 +2,10 @@
 # Should be funded with KAVA and have an ERC20 balance
 E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe nose dream glance cave turtle electric fabric jacket shaft easy myself genuine this sibling pulse word unfold'
 
+# E2E_RUN_KVTOOL_NETWORKS is the only currently supported option.
+# It triggers tests to be run against local networks spun up with kvtool.
+E2E_RUN_KVTOOL_NETWORKS=true
+
 # E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
 # Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
 E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"

--- a/tests/e2e/runner/chain.go
+++ b/tests/e2e/runner/chain.go
@@ -59,7 +59,7 @@ func (c *Chains) Register(name string, chain *ChainDetails) error {
 // the Chain details are all hardcoded because they are currently fixed by kvtool.
 // someday they may be accepted as configurable parameters.
 var (
-	kavaChain = ChainDetails{
+	kvtoolKavaChain = ChainDetails{
 		RpcUrl:    "http://localhost:26657",
 		GrpcUrl:   "http://localhost:9090",
 		EvmRpcUrl: "http://localhost:8545",
@@ -67,7 +67,7 @@ var (
 		ChainId:      "kavalocalnet_8888-1",
 		StakingDenom: "ukava",
 	}
-	ibcChain = ChainDetails{
+	kvtoolIbcChain = ChainDetails{
 		RpcUrl:    "http://localhost:26658",
 		GrpcUrl:   "http://localhost:9092",
 		EvmRpcUrl: "http://localhost:8547",

--- a/tests/e2e/runner/chain.go
+++ b/tests/e2e/runner/chain.go
@@ -16,18 +16,18 @@ var (
 
 // ChainDetails wraps information about the ports exposed to the host that endpoints could be access on.
 type ChainDetails struct {
+	EvmRpcUrl string
+
 	RpcPort  string
 	GrpcPort string
 	RestPort string
-	EvmPort  string
 
 	ChainId      string
 	StakingDenom string
 }
 
 func (c ChainDetails) EvmClient() (*ethclient.Client, error) {
-	evmRpcUrl := fmt.Sprintf("http://localhost:%s", c.EvmPort)
-	return ethclient.Dial(evmRpcUrl)
+	return ethclient.Dial(c.EvmRpcUrl)
 }
 
 func (c ChainDetails) GrpcConn() (*grpc.ClientConn, error) {
@@ -64,19 +64,21 @@ func (c *Chains) Register(name string, chain *ChainDetails) error {
 // and generate these details dynamically
 var (
 	kavaChain = ChainDetails{
+		EvmRpcUrl: "http://localhost:8545",
+
 		RpcPort:  "26657",
 		RestPort: "1317",
 		GrpcPort: "9090",
-		EvmPort:  "8545",
 
 		ChainId:      "kavalocalnet_8888-1",
 		StakingDenom: "ukava",
 	}
 	ibcChain = ChainDetails{
+		EvmRpcUrl: "http://localhost:8547",
+
 		RpcPort:  "26658",
 		RestPort: "1318",
 		GrpcPort: "9092",
-		EvmPort:  "8547",
 
 		ChainId:      "kavalocalnet_8889-2",
 		StakingDenom: "uatom",

--- a/tests/e2e/runner/chain.go
+++ b/tests/e2e/runner/chain.go
@@ -14,7 +14,7 @@ var (
 	ErrChainAlreadyExists = errors.New("chain already exists")
 )
 
-// ChainDetails wraps information about the ports exposed to the host that endpoints could be access on.
+// ChainDetails wraps information about the properties & endpoints of a chain.
 type ChainDetails struct {
 	RpcUrl    string
 	GrpcUrl   string
@@ -57,8 +57,7 @@ func (c *Chains) Register(name string, chain *ChainDetails) error {
 }
 
 // the Chain details are all hardcoded because they are currently fixed by kvtool.
-// some day they may be configurable, at which point `runner` can determine the ports
-// and generate these details dynamically
+// someday they may be accepted as configurable parameters.
 var (
 	kavaChain = ChainDetails{
 		RpcUrl:    "http://localhost:26657",

--- a/tests/e2e/runner/chain.go
+++ b/tests/e2e/runner/chain.go
@@ -16,11 +16,9 @@ var (
 
 // ChainDetails wraps information about the ports exposed to the host that endpoints could be access on.
 type ChainDetails struct {
+	RpcUrl    string
+	GrpcUrl   string
 	EvmRpcUrl string
-
-	RpcPort  string
-	GrpcPort string
-	RestPort string
 
 	ChainId      string
 	StakingDenom string
@@ -31,8 +29,7 @@ func (c ChainDetails) EvmClient() (*ethclient.Client, error) {
 }
 
 func (c ChainDetails) GrpcConn() (*grpc.ClientConn, error) {
-	grpcUrl := fmt.Sprintf("http://localhost:%s", c.GrpcPort)
-	return util.NewGrpcConnection(grpcUrl)
+	return util.NewGrpcConnection(c.GrpcUrl)
 }
 
 type Chains struct {
@@ -64,21 +61,17 @@ func (c *Chains) Register(name string, chain *ChainDetails) error {
 // and generate these details dynamically
 var (
 	kavaChain = ChainDetails{
+		RpcUrl:    "http://localhost:26657",
+		GrpcUrl:   "http://localhost:9090",
 		EvmRpcUrl: "http://localhost:8545",
-
-		RpcPort:  "26657",
-		RestPort: "1317",
-		GrpcPort: "9090",
 
 		ChainId:      "kavalocalnet_8888-1",
 		StakingDenom: "ukava",
 	}
 	ibcChain = ChainDetails{
+		RpcUrl:    "http://localhost:26658",
+		GrpcUrl:   "http://localhost:9092",
 		EvmRpcUrl: "http://localhost:8547",
-
-		RpcPort:  "26658",
-		RestPort: "1318",
-		GrpcPort: "9092",
 
 		ChainId:      "kavalocalnet_8889-2",
 		StakingDenom: "uatom",

--- a/tests/e2e/runner/kvtool.go
+++ b/tests/e2e/runner/kvtool.go
@@ -7,24 +7,24 @@ import (
 	"os/exec"
 )
 
-// KavaNodeRunner implements a NodeRunner that spins up local chains with kvtool.
+// KvtoolRunner implements a NodeRunner that spins up local chains with kvtool.
 // It has support for the following:
 // - running a Kava node
 // - optionally, running an IBC node with a channel opened to the Kava node
 // - optionally, start the Kava node on one version and upgrade to another
-type KavaNodeRunner struct {
+type KvtoolRunner struct {
 	config Config
 }
 
-var _ NodeRunner = &KavaNodeRunner{}
+var _ NodeRunner = &KvtoolRunner{}
 
-func NewKavaNode(config Config) *KavaNodeRunner {
-	return &KavaNodeRunner{
+func NewKvtoolRunner(config Config) *KvtoolRunner {
+	return &KvtoolRunner{
 		config: config,
 	}
 }
 
-func (k *KavaNodeRunner) StartChains() Chains {
+func (k *KvtoolRunner) StartChains() Chains {
 	// install kvtool if not already installed
 	installKvtoolCmd := exec.Command("./scripts/install-kvtool.sh")
 	installKvtoolCmd.Stdout = os.Stdout
@@ -75,7 +75,7 @@ func (k *KavaNodeRunner) StartChains() Chains {
 	return chains
 }
 
-func (k *KavaNodeRunner) Shutdown() {
+func (k *KvtoolRunner) Shutdown() {
 	if k.config.SkipShutdown {
 		log.Printf("would shut down but SkipShutdown is true")
 		return

--- a/tests/e2e/runner/kvtool.go
+++ b/tests/e2e/runner/kvtool.go
@@ -75,16 +75,16 @@ func (k *KvtoolRunner) StartChains() Chains {
 
 	// wait for chain to be live.
 	// if an upgrade is defined, this waits for the upgrade to be completed.
-	if err := waitForChainStart(kavaChain); err != nil {
+	if err := waitForChainStart(kvtoolKavaChain); err != nil {
 		k.Shutdown()
 		panic(err)
 	}
 	log.Println("kava is started!")
 
 	chains := NewChains()
-	chains.Register("kava", &kavaChain)
+	chains.Register("kava", &kvtoolKavaChain)
 	if k.config.IncludeIBC {
-		chains.Register("ibc", &ibcChain)
+		chains.Register("ibc", &kvtoolIbcChain)
 	}
 	return chains
 }

--- a/tests/e2e/runner/kvtool.go
+++ b/tests/e2e/runner/kvtool.go
@@ -1,0 +1,90 @@
+package runner
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+// KavaNodeRunner implements a NodeRunner that spins up local chains with kvtool.
+// It has support for the following:
+// - running a Kava node
+// - optionally, running an IBC node with a channel opened to the Kava node
+// - optionally, start the Kava node on one version and upgrade to another
+type KavaNodeRunner struct {
+	config Config
+}
+
+var _ NodeRunner = &KavaNodeRunner{}
+
+func NewKavaNode(config Config) *KavaNodeRunner {
+	return &KavaNodeRunner{
+		config: config,
+	}
+}
+
+func (k *KavaNodeRunner) StartChains() Chains {
+	// install kvtool if not already installed
+	installKvtoolCmd := exec.Command("./scripts/install-kvtool.sh")
+	installKvtoolCmd.Stdout = os.Stdout
+	installKvtoolCmd.Stderr = os.Stderr
+	if err := installKvtoolCmd.Run(); err != nil {
+		panic(fmt.Sprintf("failed to install kvtool: %s", err.Error()))
+	}
+
+	// start local test network with kvtool
+	log.Println("starting kava node")
+	kvtoolArgs := []string{"testnet", "bootstrap", "--kava.configTemplate", k.config.KavaConfigTemplate}
+	// include an ibc chain if desired
+	if k.config.IncludeIBC {
+		kvtoolArgs = append(kvtoolArgs, "--ibc")
+	}
+	// handle automated upgrade functionality, if defined
+	if k.config.EnableAutomatedUpgrade {
+		kvtoolArgs = append(kvtoolArgs,
+			"--upgrade-name", k.config.KavaUpgradeName,
+			"--upgrade-height", fmt.Sprint(k.config.KavaUpgradeHeight),
+			"--upgrade-base-image-tag", k.config.KavaUpgradeBaseImageTag,
+		)
+	}
+	// start the chain
+	startKavaCmd := exec.Command("kvtool", kvtoolArgs...)
+	startKavaCmd.Env = os.Environ()
+	startKavaCmd.Env = append(startKavaCmd.Env, fmt.Sprintf("KAVA_TAG=%s", k.config.ImageTag))
+	startKavaCmd.Stdout = os.Stdout
+	startKavaCmd.Stderr = os.Stderr
+	log.Println(startKavaCmd.String())
+	if err := startKavaCmd.Run(); err != nil {
+		panic(fmt.Sprintf("failed to start kava: %s", err.Error()))
+	}
+
+	// wait for chain to be live.
+	// if an upgrade is defined, this waits for the upgrade to be completed.
+	if err := waitForChainStart(kavaChain); err != nil {
+		k.Shutdown()
+		panic(err)
+	}
+	log.Println("kava is started!")
+
+	chains := NewChains()
+	chains.Register("kava", &kavaChain)
+	if k.config.IncludeIBC {
+		chains.Register("ibc", &ibcChain)
+	}
+	return chains
+}
+
+func (k *KavaNodeRunner) Shutdown() {
+	if k.config.SkipShutdown {
+		log.Printf("would shut down but SkipShutdown is true")
+		return
+	}
+	log.Println("shutting down kava node")
+	shutdownKavaCmd := exec.Command("kvtool", "testnet", "down")
+	shutdownKavaCmd.Stdout = os.Stdout
+	shutdownKavaCmd.Stderr = os.Stderr
+	if err := shutdownKavaCmd.Run(); err != nil {
+		panic(fmt.Sprintf("failed to shutdown kvtool: %s", err.Error()))
+	}
+}

--- a/tests/e2e/runner/kvtool.go
+++ b/tests/e2e/runner/kvtool.go
@@ -7,18 +7,32 @@ import (
 	"os/exec"
 )
 
+type KvtoolRunnerConfig struct {
+	KavaConfigTemplate string
+
+	ImageTag   string
+	IncludeIBC bool
+
+	EnableAutomatedUpgrade  bool
+	KavaUpgradeName         string
+	KavaUpgradeHeight       int64
+	KavaUpgradeBaseImageTag string
+
+	SkipShutdown bool
+}
+
 // KvtoolRunner implements a NodeRunner that spins up local chains with kvtool.
 // It has support for the following:
 // - running a Kava node
 // - optionally, running an IBC node with a channel opened to the Kava node
 // - optionally, start the Kava node on one version and upgrade to another
 type KvtoolRunner struct {
-	config Config
+	config KvtoolRunnerConfig
 }
 
 var _ NodeRunner = &KvtoolRunner{}
 
-func NewKvtoolRunner(config Config) *KvtoolRunner {
+func NewKvtoolRunner(config KvtoolRunnerConfig) *KvtoolRunner {
 	return &KvtoolRunner{
 		config: config,
 	}

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -125,9 +125,11 @@ func (k *KavaNodeRunner) waitForChainStart() error {
 	if err := backoff.Retry(k.pingKava, b); err != nil {
 		return fmt.Errorf("failed to start & connect to chain: %s", err)
 	}
+
 	b.Reset()
 	// the evm takes a bit longer to start up. wait for it to start as well.
-	if err := backoff.Retry(k.pingEvm, b); err != nil {
+	evmRpcUrl := fmt.Sprintf("http://localhost:%s", k.kavaChain.EvmPort)
+	if err := backoff.Retry(func() error { return pingEvm(evmRpcUrl) }, b); err != nil {
 		return fmt.Errorf("failed to start & connect to chain: %s", err)
 	}
 	return nil
@@ -148,10 +150,9 @@ func (k *KavaNodeRunner) pingKava() error {
 	return nil
 }
 
-func (k *KavaNodeRunner) pingEvm() error {
+func pingEvm(evmRpcUrl string) error {
 	log.Println("pinging evm...")
-	url := fmt.Sprintf("http://localhost:%s", k.kavaChain.EvmPort)
-	res, err := http.Get(url)
+	res, err := http.Get(evmRpcUrl)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -129,8 +129,7 @@ func (k *KavaNodeRunner) waitForChainStart() error {
 
 	b.Reset()
 	// the evm takes a bit longer to start up. wait for it to start as well.
-	evmRpcUrl := fmt.Sprintf("http://localhost:%s", k.kavaChain.EvmPort)
-	if err := backoff.Retry(func() error { return pingEvm(evmRpcUrl) }, b); err != nil {
+	if err := backoff.Retry(func() error { return pingEvm(kavaChain.EvmRpcUrl) }, b); err != nil {
 		return fmt.Errorf("failed to start & connect to chain: %s", err)
 	}
 	return nil

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -9,20 +9,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 )
 
-type Config struct {
-	KavaConfigTemplate string
-
-	ImageTag   string
-	IncludeIBC bool
-
-	EnableAutomatedUpgrade  bool
-	KavaUpgradeName         string
-	KavaUpgradeHeight       int64
-	KavaUpgradeBaseImageTag string
-
-	SkipShutdown bool
-}
-
 // NodeRunner is responsible for starting and managing docker containers to run a node.
 type NodeRunner interface {
 	StartChains() Chains

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -122,7 +122,8 @@ func (k *KavaNodeRunner) waitForChainStart() error {
 	b := backoff.NewExponentialBackOff()
 	b.MaxInterval = 5 * time.Second
 	b.MaxElapsedTime = 30 * time.Second
-	if err := backoff.Retry(k.pingKava, b); err != nil {
+	rpcUrl := fmt.Sprintf("http://localhost:%s", k.kavaChain.RpcPort)
+	if err := backoff.Retry(func() error { return pingKava(rpcUrl) }, b); err != nil {
 		return fmt.Errorf("failed to start & connect to chain: %s", err)
 	}
 
@@ -135,10 +136,10 @@ func (k *KavaNodeRunner) waitForChainStart() error {
 	return nil
 }
 
-func (k *KavaNodeRunner) pingKava() error {
+func pingKava(rpcUrl string) error {
 	log.Println("pinging kava chain...")
-	url := fmt.Sprintf("http://localhost:%s/status", k.kavaChain.RpcPort)
-	res, err := http.Get(url)
+	statusUrl := fmt.Sprintf("%s/status", rpcUrl)
+	res, err := http.Get(statusUrl)
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -122,8 +122,7 @@ func (k *KavaNodeRunner) waitForChainStart() error {
 	b := backoff.NewExponentialBackOff()
 	b.MaxInterval = 5 * time.Second
 	b.MaxElapsedTime = 30 * time.Second
-	rpcUrl := fmt.Sprintf("http://localhost:%s", k.kavaChain.RpcPort)
-	if err := backoff.Retry(func() error { return pingKava(rpcUrl) }, b); err != nil {
+	if err := backoff.Retry(func() error { return pingKava(kavaChain.RpcUrl) }, b); err != nil {
 		return fmt.Errorf("failed to start & connect to chain: %s", err)
 	}
 

--- a/tests/e2e/runner/main.go
+++ b/tests/e2e/runner/main.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"os/exec"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -29,88 +27,6 @@ type Config struct {
 type NodeRunner interface {
 	StartChains() Chains
 	Shutdown()
-}
-
-// KavaNodeRunner implements a NodeRunner that spins up local chains with kvtool.
-// It has support for the following:
-// - running a Kava node
-// - optionally, running an IBC node with a channel opened to the Kava node
-// - optionally, start the Kava node on one version and upgrade to another
-type KavaNodeRunner struct {
-	config Config
-}
-
-var _ NodeRunner = &KavaNodeRunner{}
-
-func NewKavaNode(config Config) *KavaNodeRunner {
-	return &KavaNodeRunner{
-		config: config,
-	}
-}
-
-func (k *KavaNodeRunner) StartChains() Chains {
-	// install kvtool if not already installed
-	installKvtoolCmd := exec.Command("./scripts/install-kvtool.sh")
-	installKvtoolCmd.Stdout = os.Stdout
-	installKvtoolCmd.Stderr = os.Stderr
-	if err := installKvtoolCmd.Run(); err != nil {
-		panic(fmt.Sprintf("failed to install kvtool: %s", err.Error()))
-	}
-
-	// start local test network with kvtool
-	log.Println("starting kava node")
-	kvtoolArgs := []string{"testnet", "bootstrap", "--kava.configTemplate", k.config.KavaConfigTemplate}
-	// include an ibc chain if desired
-	if k.config.IncludeIBC {
-		kvtoolArgs = append(kvtoolArgs, "--ibc")
-	}
-	// handle automated upgrade functionality, if defined
-	if k.config.EnableAutomatedUpgrade {
-		kvtoolArgs = append(kvtoolArgs,
-			"--upgrade-name", k.config.KavaUpgradeName,
-			"--upgrade-height", fmt.Sprint(k.config.KavaUpgradeHeight),
-			"--upgrade-base-image-tag", k.config.KavaUpgradeBaseImageTag,
-		)
-	}
-	// start the chain
-	startKavaCmd := exec.Command("kvtool", kvtoolArgs...)
-	startKavaCmd.Env = os.Environ()
-	startKavaCmd.Env = append(startKavaCmd.Env, fmt.Sprintf("KAVA_TAG=%s", k.config.ImageTag))
-	startKavaCmd.Stdout = os.Stdout
-	startKavaCmd.Stderr = os.Stderr
-	log.Println(startKavaCmd.String())
-	if err := startKavaCmd.Run(); err != nil {
-		panic(fmt.Sprintf("failed to start kava: %s", err.Error()))
-	}
-
-	// wait for chain to be live.
-	// if an upgrade is defined, this waits for the upgrade to be completed.
-	if err := waitForChainStart(kavaChain); err != nil {
-		k.Shutdown()
-		panic(err)
-	}
-	log.Println("kava is started!")
-
-	chains := NewChains()
-	chains.Register("kava", &kavaChain)
-	if k.config.IncludeIBC {
-		chains.Register("ibc", &ibcChain)
-	}
-	return chains
-}
-
-func (k *KavaNodeRunner) Shutdown() {
-	if k.config.SkipShutdown {
-		log.Printf("would shut down but SkipShutdown is true")
-		return
-	}
-	log.Println("shutting down kava node")
-	shutdownKavaCmd := exec.Command("kvtool", "testnet", "down")
-	shutdownKavaCmd.Stdout = os.Stdout
-	shutdownKavaCmd.Stderr = os.Stderr
-	if err := shutdownKavaCmd.Run(); err != nil {
-		panic(fmt.Sprintf("failed to shutdown kvtool: %s", err.Error()))
-	}
 }
 
 func waitForChainStart(chainDetails ChainDetails) error {

--- a/tests/e2e/testutil/chain.go
+++ b/tests/e2e/testutil/chain.go
@@ -69,8 +69,7 @@ func NewChain(t *testing.T, details *runner.ChainDetails, fundedAccountMnemonic 
 	}
 	chain.EncodingConfig = app.MakeEncodingConfig()
 
-	grpcUrl := fmt.Sprintf("http://localhost:%s", details.GrpcPort)
-	grpcConn, err := util.NewGrpcConnection(grpcUrl)
+	grpcConn, err := details.GrpcConn()
 	if err != nil {
 		return chain, err
 	}

--- a/tests/e2e/testutil/chain.go
+++ b/tests/e2e/testutil/chain.go
@@ -75,8 +75,7 @@ func NewChain(t *testing.T, details *runner.ChainDetails, fundedAccountMnemonic 
 		return chain, err
 	}
 
-	evmRpcUrl := fmt.Sprintf("http://localhost:%s", details.EvmPort)
-	chain.EvmClient, err = ethclient.Dial(evmRpcUrl)
+	chain.EvmClient, err = details.EvmClient()
 	if err != nil {
 		return chain, err
 	}

--- a/tests/e2e/testutil/suite.go
+++ b/tests/e2e/testutil/suite.go
@@ -48,7 +48,7 @@ func (suite *E2eTestSuite) SetupSuite() {
 	if suiteConfig.Kvtool != nil {
 		suite.UpgradeHeight = suiteConfig.Kvtool.KavaUpgradeHeight
 
-		runnerConfig := runner.Config{
+		runnerConfig := runner.KvtoolRunnerConfig{
 			KavaConfigTemplate: suiteConfig.Kvtool.KavaConfigTemplate,
 
 			IncludeIBC: suiteConfig.IncludeIbcTests,

--- a/tests/e2e/testutil/suite.go
+++ b/tests/e2e/testutil/suite.go
@@ -61,7 +61,7 @@ func (suite *E2eTestSuite) SetupSuite() {
 
 			SkipShutdown: suiteConfig.SkipShutdown,
 		}
-		suite.runner = runner.NewKavaNode(runnerConfig)
+		suite.runner = runner.NewKvtoolRunner(runnerConfig)
 	}
 
 	chains := suite.runner.StartChains()

--- a/tests/e2e/testutil/suite.go
+++ b/tests/e2e/testutil/suite.go
@@ -43,23 +43,26 @@ func (suite *E2eTestSuite) SetupSuite() {
 
 	suiteConfig := ParseSuiteConfig()
 	suite.config = suiteConfig
-	suite.UpgradeHeight = suiteConfig.KavaUpgradeHeight
 	suite.DeployedErc20Address = common.HexToAddress(suiteConfig.KavaErc20Address)
 
-	runnerConfig := runner.Config{
-		KavaConfigTemplate: suiteConfig.KavaConfigTemplate,
+	if suiteConfig.Kvtool != nil {
+		suite.UpgradeHeight = suiteConfig.Kvtool.KavaUpgradeHeight
 
-		IncludeIBC: suiteConfig.IncludeIbcTests,
-		ImageTag:   "local",
+		runnerConfig := runner.Config{
+			KavaConfigTemplate: suiteConfig.Kvtool.KavaConfigTemplate,
 
-		EnableAutomatedUpgrade:  suiteConfig.IncludeAutomatedUpgrade,
-		KavaUpgradeName:         suiteConfig.KavaUpgradeName,
-		KavaUpgradeHeight:       suiteConfig.KavaUpgradeHeight,
-		KavaUpgradeBaseImageTag: suiteConfig.KavaUpgradeBaseImageTag,
+			IncludeIBC: suiteConfig.IncludeIbcTests,
+			ImageTag:   "local",
 
-		SkipShutdown: suiteConfig.SkipShutdown,
+			EnableAutomatedUpgrade:  suiteConfig.Kvtool.IncludeAutomatedUpgrade,
+			KavaUpgradeName:         suiteConfig.Kvtool.KavaUpgradeName,
+			KavaUpgradeHeight:       suiteConfig.Kvtool.KavaUpgradeHeight,
+			KavaUpgradeBaseImageTag: suiteConfig.Kvtool.KavaUpgradeBaseImageTag,
+
+			SkipShutdown: suiteConfig.SkipShutdown,
+		}
+		suite.runner = runner.NewKavaNode(runnerConfig)
 	}
-	suite.runner = runner.NewKavaNode(runnerConfig)
 
 	chains := suite.runner.StartChains()
 	kavachain := chains.MustGetChain("kava")
@@ -99,7 +102,7 @@ func (suite *E2eTestSuite) SkipIfIbcDisabled() {
 }
 
 func (suite *E2eTestSuite) SkipIfUpgradeDisabled() {
-	if !suite.config.IncludeAutomatedUpgrade {
+	if suite.config.Kvtool != nil && suite.config.Kvtool.IncludeAutomatedUpgrade {
 		suite.T().SkipNow()
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR refactors the e2e framework in anticipation of adding support for running the e2e suite against live networks.
There are no functional changes. The `KavaNodeRunner` has been refactored and renamed to `KvtoolRunner`. The setup of this node runner is dictated by a new `E2E_RUN_KVTOOL_NETWORKS` env variable.

An implementation of a new `NodeRunner` that connects to live networks to come in a separate PR.

## Checklist
 - [x] ~~Changelog has been updated as necessary.~~
