### PR TITLE
feat(community): disable x/distribution community tax in disable inflation upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-- (metrics) [#1668] Adds non-state breaking x/metrics module for custom telemetry.
+- (metrics) [#1668] Adds non-state breaking x/metrics module for custom telemetry
 - (metrics) [#1669] Add performance timing metrics to all Begin/EndBlockers
 - (community) [#1704] Add module params
 - (community) [#1706] Add disable inflation upgrade
@@ -52,8 +52,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (community) [#1704] Add param to control when inflation will be disabled
 - (community) [#1707] Default staking rewards per second set to `744191`
-- (community) [#1706] Add disable inflation upgrade to begin blocker that updates x/mint and x/kavadist params.
+- (community) [#1706] Add disable inflation upgrade to begin blocker that updates x/mint and x/kavadist params
 - (community) [#1729] Consolidate community funds from `x/distribution` and `x/kavadist` to `x/community`
+- (community) [#1752] Set `x/distribution` CommunityTax to zero on inflation disable upgrade
 
 ## [v0.24.0]
 
@@ -294,10 +295,12 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1752]: https://github.com/Kava-Labs/kava/pull/1752
 [#1729]: https://github.com/Kava-Labs/kava/pull/1729
 [#1745]: https://github.com/Kava-Labs/kava/pull/1745
 [#1707]: https://github.com/Kava-Labs/kava/pull/1707
 [#1706]: https://github.com/Kava-Labs/kava/pull/1706
+[#1704]: https://github.com/Kava-Labs/kava/pull/1704
 [#1668]: https://github.com/Kava-Labs/kava/pull/1668
 [#1669]: https://github.com/Kava-Labs/kava/pull/1669
 [#1655]: https://github.com/Kava-Labs/kava/pull/1655

--- a/x/community/keeper/disable_inflation.go
+++ b/x/community/keeper/disable_inflation.go
@@ -19,8 +19,14 @@ func (k Keeper) CheckAndDisableMintAndKavaDistInflation(ctx sdk.Context) {
 		return
 	}
 
+	logger := k.Logger(ctx)
+	logger.Info("disable inflation upgrade started")
+
 	// run disable inflation logic
 	k.disableInflation(ctx)
+	k.disableCommunityTax(ctx)
+
+	logger.Info("disable inflation upgrade finished successfully!")
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
@@ -43,7 +49,6 @@ func (k Keeper) CheckAndDisableMintAndKavaDistInflation(ctx sdk.Context) {
 // affecting rewards.  In addition, inflation periods in kavadist should be removed.
 func (k Keeper) disableInflation(ctx sdk.Context) {
 	logger := k.Logger(ctx)
-	logger.Info("disable inflation upgrade started")
 
 	// set x/min inflation to 0
 	mintParams := k.mintKeeper.GetParams(ctx)
@@ -57,6 +62,14 @@ func (k Keeper) disableInflation(ctx sdk.Context) {
 	kavadistParams.Active = false
 	k.kavadistKeeper.SetParams(ctx, kavadistParams)
 	logger.Info("x/kavadist inflation disabled")
+}
 
-	logger.Info("disable inflation upgrade finished successfully!")
+// disableCommunityTax sets x/distribution Params.CommunityTax to 0
+func (k Keeper) disableCommunityTax(ctx sdk.Context) {
+	logger := k.Logger(ctx)
+
+	distrParams := k.distrKeeper.GetParams(ctx)
+	distrParams.CommunityTax = sdk.ZeroDec()
+	k.distrKeeper.SetParams(ctx, distrParams)
+	logger.Info("x/distribution community tax set to 0")
 }

--- a/x/community/types/expected_keepers.go
+++ b/x/community/types/expected_keepers.go
@@ -43,6 +43,8 @@ type DistributionKeeper interface {
 	GetFeePoolCommunityCoins(ctx sdk.Context) sdk.DecCoins
 	GetFeePool(ctx sdk.Context) distrtypes.FeePool
 	SetFeePool(ctx sdk.Context, feePool distrtypes.FeePool)
+	GetParams(ctx sdk.Context) distrtypes.Params
+	SetParams(ctx sdk.Context, params distrtypes.Params)
 }
 
 type MintKeeper interface {


### PR DESCRIPTION
## Description
- Sets `x/community` params `CommunityTax` to zero at switchover/inflation disable time.

## Checklist
 - [x] Changelog has been updated as necessary.
