### PR TITLE
Update e2e tests for better live network test support

### DIFF
--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -1,22 +1,38 @@
-# E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC is for a funded account used to initialize all new testing accounts.
+# E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC is for a funded account used to intialize all new testing accounts.
 # Should be funded with KAVA and have an ERC20 balance
-E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='rookie collect tomato door disease champion drum jazz episode critic city giant regular guitar pass estate just obscure inch solid door boy bacon entire'
+E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe nose dream glance cave turtle electric fabric jacket shaft easy myself genuine this sibling pulse word unfold'
 
-E2E_KAVA_UPGRADE_HEIGHT=6857732
+# E2E_RUN_KVTOOL_NETWORKS is the only currently supported option.
+# It triggers tests to be run against local networks spun up with kvtool.
+E2E_RUN_KVTOOL_NETWORKS=true
 
-# E2E_RUN_KVTOOL_NETWORKS must be false to trigger run on live network
-E2E_RUN_KVTOOL_NETWORKS=false
+# E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
+# Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
+E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
 
-# Configure the endpoints for connecting to the running network here.
-E2E_KAVA_RPC_URL='https://rpc.mirrornet.production.kava.io:443'
-E2E_KAVA_GRPC_URL='https://grpc.mirrornet.production.kava.io:443'
-E2E_KAVA_EVM_RPC_URL='https://evm.mirrornet.production.kava.io:443'
-
-# E2E_INCLUDE_IBC_TESTS is not currently supported for running tests against a live network.
+# E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
 E2E_INCLUDE_IBC_TESTS=false
 
-# E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token.
-# The E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC account must have a balance.
-# The ERC20 must be enabled via x/evmutil params for conversion to sdk.Coin.
-# The corresponding sdk.Coin must be a supported vault in x/earn.
-E2E_KAVA_ERC20_ADDRESS=0x919c1c267bc06a7039e03fcc2ef738525769109c
+# E2E_SKIP_SHUTDOWN when true will keep the networks running after tests complete (pass or fail)
+# This is useful for debugging chain state when writing tests.
+E2E_SKIP_SHUTDOWN=false
+
+# The following variables should be defined to run an upgrade.
+# E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
+E2E_INCLUDE_AUTOMATED_UPGRADE=true
+# E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
+E2E_KAVA_UPGRADE_NAME=v0.25.0-testing
+# E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.
+# If IBC tests are enabled this should be >30. Otherwise, this should be >10.
+E2E_KAVA_UPGRADE_HEIGHT=15
+# E2E_KAVA_UPGRADE_BASE_IMAGE_TAG is the tag of the docker image the chain should upgrade from.
+E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=v0.24.0
+
+# E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token with the following properties:
+# - the E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC has nonzero balance
+# - the ERC20 must be enabled via x/evmutil params for conversion to sdk.Coin
+# - the corresponsing sdk.Coin must be supported as a cdp collateral type (w/ valid pricefeed)
+# - the evmutil params must support conversion & deposits to mint in eip712 messages
+#
+# These requirements are verified on test startup in ./testutil/init_evm.go
+E2E_KAVA_ERC20_ADDRESS=0xeA7100edA2f805356291B0E55DaD448599a72C6d

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -1,38 +1,22 @@
-# E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC is for a funded account used to intialize all new testing accounts.
+# E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC is for a funded account used to initialize all new testing accounts.
 # Should be funded with KAVA and have an ERC20 balance
-E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='tent fitness boat among census primary pipe nose dream glance cave turtle electric fabric jacket shaft easy myself genuine this sibling pulse word unfold'
+E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC='rookie collect tomato door disease champion drum jazz episode critic city giant regular guitar pass estate just obscure inch solid door boy bacon entire'
 
-# E2E_RUN_KVTOOL_NETWORKS is the only currently supported option.
-# It triggers tests to be run against local networks spun up with kvtool.
-E2E_RUN_KVTOOL_NETWORKS=true
+E2E_KAVA_UPGRADE_HEIGHT=6857732
 
-# E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
-# Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
-E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
+# E2E_RUN_KVTOOL_NETWORKS must be false to trigger run on live network
+E2E_RUN_KVTOOL_NETWORKS=false
 
-# E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
+# Configure the endpoints for connecting to the running network here.
+E2E_KAVA_RPC_URL='https://rpc.mirrornet.production.kava.io:443'
+E2E_KAVA_GRPC_URL='https://grpc.mirrornet.production.kava.io:443'
+E2E_KAVA_EVM_RPC_URL='https://evm.mirrornet.production.kava.io:443'
+
+# E2E_INCLUDE_IBC_TESTS is not currently supported for running tests against a live network.
 E2E_INCLUDE_IBC_TESTS=false
 
-# E2E_SKIP_SHUTDOWN when true will keep the networks running after tests complete (pass or fail)
-# This is useful for debugging chain state when writing tests.
-E2E_SKIP_SHUTDOWN=false
-
-# The following variables should be defined to run an upgrade.
-# E2E_INCLUDE_AUTOMATED_UPGRADE when true enables the automated upgrade & corresponding tests in the suite.
-E2E_INCLUDE_AUTOMATED_UPGRADE=true
-# E2E_KAVA_UPGRADE_NAME is the name of the upgrade that must be in the current local image.
-E2E_KAVA_UPGRADE_NAME=v0.25.0-testing
-# E2E_KAVA_UPGRADE_HEIGHT is the height at which the upgrade will be applied.
-# If IBC tests are enabled this should be >30. Otherwise, this should be >10.
-E2E_KAVA_UPGRADE_HEIGHT=15
-# E2E_KAVA_UPGRADE_BASE_IMAGE_TAG is the tag of the docker image the chain should upgrade from.
-E2E_KAVA_UPGRADE_BASE_IMAGE_TAG=v0.24.0
-
-# E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token with the following properties:
-# - the E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC has nonzero balance
-# - the ERC20 must be enabled via x/evmutil params for conversion to sdk.Coin
-# - the corresponsing sdk.Coin must be supported as a cdp collateral type (w/ valid pricefeed)
-# - the evmutil params must support conversion & deposits to mint in eip712 messages
-#
-# These requirements are verified on test startup in ./testutil/init_evm.go
-E2E_KAVA_ERC20_ADDRESS=0xeA7100edA2f805356291B0E55DaD448599a72C6d
+# E2E_KAVA_ERC20_ADDRESS is the address of a pre-deployed ERC20 token.
+# The E2E_KAVA_FUNDED_ACCOUNT_MNEMONIC account must have a balance.
+# The ERC20 must be enabled via x/evmutil params for conversion to sdk.Coin.
+# The corresponding sdk.Coin must be a supported vault in x/earn.
+E2E_KAVA_ERC20_ADDRESS=0x919c1c267bc06a7039e03fcc2ef738525769109c

--- a/tests/e2e/.env.live-network-example
+++ b/tests/e2e/.env.live-network-example
@@ -20,4 +20,5 @@ E2E_INCLUDE_IBC_TESTS=false
 # - the evmutil params must support conversion & deposits to mint in eip712 messages
 #
 # These requirements are verified on test startup in ./testutil/init_evm.go
-E2E_KAVA_ERC20_ADDRESS=0xeA7100edA2f805356291B0E55DaD448599a72C6d
+# This address is a USDT contract
+E2E_KAVA_ERC20_ADDRESS=0x919c1c267bc06a7039e03fcc2ef738525769109c

--- a/tests/e2e/e2e_convert_cosmos_coins_test.go
+++ b/tests/e2e/e2e_convert_cosmos_coins_test.go
@@ -394,7 +394,7 @@ func (suite *IntegrationTestSuite) TestConvertCosmosCoins_ERC20Magic() {
 		Data: "bob transfers alice's funds, allowed because he's approved",
 	}
 	res = bob.SignAndBroadcastEvmTx(transferJustRightTx)
-	suite.NoError(res.Err)
+	suite.Require().NoError(res.Err)
 
 	// alice should have amount deducted
 	erc20Balance := suite.Kava.GetErc20Balance(contractAddress.Address, alice.EvmAddress)

--- a/tests/e2e/e2e_convert_cosmos_coins_test.go
+++ b/tests/e2e/e2e_convert_cosmos_coins_test.go
@@ -198,8 +198,8 @@ func (suite *IntegrationTestSuite) TestEIP712ConvertCosmosCoinsToFromERC20() {
 	suite.NoError(err)
 	suite.Equal(sdkerrors.SuccessABCICode, res.TxResponse.Code)
 
-	_, err = util.WaitForSdkTxCommit(suite.Kava.Tx, res.TxResponse.TxHash, 6*time.Second)
-	suite.NoError(err)
+	_, err = util.WaitForSdkTxCommit(suite.Kava.Tx, res.TxResponse.TxHash, 12*time.Second)
+	suite.Require().NoError(err)
 
 	// query for the deployed contract
 	deployedContracts, err := suite.Kava.Evmutil.DeployedCosmosCoinContracts(

--- a/tests/e2e/e2e_min_fees_test.go
+++ b/tests/e2e/e2e_min_fees_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func (suite *IntegrationTestSuite) TestEthGasPriceReturnsMinFee() {
+	suite.SkipIfKvtoolDisabled()
+
 	// read expected min fee from app.toml
 	minGasPrices, err := getMinFeeFromAppToml(util.KavaHomePath())
 	suite.NoError(err)
@@ -32,6 +34,8 @@ func (suite *IntegrationTestSuite) TestEthGasPriceReturnsMinFee() {
 }
 
 func (suite *IntegrationTestSuite) TestEvmRespectsMinFee() {
+	suite.SkipIfKvtoolDisabled()
+
 	// setup sender & receiver
 	sender := suite.Kava.NewFundedAccount("evm-min-fee-test-sender", sdk.NewCoins(ukava(1e3)))
 	randoReceiver := util.SdkToEvmAddress(app.RandomAddress())

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -99,7 +99,7 @@ func (suite *IntegrationTestSuite) TestTransferOverEVM() {
 		Data: "any ol' data to track this through the system",
 	}
 	res := acc.SignAndBroadcastEvmTx(req)
-	suite.NoError(res.Err)
+	suite.Require().NoError(res.Err)
 	suite.Equal(ethtypes.ReceiptStatusSuccessful, res.Receipt.Status)
 
 	// evm txs refund unused gas. so to know the expected balance we need to know how much gas was used.

--- a/tests/e2e/e2e_upgrade_inflation_test.go
+++ b/tests/e2e/e2e_upgrade_inflation_test.go
@@ -372,6 +372,8 @@ func (suite *IntegrationTestSuite) TestUpgradeInflation_Disable() {
 
 	// Staking rewards can still be claimed
 	suite.Run("staking rewards claimable after switchover", func() {
+		suite.SkipIfKvtoolDisabled()
+
 		// Get the delegator of the only validator
 		validators, err := suite.Kava.Staking.Validators(
 			context.Background(),

--- a/tests/e2e/e2e_upgrade_inflation_test.go
+++ b/tests/e2e/e2e_upgrade_inflation_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func (suite *IntegrationTestSuite) TestUpgradeInflation_Disable() {
+	suite.SkipIfUpgradeDisabled()
+
 	afterUpgradeCtx := util.CtxAtHeight(suite.UpgradeHeight)
 
 	// Get x/community for switchover time

--- a/tests/e2e/readme.md
+++ b/tests/e2e/readme.md
@@ -27,12 +27,17 @@ The end-to-end tests support being run on a live network. The primary toggle for
 * `E2E_KAVA_RPC_URL`
 * `E2E_KAVA_GRPC_URL`
 * `E2E_KAVA_EVM_RPC_URL`
+* `E2E_KAVA_UPGRADE_HEIGHT` - the height at which an existing upgrade was run
 
 See an example environment configuration with full description of all supported configurations in [`.env.live-network-example`](./.env.live-network-example). This example expects a local kvtool network to be running: `kvtool testnet bootstrap`.
 
 When run against a live network, the suite will automatically return all the sdk funds sent to `SigningAccount`s on the chain, and will return any ERC20 balance from those accounts if the ERC20 is registered via `Chain.RegisterERC20`. The pre-deployed ERC20 that is required for the tests is registered on setup.
 
-At this time, live-network tests do not support `E2E_INCLUDE_IBC_TESTS=true` and they do not support automated upgrades.
+At this time, live-network tests do not support `E2E_INCLUDE_IBC_TESTS=true`.
+
+`E2E_KAVA_UPGRADE_HEIGHT` is supported for an existing upgrade height, and can
+be used to verify before / after upgrade state. This doesn't run automatically
+any upgrades.
 
 ## `Chain`s
 

--- a/tests/e2e/runner/live.go
+++ b/tests/e2e/runner/live.go
@@ -14,6 +14,8 @@ type LiveNodeRunnerConfig struct {
 	KavaRpcUrl    string
 	KavaGrpcUrl   string
 	KavaEvmRpcUrl string
+
+	UpgradeHeight int64
 }
 
 // LiveNodeRunner implements NodeRunner for an already-running chain.

--- a/tests/e2e/testutil/config.go
+++ b/tests/e2e/testutil/config.go
@@ -56,6 +56,8 @@ type LiveNetworkConfig struct {
 	KavaRpcUrl    string
 	KavaGrpcUrl   string
 	KavaEvmRpcUrl string
+
+	UpgradeHeight int64
 }
 
 // ParseSuiteConfig builds a SuiteConfig from environment variables.
@@ -107,11 +109,23 @@ func ParseKvtoolConfig() KvtoolConfig {
 
 // ParseLiveNetworkConfig builds a LiveNetworkConfig from environment variables.
 func ParseLiveNetworkConfig() LiveNetworkConfig {
-	return LiveNetworkConfig{
+	config := LiveNetworkConfig{
 		KavaRpcUrl:    nonemptyStringEnv("E2E_KAVA_RPC_URL"),
 		KavaGrpcUrl:   nonemptyStringEnv("E2E_KAVA_GRPC_URL"),
 		KavaEvmRpcUrl: nonemptyStringEnv("E2E_KAVA_EVM_RPC_URL"),
 	}
+
+	upgradeHeight := os.Getenv("E2E_KAVA_UPGRADE_HEIGHT")
+	if upgradeHeight != "" {
+		parsedHeight, err := strconv.ParseInt(upgradeHeight, 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("E2E_KAVA_UPGRADE_HEIGHT must be a number: %s", err))
+		}
+
+		config.UpgradeHeight = parsedHeight
+	}
+
+	return config
 }
 
 // mustParseBool is a helper method that panics if the env variable `name`

--- a/tests/e2e/testutil/init_evm.go
+++ b/tests/e2e/testutil/init_evm.go
@@ -20,7 +20,11 @@ func (suite *E2eTestSuite) InitKavaEvmData() {
 	// ensure funded account has nonzero erc20 balance
 	balance := suite.Kava.GetErc20Balance(suite.DeployedErc20.Address, whale.EvmAddress)
 	if balance.Cmp(big.NewInt(0)) != 1 {
-		panic(fmt.Sprintf("expected funded account (%s) to have erc20 balance", whale.EvmAddress.Hex()))
+		panic(fmt.Sprintf(
+			"expected funded account (%s) to have erc20 balance of token %s",
+			whale.EvmAddress.Hex(),
+			suite.DeployedErc20.Address.Hex(),
+		))
 	}
 
 	// expect the erc20 to be enabled for conversion to sdk.Coin

--- a/tests/e2e/testutil/suite.go
+++ b/tests/e2e/testutil/suite.go
@@ -193,12 +193,16 @@ func (suite *E2eTestSuite) SetupLiveNetworkNodeRunner() *runner.LiveNodeRunner {
 	if suite.config.IncludeIbcTests {
 		panic("ibc tests not supported for live network configuration")
 	}
+
+	// Manually set upgrade height for live networks
+	suite.UpgradeHeight = suite.config.LiveNetwork.UpgradeHeight
 	suite.enableRefunds = true
 
 	runnerConfig := runner.LiveNodeRunnerConfig{
 		KavaRpcUrl:    suite.config.LiveNetwork.KavaRpcUrl,
 		KavaGrpcUrl:   suite.config.LiveNetwork.KavaGrpcUrl,
 		KavaEvmRpcUrl: suite.config.LiveNetwork.KavaEvmRpcUrl,
+		UpgradeHeight: suite.config.LiveNetwork.UpgradeHeight,
 	}
 
 	return runner.NewLiveNodeRunner(runnerConfig)
@@ -217,6 +221,20 @@ func (suite *E2eTestSuite) SkipIfIbcDisabled() {
 // Note: automated upgrade tests are currently only enabled for Kvtool suite runs.
 func (suite *E2eTestSuite) SkipIfUpgradeDisabled() {
 	if suite.config.Kvtool != nil && !suite.config.Kvtool.IncludeAutomatedUpgrade {
+		fmt.Println("skipping upgrade test, kvtool automated upgrade is disabled")
+		suite.T().SkipNow()
+	}
+
+	// If there isn't a manual upgrade height set in the config, skip the test
+	if suite.config.LiveNetwork != nil && suite.config.LiveNetwork.UpgradeHeight == 0 {
+		fmt.Println("skipping upgrade test, live network upgrade height is not set")
+		suite.T().SkipNow()
+	}
+}
+
+// SkipIfKvtoolDisabled should be called at the start of tests that require kvtool.
+func (suite *E2eTestSuite) SkipIfKvtoolDisabled() {
+	if suite.config.Kvtool == nil {
 		suite.T().SkipNow()
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
- Auto skip some tests that require local kvtool
- Support specifying (non-automated) upgrade height to reference in tests
- Sprinkle in some `.Require()` calls to prevent even more errors when a critical parts in some tests fail

## Checklist
 - [ ] ~~Changelog has been updated as necessary.~~
