### PR TITLE
fix: upstream ethermint patches for gas tracking and traceTx/Block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ replace (
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v23-1
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20231127220940-f5eaf3a08c1a
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	// Use the cosmos modified protobufs

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ github.com/kava-labs/cometbft-db v0.7.0-rocksdb-v7.9.2-kava.1 h1:EZnZAkZ+dqK+1OM
 github.com/kava-labs/cometbft-db v0.7.0-rocksdb-v7.9.2-kava.1/go.mod h1:mI/4J4IxRzPrXvMiwefrt0fucGwaQ5Hm9IKS7HnoJeI=
 github.com/kava-labs/cosmos-sdk v0.46.11-kava.1 h1:3VRpm4zf/gQgmpRVd1p99/2P8ZecAu2FVAXHru5caIo=
 github.com/kava-labs/cosmos-sdk v0.46.11-kava.1/go.mod h1:bG4AkW9bqc8ycrryyKGQEl3YV9BY2wr6HggGq8kvcgM=
-github.com/kava-labs/ethermint v0.21.0-kava-v23-1 h1:5TSyCtPvFdMuSe8p2iMVqXmFBlK3lHyjaT9EqN752aI=
-github.com/kava-labs/ethermint v0.21.0-kava-v23-1/go.mod h1:rdm6AinxZ4dzPEv/cjH+/AGyTbKufJ3RE7M2MDyklH0=
+github.com/kava-labs/ethermint v0.21.1-0.20231127220940-f5eaf3a08c1a h1:PJoBOGYS4sbUzlJP6QBKDGEFpjGNPgSCraeOetZ/G4M=
+github.com/kava-labs/ethermint v0.21.1-0.20231127220940-f5eaf3a08c1a/go.mod h1:rdm6AinxZ4dzPEv/cjH+/AGyTbKufJ3RE7M2MDyklH0=
 github.com/kava-labs/tm-db v0.6.7-kava.3 h1:4vyAh+NyZ1xTjCt0utNT6FJHnsZK1I19xwZeJttdRXQ=
 github.com/kava-labs/tm-db v0.6.7-kava.3/go.mod h1:70tpLhNfwCP64nAlq+bU+rOiVfWr3Nnju1D1nhGDGKs=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/third_party/proto/ethermint/evm/v1/query.proto
+++ b/third_party/proto/ethermint/evm/v1/query.proto
@@ -255,6 +255,8 @@ message QueryTraceTxRequest {
   bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.ConsAddress"];
   // chain_id is the the eip155 chain id parsed from the requested block header
   int64 chain_id = 9;
+  // block_max_gas of the block of the requested transaction
+  int64 block_max_gas = 10;
 }
 
 // QueryTraceTxResponse defines TraceTx response
@@ -279,6 +281,8 @@ message QueryTraceBlockRequest {
   bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/cosmos/cosmos-sdk/types.ConsAddress"];
   // chain_id is the eip155 chain id parsed from the requested block header
   int64 chain_id = 9;
+  // block_max_gas of the traced block
+  int64 block_max_gas = 10;
 }
 
 // QueryTraceBlockResponse defines TraceBlock response


### PR DESCRIPTION
Right now these changes are based off the v0.24.1 release branch (so that I can build and test it on the current mainnet boxes that are running an older version of rocksdb), assuming the changeset is approved I'll rebase this pr to be off of the planned v0.25 release and master branches

## Description
[Issue 1](https://github.com/evmos/ethermint/pull/1591)
[Issue 2](https://github.com/evmos/evmos/pull/1801)
[Issue 3](https://github.com/evmos/evmos/pull/1676/)

Full ethermint changes viewable at https://github.com/Kava-Labs/ethermint/pull/27

## Checklist
 - [ ] Changelog has been updated as necessary.
