### PR TITLE
unregister x/metrics & call BeginBlocker directly

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -196,7 +196,6 @@ var (
 		validatorvesting.AppModuleBasic{},
 		evmutil.AppModuleBasic{},
 		bridge.AppModuleBasic{},
-		metrics.AppModuleBasic{},
 	)
 
 	// module account permissions
@@ -307,6 +306,12 @@ type App struct {
 
 	// configurator
 	configurator module.Configurator
+
+	// backported x/metrics Metrics
+	// to prevent AppHash mismatch, the module is not registered to the module manager.
+	// instead, the module's BeginBlocker is called directly.
+	// this way, its consensus version has no bearing on the ModuleVersionMap included in the AppHash.
+	metrics *metricstypes.Metrics
 }
 
 func init() {
@@ -360,6 +365,7 @@ func NewApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
+		metrics:           metricstypes.NewMetrics(options.TelemetryOptions),
 	}
 
 	// init params keeper and subspaces
@@ -701,12 +707,10 @@ func NewApp(
 		evmutil.NewAppModule(app.evmutilKeeper, app.bankKeeper),
 		savings.NewAppModule(app.savingsKeeper, app.accountKeeper, app.bankKeeper),
 		bridge.NewAppModule(app.bridgeKeeper, app.accountKeeper),
-		metrics.NewAppModule(options.TelemetryOptions),
 	)
 
 	// Warning: Some begin blockers must run before others. Ensure the dependencies are understood before modifying this list.
 	app.mm.SetOrderBeginBlockers(
-		metricstypes.ModuleName,
 		// Upgrade begin blocker runs migrations on the first block after an upgrade. It should run before any other module.
 		upgradetypes.ModuleName,
 		// Capability begin blocker runs non state changing initialization.
@@ -789,7 +793,6 @@ func NewApp(
 		evmutiltypes.ModuleName,
 		savingstypes.ModuleName,
 		bridgetypes.ModuleName,
-		metricstypes.ModuleName,
 	)
 
 	// Warning: Some init genesis methods must run before others. Ensure the dependencies are understood before modifying this list
@@ -828,7 +831,6 @@ func NewApp(
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		validatorvestingtypes.ModuleName,
-		metricstypes.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)
@@ -913,6 +915,10 @@ func NewApp(
 
 // BeginBlocker contains app specific logic for the BeginBlock abci call.
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	// call the metrics BeginBlocker directly instead of registering the module to the module manager.
+	// all consensus versions of modules registrered to the moduel manager contribute to the AppHash.
+	// to prevent the backport of x/metrics from being consensus breaking, it is called directly.
+	metrics.BeginBlocker(ctx, app.metrics)
 	return app.mm.BeginBlock(ctx, req)
 }
 


### PR DESCRIPTION
registering x/metrics to the module manager breaks the AppHash because its consensus version is added to the ModuleVersionMap which affects the AppHash.

this commit unregisters the module so it is not consensus breaking. instead, it directly calls the BeginBlock before running the module manager's.

(backport of #1686 to v0.18)