### PR TITLE
go formatter fixes

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -42,7 +42,7 @@ func (app *App) ExportAppStateAndValidators(forZeroHeight bool, jailWhiteList []
 
 // prepare for fresh start at zero height
 // NOTE zero height genesis is a temporary feature which will be deprecated
-//      in favour of export at a block height
+// in favour of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []string) {
 	applyWhiteList := false
 

--- a/app/test_builder.go
+++ b/app/test_builder.go
@@ -13,10 +13,10 @@ import (
 // All methods return the builder so method calls can be chained together.
 //
 // Example:
-//     // create a single account genesis state
-//     builder := NewAuthBankGenesisBuilder().WithSimpleAccount(testUserAddress, testCoins)
-//     genesisState := builder.BuildMarshalled()
 //
+//	// create a single account genesis state
+//	builder := NewAuthBankGenesisBuilder().WithSimpleAccount(testUserAddress, testCoins)
+//	genesisState := builder.BuildMarshalled()
 type AuthBankGenesisBuilder struct {
 	AuthGenesis authtypes.GenesisState
 	BankGenesis banktypes.GenesisState

--- a/migrate/doc.go
+++ b/migrate/doc.go
@@ -24,6 +24,5 @@ The process is:
 On each release we can delete the previous releases migration and old GenesisState type.
 eg kava-3 migrates `auth.GenesisState` from kava-2 to `auth.GenesisState` from kava-3,
 but for kava-4 we don't need to keep around kava-2's `auth.GenesisState` type.
-
 */
 package migrate

--- a/x/evmutil/client/cli/address.go
+++ b/x/evmutil/client/cli/address.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ParseAddrFromHexOrBech32 parses a string address that can be either a hex or
-//Bech32 string.
+// Bech32 string.
 func ParseAddrFromHexOrBech32(addrString string) (common.Address, error) {
 	if common.IsHexAddress(addrString) {
 		return common.HexToAddress(addrString), nil

--- a/x/issuance/types/params.go
+++ b/x/issuance/types/params.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 

--- a/x/kavadist/handler.go
+++ b/x/kavadist/handler.go
@@ -1,9 +1,9 @@
 package kavadist
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	"github.com/kava-labs/kava/x/kavadist/keeper"

--- a/x/kavadist/keeper/proposal_handler.go
+++ b/x/kavadist/keeper/proposal_handler.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 
 	"github.com/kava-labs/kava/x/kavadist/types"
 )

--- a/x/kavadist/keeper/querier.go
+++ b/x/kavadist/keeper/querier.go
@@ -1,10 +1,10 @@
 package keeper
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 

--- a/x/liquid/types/msg_test.go
+++ b/x/liquid/types/msg_test.go
@@ -4,11 +4,11 @@ import (
 	fmt "fmt"
 	"testing"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	sdkmath "cosmossdk.io/math"
 
 	"github.com/kava-labs/kava/x/liquid/types"
 )

--- a/x/router/client/cli/tx.go
+++ b/x/router/client/cli/tx.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/kava-labs/kava/x/router/types"

--- a/x/router/keeper/msg_server.go
+++ b/x/router/keeper/msg_server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	earntypes "github.com/kava-labs/kava/x/earn/types"

--- a/x/router/types/msg.go
+++ b/x/router/types/msg.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-errorsmod "cosmossdk.io/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 )
 

--- a/x/swap/keeper/hooks_test.go
+++ b/x/swap/keeper/hooks_test.go
@@ -4,8 +4,8 @@ import (
 	"github.com/kava-labs/kava/x/swap/types"
 	"github.com/kava-labs/kava/x/swap/types/mocks"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/x/swap/types/mocks/swap_hooks.go
+++ b/x/swap/types/mocks/swap_hooks.go
@@ -3,8 +3,8 @@
 package mocks
 
 import (
-	mock "github.com/stretchr/testify/mock"
 	math "cosmossdk.io/math"
+	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/cosmos/cosmos-sdk/types"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
<!--- Describe your changes in detail -->
Noticed there are a number of formatting issues after running `gofmt`. This is the result of 
```sh
find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -name '*.pb.go' | xargs gofmt -w -s
```

## Checklist
 - [ ] ~~Changelog has been updated as necessary.~~
