### PR TITLE
fix(rocksdb): correctly resolve rocksdb path (#1767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evmutil) [#1655] Initialize x/evmutil module account in InitGenesis
 - (deps) [#1770] Bump ledger-cosmos-go to v0.13.1 to resolve signing error with
   cosmos ledger app 2.34.12
+- (rockdb) [#1776] Fix resolution of rocksdb database path
 
 ## State Machine Breaking
 
@@ -304,6 +305,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1776]: https://github.com/Kava-Labs/kava/pull/1776
 [#1770]: https://github.com/Kava-Labs/kava/pull/1770
 [#1755]: https://github.com/Kava-Labs/kava/pull/1755
 [#1761]: https://github.com/Kava-Labs/kava/pull/1761

--- a/cmd/kava/opendb/opendb_rocksdb.go
+++ b/cmd/kava/opendb/opendb_rocksdb.go
@@ -81,7 +81,7 @@ const (
 func OpenDB(appOpts types.AppOptions, home string, backendType dbm.BackendType) (dbm.DB, error) {
 	dataDir := filepath.Join(home, "data")
 	if backendType == dbm.RocksDBBackend {
-		return openRocksdb(filepath.Join(dataDir, "application.db"), appOpts)
+		return openRocksdb(dataDir, appOpts)
 	}
 
 	return dbm.NewDB("application", backendType, dataDir)
@@ -90,7 +90,8 @@ func OpenDB(appOpts types.AppOptions, home string, backendType dbm.BackendType) 
 // openRocksdb loads existing options, overrides some of them with appOpts and opens database
 // option will be overridden only in case if it explicitly specified in appOpts
 func openRocksdb(dir string, appOpts types.AppOptions) (dbm.DB, error) {
-	dbOpts, cfOpts, err := loadLatestOptions(dir)
+	optionsPath := filepath.Join(dir, "application.db")
+	dbOpts, cfOpts, err := loadLatestOptions(optionsPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Backport (forward-port?) of #1767 from `release/v0.25.x`

ensure we use KAVA_HOME/data/application.db and not a nested application.db within that path

This fix already exists on release/v0.25.x. Will backport to all other kava_2222-10 release branches.

## Checklist
 - [x] Changelog has been updated as necessary.
