### PR TITLE
feat(metrics): add timing metrics to abci methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 - (metrics) [#1668] Adds non-state breaking x/metrics module for custom telemetry.
+- (metrics) [#1669] Add performance timing metrics to all Begin/EndBlockers
 
 ### Bug Fixes
 - (evmutil) [#1655] Initialize x/evmutil module account in InitGenesis
@@ -280,6 +281,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
   large-scale simulations remotely using aws-batch
 
 [#1668]: https://github.com/Kava-Labs/kava/pull/1668
+[#1669]: https://github.com/Kava-Labs/kava/pull/1669
 [#1655]: https://github.com/Kava-Labs/kava/pull/1655
 [#1624]: https://github.com/Kava-Labs/kava/pull/1624
 [#1631]: https://github.com/Kava-Labs/kava/pull/1631

--- a/x/auction/abci.go
+++ b/x/auction/abci.go
@@ -2,7 +2,9 @@ package auction
 
 import (
 	"errors"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/x/auction/keeper"
@@ -12,6 +14,8 @@ import (
 // BeginBlocker closes all expired auctions at the end of each block. It panics if
 // there's an error other than ErrAuctionNotFound.
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	err := k.CloseExpiredAuctions(ctx)
 	if err != nil && !errors.Is(err, types.ErrAuctionNotFound) {
 		panic(err)

--- a/x/bep3/abci.go
+++ b/x/bep3/abci.go
@@ -1,13 +1,19 @@
 package bep3
 
 import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/x/bep3/keeper"
+	"github.com/kava-labs/kava/x/bep3/types"
 )
 
 // BeginBlocker on every block expires outdated atomic swaps and removes closed
 // swap from long term storage (default storage time of 1 week)
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	k.UpdateTimeBasedSupplyLimits(ctx)
 	k.UpdateExpiredAtomicSwaps(ctx)
 	k.DeleteClosedAtomicSwapsFromLongtermStorage(ctx)

--- a/x/cdp/abci.go
+++ b/x/cdp/abci.go
@@ -2,17 +2,22 @@ package cdp
 
 import (
 	"errors"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/kava-labs/kava/x/cdp/keeper"
+	"github.com/kava-labs/kava/x/cdp/types"
 	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 )
 
 // BeginBlocker compounds the debt in outstanding cdps and liquidates cdps that are below the required collateralization ratio
 func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	params := k.GetParams(ctx)
 
 	for _, cp := range params.CollateralParams {

--- a/x/committee/abci.go
+++ b/x/committee/abci.go
@@ -1,14 +1,20 @@
 package committee
 
 import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/kava-labs/kava/x/committee/keeper"
+	"github.com/kava-labs/kava/x/committee/types"
 )
 
 // BeginBlocker runs at the start of every block.
 func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	k.ProcessProposals(ctx)
 }

--- a/x/hard/abci.go
+++ b/x/hard/abci.go
@@ -1,11 +1,17 @@
 package hard
 
 import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/x/hard/keeper"
+	"github.com/kava-labs/kava/x/hard/types"
 )
 
 // BeginBlocker updates interest rates
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	k.ApplyInterestRateUpdates(ctx)
 }

--- a/x/incentive/abci.go
+++ b/x/incentive/abci.go
@@ -2,14 +2,19 @@ package incentive
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/x/incentive/keeper"
+	"github.com/kava-labs/kava/x/incentive/types"
 )
 
 // BeginBlocker runs at the start of every block
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	params := k.GetParams(ctx)
 
 	for _, rp := range params.USDXMintingRewardPeriods {

--- a/x/issuance/abci.go
+++ b/x/issuance/abci.go
@@ -1,12 +1,18 @@
 package issuance
 
 import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/x/issuance/keeper"
+	"github.com/kava-labs/kava/x/issuance/types"
 )
 
 // BeginBlocker iterates over each asset and seizes coins from blocked addresses by returning them to the asset owner
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	err := k.SeizeCoinsForBlockableAssets(ctx)
 	if err != nil {
 		panic(err)

--- a/x/kavadist/abci.go
+++ b/x/kavadist/abci.go
@@ -1,12 +1,18 @@
 package kavadist
 
 import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/kava-labs/kava/x/kavadist/keeper"
+	"github.com/kava-labs/kava/x/kavadist/types"
 )
 
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	err := k.MintPeriodInflation(ctx)
 	if err != nil {
 		panic(err)

--- a/x/pricefeed/abci.go
+++ b/x/pricefeed/abci.go
@@ -2,7 +2,9 @@ package pricefeed
 
 import (
 	"errors"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/x/pricefeed/keeper"
 	"github.com/kava-labs/kava/x/pricefeed/types"
@@ -10,6 +12,8 @@ import (
 
 // EndBlocker updates the current pricefeed
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
+
 	// Update the current price of each asset.
 	for _, market := range k.GetMarkets(ctx) {
 		if !market.Active {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Adds timing metrics to all Begin & End Blockers. When telemetry is enabled, the chain will now broadcast metrics that track how long each Begin/EndBlocker takes for each module. This matches how cosmos-sdk times their modules and allows higher fidelity in tracking performance of the chain.

## Checklist
 - [x] Changelog has been updated as necessary.
