### PR TITLE
ci: update CI workflows and pipelines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,15 @@
 out/
 **/node_modules/
 .git/
-docs/
+.github/
 tests/
+
+ci/
 contracts/
+contrib/
+docs/
+networks/
+scratch/
 
 go.work
 go.work.sum

--- a/.github/scripts/install-rocksdb.sh
+++ b/.github/scripts/install-rocksdb.sh
@@ -7,9 +7,9 @@ sudo apt-get install -y libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4
 # get rocksdb sources
 git clone https://github.com/facebook/rocksdb.git /home/runner/rocksdb
 
-cd /home/runner/rocksdb
+cd /home/runner/rocksdb || exit 1
 
 git checkout "$ROCKSDB_VERSION"
 
 # install rocksdb locally
-sudo make -j $(nproc --all) install-shared
+sudo make -j "$(nproc --all)" install-shared && sudo ldconfig

--- a/.github/workflows/cd-reset-internal-testnet.yml
+++ b/.github/workflows/cd-reset-internal-testnet.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: take the chain offline
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
         env:
@@ -45,18 +45,16 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_KEY_SECRET }}
       - name: checkout infrastructure repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Kava-Labs/infrastructure
           token: ${{ secrets.KAVA_PRIVATE_GITHUB_ACCESS_TOKEN }}
           path: infrastructure
           ref: master
-      - name: set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build kava node updater
         run: cd infrastructure/cli/kava-node-updater && make install && cd ../../../
       - name: run reset playbook on all chain nodes

--- a/.github/workflows/cd-seed-chain.yml
+++ b/.github/workflows/cd-seed-chain.yml
@@ -32,25 +32,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-         ref: master
+          ref: master
       - name: checkout version of kava used by network
         run: |
           git pull -p
           git checkout $(cat ${KAVA_VERSION_FILEPATH})
         env:
-            KAVA_VERSION_FILEPATH: ${{ inputs.kava_version_filepath }}
+          KAVA_VERSION_FILEPATH: ${{ inputs.kava_version_filepath }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build kava binary
         run: make install
       - name: checkout go evm tools repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ethereum/go-ethereum
           path: go-ethereum
@@ -61,7 +59,7 @@ jobs:
           make devtools
         working-directory: go-ethereum
       - name: checkout kava bridge repo for deploying evm contracts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Kava-Labs/kava-bridge
           path: kava-bridge
@@ -82,7 +80,7 @@ jobs:
         run: wget https://raw.githubusercontent.com/Kava-Labs/kava/master/.github/scripts/${SEED_SCRIPT_FILENAME} && chmod +x ${SEED_SCRIPT_FILENAME}
         working-directory: kava-bridge/contract
         env:
-            SEED_SCRIPT_FILENAME: ${{ inputs.seed-script-filename }}
+          SEED_SCRIPT_FILENAME: ${{ inputs.seed-script-filename }}
       - name: run seed scripts
         run: bash ./${SEED_SCRIPT_FILENAME}
         working-directory: kava-bridge/contract

--- a/.github/workflows/cd-start-chain.yml
+++ b/.github/workflows/cd-start-chain.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: take the chain offline
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/put-all-chain-nodes-on-standby.sh
         env:
@@ -41,18 +41,16 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_KEY_SECRET }}
       - name: checkout infrastructure repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Kava-Labs/infrastructure
           token: ${{ secrets.KAVA_PRIVATE_GITHUB_ACCESS_TOKEN }}
           path: infrastructure
           ref: master
-      - name: set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build kava node updater
         run: cd infrastructure/cli/kava-node-updater && make install && cd ../../../
       - name: run start-chain playbook on all chain nodes

--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -7,28 +7,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            tests/e2e/kvtool/go.sum
       - name: build application
         run: make build
   test:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            tests/e2e/kvtool/go.sum
       - name: run unit tests
         run: make test
       - name: run e2e tests
@@ -37,13 +39,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: save version of kava that will be deployed if this pr is merged
         id: kava-version
         run: |
           echo "KAVA_VERSION=$(cat ./ci/env/kava-internal-testnet/KAVA.VERSION)" >> $GITHUB_OUTPUT
       - name: checkout repo from master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: checkout version of kava that will be deployed if this pr is merged
@@ -53,28 +55,24 @@ jobs:
         env:
           KAVA_VERSION: ${{ steps.kava-version.outputs.KAVA_VERSION }}
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build kava cli
         run: make install
       - name: checkout repo from current commit to validate current branch's genesis
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: validate testnet genesis
         run: kava validate-genesis ci/env/kava-internal-testnet/genesis.json
   validate-protonet-genesis:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build kava cli
         run: make install
       - name: validate protonet genesis

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -6,6 +6,14 @@ on:
       dockerhub-username:
         required: true
         type: string
+      # this workflow publishes a rocksdb & goleveldb docker images with these tags:
+      # - <commit-hash>-goleveldb
+      # - <extra-image-tag>-goleveldb
+      # - <commit-hash>-rocksdb
+      # - <extra-image-tag>-rocksdb
+      extra-image-tag:
+        required: true
+        type: string
     secrets:
       CI_DOCKERHUB_TOKEN:
         required: true
@@ -14,34 +22,81 @@ on:
 # you can use images built by this action in future jobs.
 # https://docs.docker.com/build/ci/github-actions/examples/#share-built-image-between-jobs
 jobs:
-  docker:
+  docker-goleveldb:
     # https://github.com/marketplace/actions/build-and-push-docker-images
     runs-on: ubuntu-latest
     steps:
       # ensure working with latest code
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       # generate a git commit hash to be used as image tag
       - name: Generate short hash
         id: commit-hash
         run: echo "short=$( git rev-parse --short $GITHUB_SHA )" >> $GITHUB_OUTPUT
+
       # qemu is used to emulate different platform architectures
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
+
       # cross-platform build of the image
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+
       # authenticate for publish to docker hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
       # publish to docker hub, tag with short git hash
-      - name: Build and push
-        uses: docker/build-push-action@v3
+      - name: Build and push (goleveldb)
+        uses: docker/build-push-action@v5
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: kava/kava:${{ steps.commit-hash.outputs.short }},kava/kava:master
+          tags: kava/kava:${{ steps.commit-hash.outputs.short }}-goleveldb,kava/kava:${{ inputs.extra-image-tag }}-goleveldb
+
+  docker-rocksdb:
+    # https://github.com/marketplace/actions/build-and-push-docker-images
+    runs-on: ubuntu-latest
+    steps:
+      # ensure working with latest code
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # generate a git commit hash to be used as image tag
+      - name: Generate short hash
+        id: commit-hash
+        run: echo "short=$( git rev-parse --short $GITHUB_SHA )" >> $GITHUB_OUTPUT
+
+      # qemu is used to emulate different platform architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # cross-platform build of the image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # authenticate for publish to docker hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.dockerhub-username }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      # publish to docker hub, tag with short git hash
+      - name: Build and push (rocksdb)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile-rocksdb
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: kava/kava:${{ steps.commit-hash.outputs.short }}-rocksdb,kava/kava:${{ inputs.extra-image-tag }}-rocksdb

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -8,7 +8,7 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -19,13 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: set build tag
         run: echo "BUILD_TAG=$(date +%s)-$(git rev-parse HEAD | cut -c 1-8)" >> $GITHUB_ENV
       - name: build rocksdb dependency
@@ -45,6 +43,7 @@ jobs:
     uses: ./.github/workflows/ci-docker.yml
     with:
       dockerhub-username: kavaops
+      extra-image-tag: master
     secrets: inherit
   post-pipeline-metrics:
     uses: ./.github/workflows/metric-pipeline.yml

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,35 @@
+name: Continuous Integration (Release)
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+jobs:
+  # run per commit ci checks against released version
+  lint-checks:
+    uses: ./.github/workflows/ci-lint.yml
+  # run default ci checks against released version
+  default-checks:
+    uses: ./.github/workflows/ci-default.yml
+
+  # get the version tag that triggered this workflow
+  get-version-tag:
+    # prep version release only if all checks pass
+    needs: [lint-checks, default-checks]
+    runs-on: ubuntu-latest
+    outputs:
+      git-tag: ${{ steps.git-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: git-tag
+        run: echo "tag=$(git describe --always --tags --match='v*')" >> $GITHUB_OUTPUT
+
+  # build and upload versions of kava for use on internal infrastructure
+  # configurations for databases, cpu architectures and operating systems
+  docker:
+    # only run if all checks pass
+    needs: get-version-tag
+    uses: ./.github/workflows/ci-docker.yml
+    with:
+      dockerhub-username: kavaops
+      extra-image-tag: ${{ needs.get-version-tag.outputs.git-tag }}
+    secrets: inherit

--- a/.github/workflows/ci-rocksdb-build.yml
+++ b/.github/workflows/ci-rocksdb-build.yml
@@ -10,13 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: build rocksdb dependency
         run: bash ${GITHUB_WORKSPACE}/.github/scripts/install-rocksdb.sh
       - name: build application
@@ -34,14 +32,12 @@ jobs:
           && sudo make -j$(nproc) install-shared
           && sudo ldconfig
       - name: checkout repo from current commit
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
+          go-version-file: go.mod
       - name: run unit tests
         run: make test-rocksdb

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -8,11 +8,11 @@ jobs:
     name: "Check Proto"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-          cache: true
       - run: go mod download
       - run: make install-build-deps
       - run: make check-proto-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,15 @@ RUN apk add bash git make libc-dev gcc linux-headers eudev-dev jq curl
 WORKDIR /root/kava
 # default home directory is /root
 
+# Copy dependency files first to facilitate dependency caching
+COPY ./go.mod ./
+COPY ./go.sum ./
+
+# Download dependencies
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go version && go mod download
+
 # Add source files
 COPY . .
 

--- a/Dockerfile-rocksdb
+++ b/Dockerfile-rocksdb
@@ -19,8 +19,18 @@ RUN git clone https://github.com/facebook/rocksdb.git \
     && make -j$(nproc) install-shared \
     && ldconfig
 
-# Add source files for kava
-COPY . kava
+WORKDIR /root/kava
+# Copy dependency files first to facilitate dependency caching
+COPY ./go.mod ./
+COPY ./go.sum ./
+
+# Download dependencies
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go version && go mod download
+
+# Add source files
+COPY . .
 
 ARG kava_database_backend=rocksdb
 ENV KAVA_DATABASE_BACKEND=$kava_database_backend
@@ -28,7 +38,7 @@ ENV KAVA_DATABASE_BACKEND=$kava_database_backend
 # Mount go build and mod caches as container caches, persisted between builder invocations
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    cd kava && make install COSMOS_BUILD_OPTIONS=$KAVA_DATABASE_BACKEND
+    make install COSMOS_BUILD_OPTIONS=$KAVA_DATABASE_BACKEND
 
 
 FROM ubuntu:22.04


### PR DESCRIPTION
* build & publish rocksdb docker images on merge to master
* publish docker images on push of release version tags

NOTE: New docker image tag pattern. ALL tags now include database suffix 
ex. \<githash\>-goleveldb, v0.25.0-alpha.1-rocksdb, master-rocksdb, etc

* update dockerfiles for better caching
* update all github action workflow versions
* improve caching of go packages
* cache docker image layers for reuse between runs
* update dockerignore to remove non-essential files
