### PR TITLE
Update rocksdb version in ci-master workflow

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -31,7 +31,7 @@ jobs:
       - name: build rocksdb dependency
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/install-rocksdb.sh
         env:
-          ROCKSDB_VERSION: v7.10.2
+          ROCKSDB_VERSION: v8.1.1
       - name: Build and upload release artifacts
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/publish-internal-release-artifacts.sh
         env:


### PR DESCRIPTION
Noticed that CI fails on master on `Build and upload release artifacts` step: https://github.com/Kava-Labs/kava/actions/runs/5940863336/job/16110845695