### PR TITLE
fix(evmutil): create module account on InitGenesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+- (evmutil) [#1655] Initialize x/evmutil module account in InitGenesis
+
+## [v0.24.0]
+
 ### Features
 - (evmutil) [#1590] & [#1596] Add allow list param of sdk native denoms that can be transferred to evm
 - (evmutil) [#1591] & [#1596] Configure module to support deploying ERC20KavaWrappedCosmosCoin contracts
@@ -268,6 +273,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1655]: https://github.com/Kava-Labs/kava/pull/1655
 [#1624]: https://github.com/Kava-Labs/kava/pull/1624
 [#1622]: https://github.com/Kava-Labs/kava/pull/1622
 [#1614]: https://github.com/Kava-Labs/kava/pull/1614
@@ -307,7 +313,8 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 [#750]: https://github.com/Kava-Labs/kava/pull/750
 [#751]: https://github.com/Kava-Labs/kava/pull/751
 [#780]: https://github.com/Kava-Labs/kava/pull/780
-[unreleased]: https://github.com/Kava-Labs/kava/compare/v0.23.2...HEAD
+[unreleased]: https://github.com/Kava-Labs/kava/compare/v0.24.0...HEAD
+[v0.24.0]: https://github.com/Kava-Labs/kava/compare/v0.24.0...v0.23.2
 [v0.23.2]: https://github.com/Kava-Labs/kava/compare/v0.23.1...v0.23.2
 [v0.23.1]: https://github.com/Kava-Labs/kava/compare/v0.23.0...v0.23.1
 [v0.23.0]: https://github.com/Kava-Labs/kava/compare/v0.21.1...v0.23.0

--- a/app/app.go
+++ b/app/app.go
@@ -782,7 +782,7 @@ func NewApp(
 		hard.NewAppModule(app.hardKeeper, app.accountKeeper, app.bankKeeper, app.pricefeedKeeper),
 		committee.NewAppModule(app.committeeKeeper, app.accountKeeper),
 		incentive.NewAppModule(app.incentiveKeeper, app.accountKeeper, app.bankKeeper, app.cdpKeeper),
-		evmutil.NewAppModule(app.evmutilKeeper, app.bankKeeper),
+		evmutil.NewAppModule(app.evmutilKeeper, app.bankKeeper, app.accountKeeper),
 		savings.NewAppModule(app.savingsKeeper, app.accountKeeper, app.bankKeeper),
 		liquid.NewAppModule(app.liquidKeeper),
 		earn.NewAppModule(app.earnKeeper, app.accountKeeper, app.bankKeeper),

--- a/x/evmutil/client/cli/tx.go
+++ b/x/evmutil/client/cli/tx.go
@@ -100,6 +100,7 @@ func getCmdConvertEvmERC20ToCoin() *cobra.Command {
 			}
 
 			signer := clientCtx.GetFromAddress()
+			fmt.Println("signer: ", signer.String())
 			initiator, err := ParseAddrFromHexOrBech32(signer.String())
 			if err != nil {
 				return err
@@ -118,6 +119,8 @@ func getCmdConvertEvmERC20ToCoin() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
+
+			fmt.Printf("%+v\n", msg)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},

--- a/x/evmutil/client/cli/tx.go
+++ b/x/evmutil/client/cli/tx.go
@@ -100,7 +100,6 @@ func getCmdConvertEvmERC20ToCoin() *cobra.Command {
 			}
 
 			signer := clientCtx.GetFromAddress()
-			fmt.Println("signer: ", signer.String())
 			initiator, err := ParseAddrFromHexOrBech32(signer.String())
 			if err != nil {
 				return err
@@ -119,8 +118,6 @@ func getCmdConvertEvmERC20ToCoin() *cobra.Command {
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
-
-			fmt.Printf("%+v\n", msg)
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 		},

--- a/x/evmutil/genesis.go
+++ b/x/evmutil/genesis.go
@@ -10,12 +10,17 @@ import (
 )
 
 // InitGenesis initializes the store state from a genesis state.
-func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, gs *types.GenesisState) {
+func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, gs *types.GenesisState, ak types.AccountKeeper) {
 	if err := gs.Validate(); err != nil {
 		panic(fmt.Sprintf("failed to validate %s genesis state: %s", types.ModuleName, err))
 	}
 
 	keeper.SetParams(ctx, gs.Params)
+
+	// initialize module account
+	if moduleAcc := ak.GetModuleAccount(ctx, types.ModuleName); moduleAcc == nil {
+		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
+	}
 
 	for _, account := range gs.Accounts {
 		keeper.SetAccount(ctx, account)

--- a/x/evmutil/keeper/conversion_evm_native.go
+++ b/x/evmutil/keeper/conversion_evm_native.go
@@ -184,7 +184,7 @@ func (k Keeper) LockERC20Tokens(
 	contractAddr := pair.GetAddress()
 	initiatorStartBal, err := k.QueryERC20BalanceOf(ctx, contractAddr, initiator)
 	if err != nil {
-		return errorsmod.Wrapf(types.ErrEVMCall, "failed to retrieve balance %s", err.Error())
+		return errorsmod.Wrapf(types.ErrEVMCall, "failed to retrieve balance: %s", err.Error())
 	}
 
 	res, err := k.CallEVM(

--- a/x/evmutil/keeper/conversion_evm_native_test.go
+++ b/x/evmutil/keeper/conversion_evm_native_test.go
@@ -345,7 +345,7 @@ func (suite *ConversionTestSuite) TestConvertERC20ToCoin_EmptyContract() {
 		convertAmt,
 	)
 	suite.Require().Error(err)
-	suite.Require().ErrorContains(err, "contract call failed: method 'balanceOf'")
+	suite.Require().ErrorContains(err, "failed to retrieve balance: failed to unpack method balanceOf")
 
 	// bank balance should not change
 	bal := suite.App.GetBankKeeper().GetBalance(suite.Ctx, userAddr, pair.Denom)

--- a/x/evmutil/keeper/erc20.go
+++ b/x/evmutil/keeper/erc20.go
@@ -236,6 +236,10 @@ func unpackERC20ResToBigInt(res *evmtypes.MsgEthereumTxResponse, methodName stri
 		return nil, status.Error(codes.Internal, res.VmError)
 	}
 
+	if len(res.Ret) == 0 {
+		return nil, fmt.Errorf("failed to unpack method %s: expected response to be big.Int but found nil", methodName)
+	}
+
 	anyOutput, err := types.ERC20MintableBurnableContract.ABI.Unpack(methodName, res.Ret)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/x/evmutil/module.go
+++ b/x/evmutil/module.go
@@ -95,15 +95,17 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper     keeper.Keeper
-	bankKeeper types.BankKeeper
+	keeper       keeper.Keeper
+	accountKeeer types.AccountKeeper
+	bankKeeper   types.BankKeeper
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(keeper keeper.Keeper, bankKeeper types.BankKeeper) AppModule {
+func NewAppModule(keeper keeper.Keeper, bankKeeper types.BankKeeper, accountKeeper types.AccountKeeper) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(),
 		keeper:         keeper,
+		accountKeeer:   accountKeeper,
 		bankKeeper:     bankKeeper,
 	}
 }
@@ -146,7 +148,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 	// Initialize global index to index in genesis state
 	cdc.MustUnmarshalJSON(gs, &genState)
 
-	InitGenesis(ctx, am.keeper, &genState)
+	InitGenesis(ctx, am.keeper, &genState, am.accountKeeer)
 	return []abci.ValidatorUpdate{}
 }
 

--- a/x/evmutil/types/expected_keepers.go
+++ b/x/evmutil/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
@@ -11,6 +12,7 @@ import (
 
 // AccountKeeper defines the expected account keeper interface
 type AccountKeeper interface {
+	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI
 	GetModuleAddress(moduleName string) sdk.AccAddress
 	GetSequence(sdk.Context, sdk.AccAddress) (uint64, error)
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
ensures the creation of the x/evmutil module account on init genesis.

this is non-state breaking because mainnet will never call init genesis. additionally, the module account already exists on mainnet.

## Checklist
 - [x] Changelog has been updated as necessary.
