### PR TITLE
chore: allow override of go binary in Makefile

### DIFF
--- a/build/deps.mk
+++ b/build/deps.mk
@@ -27,10 +27,11 @@ DIRS := $(BUILD_CACHE_DIR) $(BIN_DIR)
 ################################################################################
 ###                             Tool Versions                                ###
 ################################################################################
+GO_BIN ?= go
 PROTOC_VERSION ?= v21.9
 BUF_VERSION ?= v1.9.0
 PROTOC_GEN_GOCOSMOS_VERSION ?= v0.3.1
-PROTOC_GEN_GRPC_GATEWAY_VERSION ?= $(shell go list -m github.com/grpc-ecosystem/grpc-gateway| sed 's:.* ::')
+PROTOC_GEN_GRPC_GATEWAY_VERSION ?= $(shell $(GO_BIN) list -m github.com/grpc-ecosystem/grpc-gateway| sed 's:.* ::')
 PROTOC_GEN_DOC_VERSION ?= v1.5.1
 SWAGGER_COMBINE_VERSION ?= v1.4.0
 
@@ -115,7 +116,7 @@ $(PROTOC_GEN_GOCOSMOS_VERSION_FILE):
 	git clone -q https://github.com/regen-network/cosmos-proto.git; \
 	cd cosmos-proto; \
 	git checkout -q $(PROTOC_GEN_GOCOSMOS_VERSION); \
-	GOBIN=$(ROOT_DIR)/$(BIN_DIR) go install ./protoc-gen-gocosmos
+	GOBIN=$(ROOT_DIR)/$(BIN_DIR) $(GO_BIN) install ./protoc-gen-gocosmos
 	@rm -rf $(BUILD_CACHE_DIR)/protoc-gen-gocosmos
 
 PROTOC_GEN_GOCOSMOS := $(BIN_DIR)/protoc-gen-gocosmos
@@ -138,8 +139,8 @@ $(PROTOC_GEN_GRPC_GATEWAY_VERSION_FILE):
 	git clone -q https://github.com/grpc-ecosystem/grpc-gateway.git; \
 	cd grpc-gateway; \
 	git checkout -q $(PROTOC_GEN_GRPC_GATEWAY_VERSION); \
-	GOBIN=$(ROOT_DIR)/$(BIN_DIR) go install ./protoc-gen-grpc-gateway; \
-	GOBIN=$(ROOT_DIR)/$(BIN_DIR) go install ./protoc-gen-swagger
+	GOBIN=$(ROOT_DIR)/$(BIN_DIR) $(GO_BIN) install ./protoc-gen-grpc-gateway; \
+	GOBIN=$(ROOT_DIR)/$(BIN_DIR) $(GO_BIN) install ./protoc-gen-swagger
 	@rm -rf $(BUILD_CACHE_DIR)/protoc-gen-grpc-gateway
 
 PROTOC_GEN_GRPC_GATEWAY := $(BIN_DIR)/protoc-gen-grpc-gateway

--- a/build/proto-deps.mk
+++ b/build/proto-deps.mk
@@ -1,4 +1,5 @@
 RSYNC_BIN ?= rsync
+GO_BIN ?= go
 
 #
 # Versioning for google protobuf dependencies (any, http, etc) and
@@ -13,12 +14,12 @@ PROTOBUF_ANY_DOWNLOAD_URL = https://raw.githubusercontent.com/protocolbuffers/pr
 #
 # Proto dependencies under go.mod
 #
-GOGO_PATH := $(shell go list -m -f '{{.Dir}}' github.com/gogo/protobuf)
-TENDERMINT_PATH := $(shell go list -m -f '{{.Dir}}' github.com/tendermint/tendermint)
-COSMOS_PROTO_PATH := $(shell go list -m -f '{{.Dir}}' github.com/cosmos/cosmos-proto)
-COSMOS_SDK_PATH := $(shell go list -m -f '{{.Dir}}' github.com/cosmos/cosmos-sdk)
-IBC_GO_PATH := $(shell go list -m -f '{{.Dir}}' github.com/cosmos/ibc-go/v6)
-ETHERMINT_PATH := $(shell go list -m -f '{{.Dir}}' github.com/evmos/ethermint)
+GOGO_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/gogo/protobuf)
+TENDERMINT_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/tendermint/tendermint)
+COSMOS_PROTO_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/cosmos/cosmos-proto)
+COSMOS_SDK_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/cosmos/cosmos-sdk)
+IBC_GO_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/cosmos/ibc-go/v6)
+ETHERMINT_PATH := $(shell $(GO_BIN) list -m -f '{{.Dir}}' github.com/evmos/ethermint)
 
 #
 # Common target directories


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
updates all hardcoded references to `go` in the `Makefile` to allow overriding with an env variable `GO_BIN`. this can allow running `make` commands with different go binaries, like if you need to build with a different go version.

i expect to backport this to all `kava_2222-10` release branches (v0.17, v0.18, v0.19, v0.21, v0.23, v0.24)

## Checklist
 - [x] Changelog has been updated as necessary.
