### PR TITLE
Dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:  
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This PR enables dependabot to automatically check for updates to github actions and go modules.

Reasoning: a few go modules and github actions were out of date and this will be much faster than writing manual PR's for them. 
