### PR TITLE
unregister x/metrics & call BeginBlocker directly

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -218,7 +218,6 @@ var (
 		router.AppModuleBasic{},
 		mint.AppModuleBasic{},
 		community.AppModuleBasic{},
-		metrics.AppModuleBasic{},
 	)
 
 	// module account permissions
@@ -334,6 +333,12 @@ type App struct {
 
 	// configurator
 	configurator module.Configurator
+
+	// backported x/metrics Metrics
+	// to prevent AppHash mismatch, the module is not registered to the module manager.
+	// instead, the module's BeginBlocker is called directly.
+	// this way, its consensus version has no bearing on the ModuleVersionMap included in the AppHash.
+	metrics *metricstypes.Metrics
 }
 
 func init() {
@@ -387,6 +392,7 @@ func NewApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
+		metrics:           metricstypes.NewMetrics(options.TelemetryOptions),
 	}
 
 	// init params keeper and subspaces
@@ -794,12 +800,10 @@ func NewApp(
 		// nil InflationCalculationFn, use SDK's default inflation function
 		mint.NewAppModule(appCodec, app.mintKeeper, app.accountKeeper, nil),
 		community.NewAppModule(app.communityKeeper, app.accountKeeper),
-		metrics.NewAppModule(options.TelemetryOptions),
 	)
 
 	// Warning: Some begin blockers must run before others. Ensure the dependencies are understood before modifying this list.
 	app.mm.SetOrderBeginBlockers(
-		metricstypes.ModuleName,
 		// Upgrade begin blocker runs migrations on the first block after an upgrade. It should run before any other module.
 		upgradetypes.ModuleName,
 		// Capability begin blocker runs non state changing initialization.
@@ -888,7 +892,6 @@ func NewApp(
 		routertypes.ModuleName,
 		minttypes.ModuleName,
 		communitytypes.ModuleName,
-		metricstypes.ModuleName,
 	)
 
 	// Warning: Some init genesis methods must run before others. Ensure the dependencies are understood before modifying this list
@@ -930,7 +933,6 @@ func NewApp(
 		validatorvestingtypes.ModuleName,
 		liquidtypes.ModuleName,
 		routertypes.ModuleName,
-		metricstypes.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)
@@ -1018,6 +1020,10 @@ func (app *App) RegisterServices(cfg module.Configurator) {
 
 // BeginBlocker contains app specific logic for the BeginBlock abci call.
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	// call the metrics BeginBlocker directly instead of registering the module to the module manager.
+	// all consensus versions of modules registrered to the moduel manager contribute to the AppHash.
+	// to prevent the backport of x/metrics from being consensus breaking, it is called directly.
+	metrics.BeginBlocker(ctx, app.metrics)
 	return app.mm.BeginBlock(ctx, req)
 }
 


### PR DESCRIPTION
registering x/metrics to the module manager breaks the AppHash because its consensus version is added to the ModuleVersionMap which affects the AppHash.

this commit unregisters the module so it is not consensus breaking. instead, it directly calls the BeginBlock before running the module manager's.

(backport of https://github.com/Kava-Labs/kava/pull/1686)
