### PR TITLE
add docs and docker config for local and remote app telemetry collection and display

### DIFF
--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -1,0 +1,86 @@
+# Telemetry
+
+[example metrics emitted by Kava application](./example-prometheus-metrics.txt)
+
+## Enabling Kava Metric Telemetry
+
+To enable the kava app to emit telemetry during operation, update the relevant config values to enable metrics:
+
+`config.toml`
+
+```toml
+[instrumentation]
+
+# When true, Prometheus metrics are served under /metrics on
+# PrometheusListenAddr.
+# Check out the documentation for the list of available metrics.
+prometheus = true
+
+# Address to listen for Prometheus collector(s) connections
+prometheus_listen_addr = ":8888"
+```
+
+`app.toml`
+
+```toml
+[telemetry]
+
+# Prefixed with keys to separate services.
+service-name = ""
+
+# Enabled enables the application telemetry functionality. When enabled,
+# an in-memory sink is also enabled by default. Operators may also enabled
+# other sinks such as Prometheus.
+enabled = true
+```
+
+Then restart the service with the updated settings
+
+## Running local prometheus collector and grafana services
+
+To collect app metrics and visualize them locally, you can run the prometheus collector and grafana services with docker compose from the repo root directory
+
+```bash
+docker compose -f prometheus.docker-compose.yml
+```
+
+Navigate to localhost:3000 to view the grafana unix
+
+Login with `admin` as the username and `admin` as the password
+
+Hook up grafana to the local prometheus collector by navigating to `http://localhost:3000/connections/datasources/new`, selecting prometheus, entering `http://prometheus:9090` for the url, and clicking `Save & test` at the bottom of the screen
+
+See [grafana docs](https://grafana.com/docs/grafana/latest/dashboards/) for information on how to construct queries and build dashboards
+
+### Collecting from local host
+
+Update [prometheus config](../prometheus.yml) to collect metrics from your local source
+
+```yaml
+  metrics_path: /
+  static_configs:
+    - targets:
+      - localhost:8888
+```
+
+### Collecting from remote host
+
+Update the kava config on the host and restart using the instructions from `Enabling Kava Metric Emission`
+
+Install [ngrok](https://ngrok.com/download) on the remote host
+
+Run ngrok on the remote host to forward the prometheus metric port
+
+```bash
+ngrok http 8888
+```
+
+```yaml
+scrape_configs:
+- job_name: proxy
+  scheme: https
+  metrics_path: /
+  static_configs:
+    - targets:
+      - 4efb-18-207-102-158.ngrok-free.app
+```

--- a/docs/example-prometheus-metrics.txt
+++ b/docs/example-prometheus-metrics.txt
@@ -1,0 +1,1518 @@
+# HELP _cosmos_bank_v1beta1_Query_AllBalances _cosmos_bank_v1beta1_Query_AllBalances
+# TYPE _cosmos_bank_v1beta1_Query_AllBalances summary
+_cosmos_bank_v1beta1_Query_AllBalances{quantile="0.5"} NaN
+_cosmos_bank_v1beta1_Query_AllBalances{quantile="0.9"} NaN
+_cosmos_bank_v1beta1_Query_AllBalances{quantile="0.99"} NaN
+_cosmos_bank_v1beta1_Query_AllBalances_sum 3966.240769356489
+_cosmos_bank_v1beta1_Query_AllBalances_count 447
+# HELP _cosmos_bank_v1beta1_Query_Balance _cosmos_bank_v1beta1_Query_Balance
+# TYPE _cosmos_bank_v1beta1_Query_Balance summary
+_cosmos_bank_v1beta1_Query_Balance{quantile="0.5"} NaN
+_cosmos_bank_v1beta1_Query_Balance{quantile="0.9"} NaN
+_cosmos_bank_v1beta1_Query_Balance{quantile="0.99"} NaN
+_cosmos_bank_v1beta1_Query_Balance_sum 131.39876666665077
+_cosmos_bank_v1beta1_Query_Balance_count 13
+# HELP _cosmos_distribution_v1beta1_Query_DelegationTotalRewards _cosmos_distribution_v1beta1_Query_DelegationTotalRewards
+# TYPE _cosmos_distribution_v1beta1_Query_DelegationTotalRewards summary
+_cosmos_distribution_v1beta1_Query_DelegationTotalRewards{quantile="0.5"} NaN
+_cosmos_distribution_v1beta1_Query_DelegationTotalRewards{quantile="0.9"} NaN
+_cosmos_distribution_v1beta1_Query_DelegationTotalRewards{quantile="0.99"} NaN
+_cosmos_distribution_v1beta1_Query_DelegationTotalRewards_sum 842.2171558439732
+_cosmos_distribution_v1beta1_Query_DelegationTotalRewards_count 76
+# HELP _cosmos_slashing_v1beta1_Query_SigningInfo _cosmos_slashing_v1beta1_Query_SigningInfo
+# TYPE _cosmos_slashing_v1beta1_Query_SigningInfo summary
+_cosmos_slashing_v1beta1_Query_SigningInfo{quantile="0.5"} NaN
+_cosmos_slashing_v1beta1_Query_SigningInfo{quantile="0.9"} NaN
+_cosmos_slashing_v1beta1_Query_SigningInfo{quantile="0.99"} NaN
+_cosmos_slashing_v1beta1_Query_SigningInfo_sum 4577.124782323837
+_cosmos_slashing_v1beta1_Query_SigningInfo_count 415
+# HELP _cosmos_staking_v1beta1_Query_DelegatorDelegations _cosmos_staking_v1beta1_Query_DelegatorDelegations
+# TYPE _cosmos_staking_v1beta1_Query_DelegatorDelegations summary
+_cosmos_staking_v1beta1_Query_DelegatorDelegations{quantile="0.5"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorDelegations{quantile="0.9"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorDelegations{quantile="0.99"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorDelegations_sum 3267.1603242754936
+_cosmos_staking_v1beta1_Query_DelegatorDelegations_count 247
+# HELP _cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations _cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations
+# TYPE _cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations summary
+_cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations{quantile="0.5"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations{quantile="0.9"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations{quantile="0.99"} NaN
+_cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations_sum 2872.724914997816
+_cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations_count 211
+# HELP _cosmos_staking_v1beta1_Query_Validator _cosmos_staking_v1beta1_Query_Validator
+# TYPE _cosmos_staking_v1beta1_Query_Validator summary
+_cosmos_staking_v1beta1_Query_Validator{quantile="0.5"} NaN
+_cosmos_staking_v1beta1_Query_Validator{quantile="0.9"} NaN
+_cosmos_staking_v1beta1_Query_Validator{quantile="0.99"} NaN
+_cosmos_staking_v1beta1_Query_Validator_sum 4638.930439531803
+_cosmos_staking_v1beta1_Query_Validator_count 393
+# HELP _cosmos_staking_v1beta1_Query_Validators _cosmos_staking_v1beta1_Query_Validators
+# TYPE _cosmos_staking_v1beta1_Query_Validators summary
+_cosmos_staking_v1beta1_Query_Validators{quantile="0.5"} NaN
+_cosmos_staking_v1beta1_Query_Validators{quantile="0.9"} NaN
+_cosmos_staking_v1beta1_Query_Validators{quantile="0.99"} NaN
+_cosmos_staking_v1beta1_Query_Validators_sum 722.1452040672302
+_cosmos_staking_v1beta1_Query_Validators_count 47
+# HELP _cosmwasm_wasm_v1_Query_SmartContractState _cosmwasm_wasm_v1_Query_SmartContractState
+# TYPE _cosmwasm_wasm_v1_Query_SmartContractState summary
+_cosmwasm_wasm_v1_Query_SmartContractState{quantile="0.5"} NaN
+_cosmwasm_wasm_v1_Query_SmartContractState{quantile="0.9"} NaN
+_cosmwasm_wasm_v1_Query_SmartContractState{quantile="0.99"} NaN
+_cosmwasm_wasm_v1_Query_SmartContractState_sum 0.19835000252351165
+_cosmwasm_wasm_v1_Query_SmartContractState_count 12
+# HELP _kava_swap_v1beta1_Query_Pools _kava_swap_v1beta1_Query_Pools
+# TYPE _kava_swap_v1beta1_Query_Pools summary
+_kava_swap_v1beta1_Query_Pools{quantile="0.5"} NaN
+_kava_swap_v1beta1_Query_Pools{quantile="0.9"} NaN
+_kava_swap_v1beta1_Query_Pools{quantile="0.99"} NaN
+_kava_swap_v1beta1_Query_Pools_sum 22485.62510150671
+_kava_swap_v1beta1_Query_Pools_count 2973
+# HELP begin_blocker begin_blocker
+# TYPE begin_blocker summary
+begin_blocker{module="auction",quantile="0.5"} 0.13248400390148163
+begin_blocker{module="auction",quantile="0.9"} 0.13248400390148163
+begin_blocker{module="auction",quantile="0.99"} 0.13248400390148163
+begin_blocker_sum{module="auction"} 1690.6133300364017
+begin_blocker_count{module="auction"} 11961
+begin_blocker{module="bep3",quantile="0.5"} 0.47380998730659485
+begin_blocker{module="bep3",quantile="0.9"} 0.47380998730659485
+begin_blocker{module="bep3",quantile="0.99"} 0.47380998730659485
+begin_blocker_sum{module="bep3"} 6828.068249315023
+begin_blocker_count{module="bep3"} 11961
+begin_blocker{module="capability",quantile="0.5"} 0.006816000211983919
+begin_blocker{module="capability",quantile="0.9"} 0.006816000211983919
+begin_blocker{module="capability",quantile="0.99"} 0.006816000211983919
+begin_blocker_sum{module="capability"} 93.95409707725048
+begin_blocker_count{module="capability"} 11961
+begin_blocker{module="cdp",quantile="0.5"} 792.978515625
+begin_blocker{module="cdp",quantile="0.9"} 792.978515625
+begin_blocker{module="cdp",quantile="0.99"} 792.978515625
+begin_blocker_sum{module="cdp"} 9.956126070922852e+06
+begin_blocker_count{module="cdp"} 11961
+begin_blocker{module="committee",quantile="0.5"} 0.12749600410461426
+begin_blocker{module="committee",quantile="0.9"} 0.12749600410461426
+begin_blocker{module="committee",quantile="0.99"} 0.12749600410461426
+begin_blocker_sum{module="committee"} 2089.1485115662217
+begin_blocker_count{module="committee"} 11961
+begin_blocker{module="community",quantile="0.5"} 0.033142998814582825
+begin_blocker{module="community",quantile="0.9"} 0.033142998814582825
+begin_blocker{module="community",quantile="0.99"} 0.033142998814582825
+begin_blocker_sum{module="community"} 482.778574263677
+begin_blocker_count{module="community"} 11961
+begin_blocker{module="distribution",quantile="0.5"} 3.9016408920288086
+begin_blocker{module="distribution",quantile="0.9"} 3.9016408920288086
+begin_blocker{module="distribution",quantile="0.99"} 3.9016408920288086
+begin_blocker_sum{module="distribution"} 53849.77843642235
+begin_blocker_count{module="distribution"} 11961
+begin_blocker{module="evidence",quantile="0.5"} 0.0002859999949578196
+begin_blocker{module="evidence",quantile="0.9"} 0.0002859999949578196
+begin_blocker{module="evidence",quantile="0.99"} 0.0002859999949578196
+begin_blocker_sum{module="evidence"} 5.442739000936854
+begin_blocker_count{module="evidence"} 11961
+begin_blocker{module="hard",quantile="0.5"} 1.6735550165176392
+begin_blocker{module="hard",quantile="0.9"} 1.6735550165176392
+begin_blocker{module="hard",quantile="0.99"} 1.6735550165176392
+begin_blocker_sum{module="hard"} 24952.69405889511
+begin_blocker_count{module="hard"} 11961
+begin_blocker{module="incentive",quantile="0.5"} 41.87821960449219
+begin_blocker{module="incentive",quantile="0.9"} 41.87821960449219
+begin_blocker{module="incentive",quantile="0.99"} 41.87821960449219
+begin_blocker_sum{module="incentive"} 540793.5799751282
+begin_blocker_count{module="incentive"} 11961
+begin_blocker{module="kavadist",quantile="0.5"} 0.6815450191497803
+begin_blocker{module="kavadist",quantile="0.9"} 0.6815450191497803
+begin_blocker{module="kavadist",quantile="0.99"} 0.6815450191497803
+begin_blocker_sum{module="kavadist"} 9978.374494671822
+begin_blocker_count{module="kavadist"} 11961
+begin_blocker{module="mint",quantile="0.5"} 0.23059199750423431
+begin_blocker{module="mint",quantile="0.9"} 0.23059199750423431
+begin_blocker{module="mint",quantile="0.99"} 0.23059199750423431
+begin_blocker_sum{module="mint"} 8136.461262211204
+begin_blocker_count{module="mint"} 11961
+begin_blocker{module="slashing",quantile="0.5"} 2.9535489082336426
+begin_blocker{module="slashing",quantile="0.9"} 2.9535489082336426
+begin_blocker{module="slashing",quantile="0.99"} 2.9535489082336426
+begin_blocker_sum{module="slashing"} 49147.59322762489
+begin_blocker_count{module="slashing"} 11961
+begin_blocker{module="staking",quantile="0.5"} 3.4198129177093506
+begin_blocker{module="staking",quantile="0.9"} 3.4198129177093506
+begin_blocker{module="staking",quantile="0.99"} 3.4198129177093506
+begin_blocker_sum{module="staking"} 78496.35699152946
+begin_blocker_count{module="staking"} 11961
+begin_blocker{module="upgrade",quantile="0.5"} 0.0055240001529455185
+begin_blocker{module="upgrade",quantile="0.9"} 0.0055240001529455185
+begin_blocker{module="upgrade",quantile="0.99"} 0.0055240001529455185
+begin_blocker_sum{module="upgrade"} 97.08074242202565
+begin_blocker_count{module="upgrade"} 11961
+# HELP custom_hard_borrows custom_hard_borrows
+# TYPE custom_hard_borrows summary
+custom_hard_borrows{quantile="0.5"} NaN
+custom_hard_borrows{quantile="0.9"} NaN
+custom_hard_borrows{quantile="0.99"} NaN
+custom_hard_borrows_sum 13719.747945651412
+custom_hard_borrows_count 1798
+# HELP custom_hard_deposits custom_hard_deposits
+# TYPE custom_hard_deposits summary
+custom_hard_deposits{quantile="0.5"} NaN
+custom_hard_deposits{quantile="0.9"} NaN
+custom_hard_deposits{quantile="0.99"} NaN
+custom_hard_deposits_sum 49020.49688000977
+custom_hard_deposits_count 1870
+# HELP custom_validatorvesting_total_supply_usdx custom_validatorvesting_total_supply_usdx
+# TYPE custom_validatorvesting_total_supply_usdx summary
+custom_validatorvesting_total_supply_usdx{quantile="0.5"} NaN
+custom_validatorvesting_total_supply_usdx{quantile="0.9"} NaN
+custom_validatorvesting_total_supply_usdx{quantile="0.99"} NaN
+custom_validatorvesting_total_supply_usdx_sum 2.921165943145752
+custom_validatorvesting_total_supply_usdx_count 4
+# HELP end_blocker end_blocker
+# TYPE end_blocker summary
+end_blocker{module="crisis",quantile="0.5"} 0.0006309999735094607
+end_blocker{module="crisis",quantile="0.9"} 0.0006309999735094607
+end_blocker{module="crisis",quantile="0.99"} 0.0006309999735094607
+end_blocker_sum{module="crisis"} 8.284692998189712
+end_blocker_count{module="crisis"} 11961
+end_blocker{module="gov",quantile="0.5"} 0.13432200253009796
+end_blocker{module="gov",quantile="0.9"} 0.13432200253009796
+end_blocker{module="gov",quantile="0.99"} 0.13432200253009796
+end_blocker_sum{module="gov"} 1721.8451995775104
+end_blocker_count{module="gov"} 11961
+end_blocker{module="pricefeed",quantile="0.5"} 45.29588317871094
+end_blocker{module="pricefeed",quantile="0.9"} 45.29588317871094
+end_blocker{module="pricefeed",quantile="0.99"} 45.29588317871094
+end_blocker_sum{module="pricefeed"} 564230.3499031067
+end_blocker_count{module="pricefeed"} 11961
+end_blocker{module="staking",quantile="0.5"} 12.702988624572754
+end_blocker{module="staking",quantile="0.9"} 12.702988624572754
+end_blocker{module="staking",quantile="0.99"} 12.702988624572754
+end_blocker_sum{module="staking"} 191951.71645259857
+end_blocker_count{module="staking"} 11961
+# HELP feemarket_block_gas feemarket_block_gas
+# TYPE feemarket_block_gas gauge
+feemarket_block_gas 266105
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.000202909
+go_gc_duration_seconds{quantile="0.25"} 0.000313148
+go_gc_duration_seconds{quantile="0.5"} 0.000392886
+go_gc_duration_seconds{quantile="0.75"} 0.000534796
+go_gc_duration_seconds{quantile="1"} 1.48026864
+go_gc_duration_seconds_sum 315.536098894
+go_gc_duration_seconds_count 3080
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 449
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.20.3"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 1.9378459504e+10
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 2.1554173323064e+13
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 6.3800265e+07
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 1.005979131153e+12
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 1.746431056e+09
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 1.9378459504e+10
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 2.7491278848e+10
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 2.482024448e+10
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 3.30543083e+08
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 2.4767111168e+10
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.2311523328e+10
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.7024995072462058e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 1.006309674236e+12
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 19200
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 31200
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 3.2007248e+08
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 6.48312e+08
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 2.0344253432e+10
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 6.1942359e+07
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 7.602176e+06
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 7.602176e+06
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 5.4839642384e+10
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 29
+# HELP gov_vote gov_vote
+# TYPE gov_vote counter
+gov_vote{proposal_id="170"} 53
+# HELP ibc_client_update ibc_client_update
+# TYPE ibc_client_update counter
+ibc_client_update{client_id="07-tendermint-1",client_type="07-tendermint",update_type="msg"} 808
+ibc_client_update{client_id="07-tendermint-119",client_type="07-tendermint",update_type="msg"} 29
+ibc_client_update{client_id="07-tendermint-120",client_type="07-tendermint",update_type="msg"} 252
+ibc_client_update{client_id="07-tendermint-125",client_type="07-tendermint",update_type="msg"} 150
+ibc_client_update{client_id="07-tendermint-130",client_type="07-tendermint",update_type="msg"} 72
+ibc_client_update{client_id="07-tendermint-138",client_type="07-tendermint",update_type="msg"} 25
+ibc_client_update{client_id="07-tendermint-147",client_type="07-tendermint",update_type="msg"} 9
+ibc_client_update{client_id="07-tendermint-149",client_type="07-tendermint",update_type="msg"} 3
+ibc_client_update{client_id="07-tendermint-158",client_type="07-tendermint",update_type="msg"} 6
+ibc_client_update{client_id="07-tendermint-160",client_type="07-tendermint",update_type="msg"} 43
+ibc_client_update{client_id="07-tendermint-2",client_type="07-tendermint",update_type="msg"} 2912
+ibc_client_update{client_id="07-tendermint-6",client_type="07-tendermint",update_type="msg"} 166
+# HELP ibc_transfer_packet_receive ibc_transfer_packet_receive
+# TYPE ibc_transfer_packet_receive gauge
+ibc_transfer_packet_receive{denom="erc20/tether/usdt"} 1.5e+09
+ibc_transfer_packet_receive{denom="uakt"} 5.13e+07
+ibc_transfer_packet_receive{denom="uatom"} 3.4080012e+07
+ibc_transfer_packet_receive{denom="ukava"} 2.579376e+06
+ibc_transfer_packet_receive{denom="uosmo"} 5.02e+07
+# HELP ibc_transfer_receive ibc_transfer_receive
+# TYPE ibc_transfer_receive counter
+ibc_transfer_receive{source="false",source_channel="channel-143",source_port="transfer"} 48
+ibc_transfer_receive{source="false",source_channel="channel-277",source_port="transfer"} 149
+ibc_transfer_receive{source="false",source_channel="channel-37",source_port="transfer"} 45
+ibc_transfer_receive{source="true",source_channel="channel-143",source_port="transfer"} 551
+ibc_transfer_receive{source="true",source_channel="channel-83",source_port="transfer"} 219
+# HELP ibc_transfer_send ibc_transfer_send
+# TYPE ibc_transfer_send counter
+ibc_transfer_send{destination_channel="channel-143",destination_port="transfer",source="false"} 30
+ibc_transfer_send{destination_channel="channel-143",destination_port="transfer",source="true"} 198
+ibc_transfer_send{destination_channel="channel-277",destination_port="transfer",source="false"} 54
+ibc_transfer_send{destination_channel="channel-37",destination_port="transfer",source="false"} 50
+ibc_transfer_send{destination_channel="channel-83",destination_port="transfer",source="true"} 9
+# HELP minted_tokens minted_tokens
+# TYPE minted_tokens gauge
+minted_tokens{module="mint"} 1.15669048e+08
+# HELP new_account new_account
+# TYPE new_account counter
+new_account 356
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 168230.87
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 40960
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 18185
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 8.2102784e+10
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.70242472132e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.10841163776e+11
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes 1.8446744073709552e+19
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 235
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 10
+# HELP query__cosmos_bank_v1beta1_Query_AllBalances query__cosmos_bank_v1beta1_Query_AllBalances
+# TYPE query__cosmos_bank_v1beta1_Query_AllBalances counter
+query__cosmos_bank_v1beta1_Query_AllBalances 447
+# HELP query__cosmos_bank_v1beta1_Query_Balance query__cosmos_bank_v1beta1_Query_Balance
+# TYPE query__cosmos_bank_v1beta1_Query_Balance counter
+query__cosmos_bank_v1beta1_Query_Balance 13
+# HELP query__cosmos_distribution_v1beta1_Query_DelegationTotalRewards query__cosmos_distribution_v1beta1_Query_DelegationTotalRewards
+# TYPE query__cosmos_distribution_v1beta1_Query_DelegationTotalRewards counter
+query__cosmos_distribution_v1beta1_Query_DelegationTotalRewards 76
+# HELP query__cosmos_slashing_v1beta1_Query_SigningInfo query__cosmos_slashing_v1beta1_Query_SigningInfo
+# TYPE query__cosmos_slashing_v1beta1_Query_SigningInfo counter
+query__cosmos_slashing_v1beta1_Query_SigningInfo 415
+# HELP query__cosmos_staking_v1beta1_Query_DelegatorDelegations query__cosmos_staking_v1beta1_Query_DelegatorDelegations
+# TYPE query__cosmos_staking_v1beta1_Query_DelegatorDelegations counter
+query__cosmos_staking_v1beta1_Query_DelegatorDelegations 247
+# HELP query__cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations query__cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations
+# TYPE query__cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations counter
+query__cosmos_staking_v1beta1_Query_DelegatorUnbondingDelegations 211
+# HELP query__cosmos_staking_v1beta1_Query_Validator query__cosmos_staking_v1beta1_Query_Validator
+# TYPE query__cosmos_staking_v1beta1_Query_Validator counter
+query__cosmos_staking_v1beta1_Query_Validator 393
+# HELP query__cosmos_staking_v1beta1_Query_Validators query__cosmos_staking_v1beta1_Query_Validators
+# TYPE query__cosmos_staking_v1beta1_Query_Validators counter
+query__cosmos_staking_v1beta1_Query_Validators 47
+# HELP query__cosmwasm_wasm_v1_Query_SmartContractState query__cosmwasm_wasm_v1_Query_SmartContractState
+# TYPE query__cosmwasm_wasm_v1_Query_SmartContractState counter
+query__cosmwasm_wasm_v1_Query_SmartContractState 12
+# HELP query__kava_swap_v1beta1_Query_Pools query__kava_swap_v1beta1_Query_Pools
+# TYPE query__kava_swap_v1beta1_Query_Pools counter
+query__kava_swap_v1beta1_Query_Pools 2973
+# HELP query_count query_count
+# TYPE query_count counter
+query_count 11970
+# HELP query_custom_hard_borrows query_custom_hard_borrows
+# TYPE query_custom_hard_borrows counter
+query_custom_hard_borrows 1798
+# HELP query_custom_hard_deposits query_custom_hard_deposits
+# TYPE query_custom_hard_deposits counter
+query_custom_hard_deposits 1870
+# HELP query_custom_validatorvesting_total_supply_usdx query_custom_validatorvesting_total_supply_usdx
+# TYPE query_custom_validatorvesting_total_supply_usdx counter
+query_custom_validatorvesting_total_supply_usdx 4
+# HELP query_store_ibc_key query_store_ibc_key
+# TYPE query_store_ibc_key counter
+query_store_ibc_key 3451
+# HELP runtime_alloc_bytes runtime_alloc_bytes
+# TYPE runtime_alloc_bytes gauge
+runtime_alloc_bytes 1.9134230528e+10
+# HELP runtime_free_count runtime_free_count
+# TYPE runtime_free_count gauge
+runtime_free_count 1.00597727232e+12
+# HELP runtime_gc_pause_ns runtime_gc_pause_ns
+# TYPE runtime_gc_pause_ns summary
+runtime_gc_pause_ns{quantile="0.5"} NaN
+runtime_gc_pause_ns{quantile="0.9"} NaN
+runtime_gc_pause_ns{quantile="0.99"} NaN
+runtime_gc_pause_ns_sum 3.15536099297e+11
+runtime_gc_pause_ns_count 3080
+# HELP runtime_heap_objects runtime_heap_objects
+# TYPE runtime_heap_objects gauge
+runtime_heap_objects 3.23957568e+08
+# HELP runtime_malloc_count runtime_malloc_count
+# TYPE runtime_malloc_count gauge
+runtime_malloc_count 1.006301216768e+12
+# HELP runtime_num_goroutines runtime_num_goroutines
+# TYPE runtime_num_goroutines gauge
+runtime_num_goroutines 457
+# HELP runtime_sys_bytes runtime_sys_bytes
+# TYPE runtime_sys_bytes gauge
+runtime_sys_bytes 5.483964416e+10
+# HELP runtime_total_gc_pause_ns runtime_total_gc_pause_ns
+# TYPE runtime_total_gc_pause_ns gauge
+runtime_total_gc_pause_ns 3.15536113664e+11
+# HELP runtime_total_gc_runs runtime_total_gc_runs
+# TYPE runtime_total_gc_runs gauge
+runtime_total_gc_runs 3080
+# HELP staking_delegate staking_delegate
+# TYPE staking_delegate counter
+staking_delegate 20136
+# HELP staking_redelegate staking_redelegate
+# TYPE staking_redelegate counter
+staking_redelegate 33
+# HELP staking_undelegate staking_undelegate
+# TYPE staking_undelegate counter
+staking_undelegate 108
+# HELP store_iavl_commit store_iavl_commit
+# TYPE store_iavl_commit summary
+store_iavl_commit{quantile="0.5"} 0.2039870023727417
+store_iavl_commit{quantile="0.9"} 5.444818019866943
+store_iavl_commit{quantile="0.99"} 51.85783767700195
+store_iavl_commit_sum 872731.9261145815
+store_iavl_commit_count 358830
+# HELP store_iavl_delete store_iavl_delete
+# TYPE store_iavl_delete summary
+store_iavl_delete{quantile="0.5"} 0.020553000271320343
+store_iavl_delete{quantile="0.9"} 0.03359200060367584
+store_iavl_delete{quantile="0.99"} 0.055332001298666
+store_iavl_delete_sum 296008.0933091641
+store_iavl_delete_count 2.123483e+06
+# HELP store_iavl_get store_iavl_get
+# TYPE store_iavl_get summary
+store_iavl_get{quantile="0.5"} 0.010591999627649784
+store_iavl_get{quantile="0.9"} 0.014934999868273735
+store_iavl_get{quantile="0.99"} 0.05364599823951721
+store_iavl_get_sum 7.625179337455558e+06
+store_iavl_get_count 3.316548e+06
+# HELP store_iavl_query store_iavl_query
+# TYPE store_iavl_query summary
+store_iavl_query{quantile="0.5"} NaN
+store_iavl_query{quantile="0.9"} NaN
+store_iavl_query{quantile="0.99"} NaN
+store_iavl_query_sum 19.86855102237314
+store_iavl_query_count 3451
+# HELP store_ibc_key store_ibc_key
+# TYPE store_ibc_key summary
+store_ibc_key{quantile="0.5"} NaN
+store_ibc_key{quantile="0.9"} NaN
+store_ibc_key{quantile="0.99"} NaN
+store_ibc_key_sum 81.11819910584018
+store_ibc_key_count 3451
+# HELP tendermint_blocksync_latest_block_height The height of the latest block.
+# TYPE tendermint_blocksync_latest_block_height gauge
+tendermint_blocksync_latest_block_height 7.721299e+06
+# HELP tendermint_consensus_block_gossip_parts_received Number of block parts received by the node, labeled by whether the part was relevant to the block the node was currently gathering or not.
+# TYPE tendermint_consensus_block_gossip_parts_received counter
+tendermint_consensus_block_gossip_parts_received{chain_id="kava_2222-10",matches_current="false"} 14990
+tendermint_consensus_block_gossip_parts_received{chain_id="kava_2222-10",matches_current="true"} 463676
+# HELP tendermint_consensus_block_interval_seconds Time between this and the last block.
+# TYPE tendermint_consensus_block_interval_seconds histogram
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.005"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.01"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.025"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.05"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.1"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.25"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="0.5"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="1"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="2.5"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="5"} 0
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="10"} 11905
+tendermint_consensus_block_interval_seconds_bucket{chain_id="kava_2222-10",le="+Inf"} 11929
+tendermint_consensus_block_interval_seconds_sum{chain_id="kava_2222-10"} 74600.59535034826
+tendermint_consensus_block_interval_seconds_count{chain_id="kava_2222-10"} 11929
+# HELP tendermint_consensus_block_parts Number of blockparts transmitted by peer.
+# TYPE tendermint_consensus_block_parts counter
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 11658
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 11814
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 10916
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 11654
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 11826
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 11871
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 10800
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 3687
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 9896
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 11592
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 10895
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 9926
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 11875
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 11131
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 10780
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 11930
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 11447
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 11577
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 11224
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 11744
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 11584
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 2862
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 12004
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 11235
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 10580
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 12024
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 6401
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 10761
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 11284
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 9640
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 7296
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 11748
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 11800
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 9908
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 10749
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 11885
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 11949
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 5052
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 11805
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 11785
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 11553
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 10628
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 11978
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 11937
+tendermint_consensus_block_parts{chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 11975
+# HELP tendermint_consensus_block_size_bytes Size of the block.
+# TYPE tendermint_consensus_block_size_bytes gauge
+tendermint_consensus_block_size_bytes{chain_id="kava_2222-10"} 11380
+# HELP tendermint_consensus_byzantine_validators Number of validators who tried to double sign.
+# TYPE tendermint_consensus_byzantine_validators gauge
+tendermint_consensus_byzantine_validators{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_byzantine_validators_power Total power of the byzantine validators.
+# TYPE tendermint_consensus_byzantine_validators_power gauge
+tendermint_consensus_byzantine_validators_power{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_fast_syncing Whether or not a node is fast syncing. 1 if yes, 0 if no.
+# TYPE tendermint_consensus_fast_syncing gauge
+tendermint_consensus_fast_syncing{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_full_prevote_message_delay Difference in seconds between the proposal timestamp and the timestamp of the latest prevote that achieved 100% of the voting power in the prevote step.
+# TYPE tendermint_consensus_full_prevote_message_delay gauge
+tendermint_consensus_full_prevote_message_delay{chain_id="kava_2222-10"} 0.775831338
+# HELP tendermint_consensus_height Height of the chain.
+# TYPE tendermint_consensus_height gauge
+tendermint_consensus_height{chain_id="kava_2222-10"} 7.7213e+06
+# HELP tendermint_consensus_latest_block_height The latest block height.
+# TYPE tendermint_consensus_latest_block_height gauge
+tendermint_consensus_latest_block_height{chain_id="kava_2222-10"} 7.721299e+06
+# HELP tendermint_consensus_missing_validators Number of validators who did not sign.
+# TYPE tendermint_consensus_missing_validators gauge
+tendermint_consensus_missing_validators{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_missing_validators_power Total power of the missing validators.
+# TYPE tendermint_consensus_missing_validators_power gauge
+tendermint_consensus_missing_validators_power{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_num_txs Number of transactions.
+# TYPE tendermint_consensus_num_txs gauge
+tendermint_consensus_num_txs{chain_id="kava_2222-10"} 1
+# HELP tendermint_consensus_quorum_prevote_message_delay Difference in seconds between the proposal timestamp and the timestamp of the latest prevote that achieved a quorum in the prevote step.
+# TYPE tendermint_consensus_quorum_prevote_message_delay gauge
+tendermint_consensus_quorum_prevote_message_delay{chain_id="kava_2222-10"} 0.456896803
+# HELP tendermint_consensus_rounds Number of rounds.
+# TYPE tendermint_consensus_rounds gauge
+tendermint_consensus_rounds{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_state_syncing Whether or not a node is state syncing. 1 if yes, 0 if no.
+# TYPE tendermint_consensus_state_syncing gauge
+tendermint_consensus_state_syncing{chain_id="kava_2222-10"} 0
+# HELP tendermint_consensus_step_duration_seconds Time spent per step.
+# TYPE tendermint_consensus_step_duration_seconds histogram
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="0.1"} 0
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="0.2682695795279726"} 0
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="0.7196856730011522"} 0
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="1.9306977288832508"} 4508
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="5.1794746792312125"} 11770
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="13.894954943731381"} 11925
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="37.27593720314942"} 11929
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="100.00000000000006"} 11929
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Commit",le="+Inf"} 11929
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="Commit"} 27760.34108980412
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="Commit"} 11929
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="0.1"} 205
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="0.2682695795279726"} 285
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="0.7196856730011522"} 445
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="1.9306977288832508"} 1727
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="5.1794746792312125"} 11926
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="13.894954943731381"} 11928
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="37.27593720314942"} 11928
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="100.00000000000006"} 11928
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewHeight",le="+Inf"} 11928
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="NewHeight"} 32130.72758179985
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="NewHeight"} 11928
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="0.1"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="0.2682695795279726"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="0.7196856730011522"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="1.9306977288832508"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="5.1794746792312125"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="13.894954943731381"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="37.27593720314942"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="100.00000000000006"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="NewRound",le="+Inf"} 11825
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="NewRound"} 0.5199680809999994
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="NewRound"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="0.1"} 157
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="0.2682695795279726"} 372
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="0.7196856730011522"} 11895
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="1.9306977288832508"} 11950
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="5.1794746792312125"} 11953
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="13.894954943731381"} 11953
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="37.27593720314942"} 11953
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="100.00000000000006"} 11953
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Precommit",le="+Inf"} 11953
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="Precommit"} 4317.723137998985
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="Precommit"} 11953
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="0.1"} 114
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="0.2682695795279726"} 518
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="0.7196856730011522"} 11808
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="1.9306977288832508"} 11851
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="5.1794746792312125"} 11852
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="13.894954943731381"} 11852
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="37.27593720314942"} 11852
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="100.00000000000006"} 11852
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Prevote",le="+Inf"} 11852
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="Prevote"} 4661.845759802005
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="Prevote"} 11852
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="0.1"} 2
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="0.2682695795279726"} 4
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="0.7196856730011522"} 4
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="1.9306977288832508"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="5.1794746792312125"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="13.894954943731381"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="37.27593720314942"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="100.00000000000006"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="PrevoteWait",le="+Inf"} 6
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="PrevoteWait"} 2.222095445
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="PrevoteWait"} 6
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="0.1"} 158
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="0.2682695795279726"} 1714
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="0.7196856730011522"} 10467
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="1.9306977288832508"} 11789
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="5.1794746792312125"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="13.894954943731381"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="37.27593720314942"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="100.00000000000006"} 11825
+tendermint_consensus_step_duration_seconds_bucket{chain_id="kava_2222-10",step="Propose",le="+Inf"} 11825
+tendermint_consensus_step_duration_seconds_sum{chain_id="kava_2222-10",step="Propose"} 5716.383156191996
+tendermint_consensus_step_duration_seconds_count{chain_id="kava_2222-10",step="Propose"} 11825
+# HELP tendermint_consensus_total_txs Total number of transactions.
+# TYPE tendermint_consensus_total_txs gauge
+tendermint_consensus_total_txs{chain_id="kava_2222-10"} 58778
+# HELP tendermint_consensus_validators Number of validators.
+# TYPE tendermint_consensus_validators gauge
+tendermint_consensus_validators{chain_id="kava_2222-10"} 100
+# HELP tendermint_consensus_validators_power Total power of all validators.
+# TYPE tendermint_consensus_validators_power gauge
+tendermint_consensus_validators_power{chain_id="kava_2222-10"} 1.30461704e+08
+# HELP tendermint_mempool_failed_txs Number of failed transactions.
+# TYPE tendermint_mempool_failed_txs counter
+tendermint_mempool_failed_txs{chain_id="kava_2222-10"} 193094
+# HELP tendermint_mempool_recheck_times Number of times transactions are rechecked in the mempool.
+# TYPE tendermint_mempool_recheck_times counter
+tendermint_mempool_recheck_times{chain_id="kava_2222-10"} 469570
+# HELP tendermint_mempool_size Size of the mempool (number of uncommitted transactions).
+# TYPE tendermint_mempool_size gauge
+tendermint_mempool_size{chain_id="kava_2222-10"} 999
+# HELP tendermint_mempool_tx_size_bytes Transaction sizes in bytes.
+# TYPE tendermint_mempool_tx_size_bytes histogram
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="1"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="3"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="9"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="27"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="81"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="243"} 0
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="729"} 22786
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="2187"} 54500
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="6561"} 56782
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="19683"} 57125
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="59049"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="177147"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="531441"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="1.594323e+06"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="4.782969e+06"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="1.4348907e+07"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="4.3046721e+07"} 57710
+tendermint_mempool_tx_size_bytes_bucket{chain_id="kava_2222-10",le="+Inf"} 57710
+tendermint_mempool_tx_size_bytes_sum{chain_id="kava_2222-10"} 7.3299343e+07
+tendermint_mempool_tx_size_bytes_count{chain_id="kava_2222-10"} 57710
+# HELP tendermint_p2p_message_receive_bytes_total Number of bytes of each message type received.
+# TYPE tendermint_p2p_message_receive_bytes_total counter
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="blockchain_BlockRequest"} 30303
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="blockchain_BlockResponse"} 866529
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="blockchain_StatusRequest"} 2912
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="blockchain_StatusResponse"} 4756
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_BlockPart"} 8.455499671e+09
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_HasVote"} 1.060982105e+09
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_NewRoundStep"} 2.9093236e+07
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_NewValidBlock"} 2.583322e+07
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_Proposal"} 8.2541462e+07
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_Vote"} 1.5413483202e+10
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_VoteSetBits"} 6.115351e+06
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="consensus_VoteSetMaj23"} 5.4196265e+07
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="mempool_Txs"} 3.620793065e+09
+tendermint_p2p_message_receive_bytes_total{chain_id="kava_2222-10",message_type="p2p_PexRequest"} 508
+# HELP tendermint_p2p_message_send_bytes_total Number of bytes of each message type sent.
+# TYPE tendermint_p2p_message_send_bytes_total counter
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="blockchain_BlockRequest"} 588
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="blockchain_BlockResponse"} 7.4332406e+07
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="blockchain_StatusRequest"} 428
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="blockchain_StatusResponse"} 52587
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_BlockPart"} 8.153912153e+09
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_HasVote"} 1.101287256e+09
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_NewRoundStep"} 2.9612677e+07
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_NewValidBlock"} 2.7045374e+07
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_Proposal"} 7.8277329e+07
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_Vote"} 1.1688116342e+10
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_VoteSetBits"} 6.867255e+06
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="consensus_VoteSetMaj23"} 5.6163762e+07
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="mempool_Txs"} 3.204876413e+09
+tendermint_p2p_message_send_bytes_total{chain_id="kava_2222-10",message_type="p2p_PexAddrs"} 3.715497e+06
+# HELP tendermint_p2p_peer_pending_send_bytes Pending bytes to be sent to a given peer.
+# TYPE tendermint_p2p_peer_pending_send_bytes gauge
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 100
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 100
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 100
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 100
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 0
+tendermint_p2p_peer_pending_send_bytes{chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 0
+# HELP tendermint_p2p_peer_receive_bytes_total Number of bytes received from a given peer.
+# TYPE tendermint_p2p_peer_receive_bytes_total counter
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 56
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 24
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 30
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 56
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 32
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 2
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 38
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 8
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 10
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 20
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 30
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 60
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 32
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 4
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 42
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 2
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 24
+tendermint_p2p_peer_receive_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 26
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 2.8665254e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 2.832548e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 2.8566858e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 2.8648927e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 78
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 533
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 2.8154618e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 2.8160564e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 2.868088e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 9.227694e+06
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 2.3844472e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 2.8002621e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 2.8144219e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 2.4000405e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 2.8499728e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 13
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 2.8140886e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 2.5614965e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 2.8433802e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 2.7340998e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 2.8630496e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 2.7078233e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 2.8278193e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 2.8168537e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 1001
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 6.921924e+06
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 2.8530702e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 2.8685274e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 2.5430608e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 2.8482345e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 1.65267e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 2.7508916e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 2.8269718e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 2.4117471e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 2.1764512e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 2.8212028e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 2.8136636e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 2.3748503e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 2.622437e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 2.6018966e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 2.853759e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 1.204349e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 351
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 2.8310363e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 2.8317062e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 2.7686705e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 2.819525e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 2.8480745e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 2.8459866e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 2.8517535e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 367741
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 2.08322066e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 2.1040807e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 1.92893912e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 2.06944351e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 2.10272776e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 2.10739266e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 1.91734698e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 6.774011e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 1.77356663e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 2.07019338e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 1.94668677e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 1.77533375e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 2.11811248e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 1.98271625e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 1.92133222e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 2.12784424e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 2.04860516e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 2.04830177e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 1.98130066e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 2.09354199e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 2.069444e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 5.5086975e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 2.13276737e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 2.00070752e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 1.88945491e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 2.13845384e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 1.1341659e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 1.93634423e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 2.0217186e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 1.74763233e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 1.30537488e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 2.09615089e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 2.10385824e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 1.7726941e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 1.92582324e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 2.11768704e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 2.12608481e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 8.9376402e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 2.10273456e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 2.10488892e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 2.05995609e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 1.89241832e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 2.13123281e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 2.11992708e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 2.12817009e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 3.74697602e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 4.0580272e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 2.66613474e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 3.45890402e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 4.06243928e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 4.12734762e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 2.70646049e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 1.00244726e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 3.23049899e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 4.02541876e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 3.21480306e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 3.21159682e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 4.11637247e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 3.10982298e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 3.59664345e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 4.11141548e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 3.90409998e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 3.35219255e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 3.60824731e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 3.87050902e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 3.77591525e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 9.1123931e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 4.21275443e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 3.2838832e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 3.5134784e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 4.26453443e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 1.76168645e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 3.00919886e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 3.583105e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 3.00066453e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 2.29036444e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 3.92455519e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 3.99087525e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 3.37556686e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 3.44894438e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 3.79117855e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 4.16231135e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 1.80453349e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 3.98750733e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 4.04518571e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 3.73348166e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 2.75156792e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 4.21062444e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 3.91106246e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 4.21025563e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 153883
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 144748
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 183530
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 166150
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 129822
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 132955
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 184163
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 54169
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 131104
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 139566
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 173156
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 130925
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 138097
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 175745
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 127602
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 122456
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 135055
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 163736
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 149367
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 149718
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 146638
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 36991
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 129103
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 173019
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 132956
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 115422
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 108022
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 176415
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 148758
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 137705
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 39042
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 149998
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 141035
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 116086
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 139669
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 132293
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 129174
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 70233
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 148493
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 139710
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 145586
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 183262
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 122493
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 140963
+tendermint_p2p_peer_receive_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 126338
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 8.0524633e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 8.0395986e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 7.2650446e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 7.5710562e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 3.178236e+06
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 1.56173618e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 7.8977198e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 8.8954428e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 7.7863661e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 3.0511022e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 5.7679206e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 6.8390123e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 8.2750835e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 6.7555408e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 6.1740729e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 3.911715e+06
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 7.5029833e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 5.6355444e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 7.3944074e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 8.1057599e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 7.7596956e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 6.8072676e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 7.4856616e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 9.4854799e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 2.9691013e+08
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 2.1816474e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 7.6984065e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 7.7007002e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 6.8817814e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 9.0451937e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 5.1277253e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 8.8042736e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 6.1320601e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 6.3803439e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 7.2316367e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 7.3565127e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 7.6089888e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 5.6344995e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 6.1744803e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 9.0806596e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 3.018749e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 1.8524257e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 8.0217528e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 7.9843198e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 7.262064e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 7.692059e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 9.0522916e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 7.9721769e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 7.6102499e+07
+tendermint_p2p_peer_receive_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 97148
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 144
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 36
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 53303
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 87561
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 72
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 492
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 41532
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 61356
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 24
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 12934
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 91968
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 11
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 214776
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 360
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 31299
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 924
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 32900
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 16945
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 54576
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 11243
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 48
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 13031
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 57940
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 63268
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 324
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 24
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 11
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 12
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 144
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 39461
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 17433
+tendermint_p2p_peer_receive_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 120
+# HELP tendermint_p2p_peer_send_bytes_total Number of bytes sent to a given peer.
+# TYPE tendermint_p2p_peer_send_bytes_total counter
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 409470
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 87777
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 175630
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 219444
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 409359
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 233949
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 14572
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 277960
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 58508
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 73212
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 146111
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 219438
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 438973
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 234034
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 29260
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 307203
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 14626
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 175615
+tendermint_p2p_peer_send_bytes_total{chID="0x0",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 190356
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="078d4ee3fed039adcaabd14cd7d204278fd82299"} 1351
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 2.8489274e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="0df052bebd2947e6ccbd97b70da5a10810d6b698"} 3099
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 2.8329001e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 2.8409865e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 2.8434935e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="22f7637f5bd2221c09af86d99d15206b7ed73857"} 1267
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="266a6e6b8725dca6998d1ef4be5ab12e11406cdc"} 1719
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 182122
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 1.20839e+06
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 2.8350508e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 2.8060309e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 2.8510039e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 9.132724e+06
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 2.3850128e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 2.8133091e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 2.8027168e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 2.3928499e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 2.8411018e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 29337
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 2.7963307e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 2.5597559e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 2.8397572e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 2.7291797e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="6cc75f980c21c70846e3dbde5ee6142775ed5f3c"} 21426
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 2.8422149e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 2.7107907e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 2.8115995e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 2.8164903e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 2.260942e+06
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 1.2111664e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 2.8415096e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 2.844341e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 2.5364115e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="8b5c4a890c8ae7efbbe3360af71be1c3c3a9e12e"} 757
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 2.8407777e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 1.6439485e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="9e8ff36eee106c55cb3fb8ace62e96aa98e170c2"} 3101
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a0c1b80198cc49ec5a42e8f1630bcf31fc76a47c"} 1900
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 2.7564307e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 2.8390682e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 2.4156922e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 2.8448303e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 2.8023847e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 2.8095435e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 2.3669197e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 2.614149e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="bb53a4a4205d0ab6ff3600c0035c21dd291afd17"} 2879
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 2.8418635e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 2.8413755e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 1.1986633e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 912520
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 2.8219641e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 2.8316629e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 2.7636097e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 2.8092128e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 2.8408709e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 2.8364282e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 2.8408688e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 2.8400306e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x20",chain_id="kava_2222-10",peer_id="fc9b2e777d71971c50ad1a992e0f72a4146826af"} 13278
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 2.08081986e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 2.04004929e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 1.98605997e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 1.26454651e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 68016
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 464776
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 2.01880773e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 1.9494156e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 1.82937284e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 5.3521223e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 1.70269713e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 2.0387926e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 1.75646179e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 1.77105314e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 1.9688905e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 11336
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 1.56732092e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 1.83074066e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 2.04041587e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 1.94998518e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 1.22191906e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 1.95974382e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 1.830595e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 2.03155897e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 872872
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 5.3118101e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 1.96935429e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 1.42900195e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 1.81839278e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 1.77741696e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 8.863507e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 2.06276722e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 2.03098219e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 1.74914298e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 2.92073892e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 2.0815884e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 1.99093353e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 1.70166893e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 1.89095406e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 2.02393651e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 1.98524216e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 3.0476572e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 306072
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 2.06961329e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 1.99962668e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 2.01233015e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 1.78720067e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 1.83463734e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 2.03752216e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 1.91893417e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x21",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 2.11592266e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 3.32725276e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 2.76121931e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 3.55203408e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 1.56669617e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 99642
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 680887
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 3.06686707e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 2.35319278e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 2.66570735e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 6.1067451e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 2.56215379e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 2.58019749e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 1.96804159e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 2.91149219e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 2.52438146e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 16607
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 1.91333657e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 2.55845036e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 3.06989084e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 2.68748395e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 1.66066062e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 3.10585223e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 2.57193229e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 3.22651015e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 1.278739e+06
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 7.2559114e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 2.29111322e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 1.75703216e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 2.65620072e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 1.85946595e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 1.17719575e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 3.77979912e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 3.20904414e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 2.7625371e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 2.60522962e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 3.85882171e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 2.74009625e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 2.4752721e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 2.94663736e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 2.35837251e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 2.7695094e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 6.9108816e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 448389
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 3.18107868e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 2.84643389e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 3.00961235e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 2.3509459e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 2.07871741e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 2.85735266e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 2.16960104e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x22",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 4.45514488e+08
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 158156
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 174613
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 147274
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 207321
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 149762
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 182249
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 179776
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 66699
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 135773
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 171027
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 194240
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 122668
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 176899
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 197365
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 156885
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 169380
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 172388
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 209822
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 156773
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 175326
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 142183
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 39619
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 186513
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 201834
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 150408
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 197451
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 111796
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 41509
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 153751
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 120005
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 594
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 53129
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 179414
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 138590
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 140485
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 187714
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 184984
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 88501
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 164732
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 170051
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 162875
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 196034
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 189269
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 178165
+tendermint_p2p_peer_send_bytes_total{chID="0x23",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 183253
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 7.3874925e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 7.3866446e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 7.3985927e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 6.7697234e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 7.4002222e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 7.3392246e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 7.1334022e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 2.6701852e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 7.3439983e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 8.2087277e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 7.2037069e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 6.3398929e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 8.3673621e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 6.3997453e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 7.7454019e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 7.5235159e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 7.1330903e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 6.7993224e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 6.8297654e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 7.1871396e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 7.3394825e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 2.662186e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 7.3711529e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 6.9323443e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 6.7236099e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 7.4060213e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 4.2393027e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 7.3131491e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 8.3230083e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 6.3690922e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 7.3474386e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 8.4765159e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 7.2608654e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 6.350077e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 7.8881913e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 7.6973635e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 7.4741823e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 2.6536663e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 7.4397463e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 7.5091657e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 7.2581361e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 7.250513e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 7.3951411e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 7.403937e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 7.2899881e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x30",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 8.5462084e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="078d4ee3fed039adcaabd14cd7d204278fd82299"} 981
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="0be20620d27270e4a146b1e8ed32bbc1b4031152"} 31
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="0df052bebd2947e6ccbd97b70da5a10810d6b698"} 2142
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="1005622e1edf9c355de331b9327b2b99669e0783"} 27
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="11f965df6fb3091e0fa3a1e4c129ff697939b827"} 51
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="12c80ee83863066c37c307950f543bc2f6fcda73"} 73
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="22f7637f5bd2221c09af86d99d15206b7ed73857"} 963
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="266a6e6b8725dca6998d1ef4be5ab12e11406cdc"} 1206
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="3d6d05a7fb55c1eeb3acb63dee94b370d7880c9b"} 477
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="3ffc0159d16db90655635889d78e0cd092d85d8e"} 379
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="41d88639239c55fd37279d24df507238e1c417ea"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4a399804899c2ef764b71db0c21ebd37f3643863"} 61
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4bc1b2b12dc5a5493edc7d54b0684b50e2112c17"} 45
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="4e1c2471efb89239fb04a4b75f9f87177fd91d00"} 873
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="508d7ec33c7f3c9c479ca9b845cadbbefee670f7"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="544545a4f80727af896934b6a2f37ffa0cd2437f"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="54e25aa929a85fd9ab9a43789f590e1b03e66b15"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="5e90636e63827d5b802f3ab5c315fae3d277a004"} 18
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="609cb96b32f225ce0f0d8b78be574fb78ee43ef3"} 38
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="64ae69cd3742898f9af8aa490e7825b9ceb95991"} 504
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="69ee28bdc8b9a5e11dd5a949fa9fcecdd439d27a"} 82
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6b3a708006089d2e1ce31ab70134686698d7b3bf"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6b9e7e36b8a25c711286091aeba2528ddd481c44"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6c99303e86f90a6bea721a6e78a9b8b9fe38ab7e"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="6cc75f980c21c70846e3dbde5ee6142775ed5f3c"} 14616
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="747769c7b3b5b895c46160a43b5e3684ecfad022"} 136
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="74e9de6dc633df30b32dfd9a48f1078d6b8832a0"} 690637
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="76d594dd325412a0fa5f2c5c4fec8161a451072e"} 54
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7ab4b78fbe5ee9e3777b21464a3162bd4cc17f57"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7bca5df66ae0d78a26997184003b22e9d32c7a3a"} 713
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="7c37e607e5cd50cd66745faa0785ed431148046d"} 7.3654909e+07
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="891e54f5c0161ca0958dca7bec7dc49960dc0358"} 38
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="8964d64ab213497afe466abc4162b206ff1e3896"} 59
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="89757803f40da51678451735445ad40d5b15e059"} 369
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="8b5c4a890c8ae7efbbe3360af71be1c3c3a9e12e"} 540
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="8ce49f10c25f36254dc8f73c5870ee0cfe92242e"} 38
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="97e4468ac589eac505a800411c635b14511a61bb"} 432
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="9e8ff36eee106c55cb3fb8ace62e96aa98e170c2"} 2151
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a0c1b80198cc49ec5a42e8f1630bcf31fc76a47c"} 1242
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a20a227050a15b9a2bc328436184acda152bd2f5"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a24cfadd888256a2fbebbefdd8fca05c05f8f90f"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a6092abb0a4d6da1dfbea94b66e0dc2f5769eb23"} 36
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="a8ad45ebd2f536cae8a41bf1d50f96ca9726b406"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="abf487c8cd669aa4000f7f706a773e5dabaff805"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="af9f4b0b8b64f8beb4406d6d0bfddc566be0e083"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="b52f73caaba88583f33f0750ee4f0a3c1703305c"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="b6fb2db398cdc73fc5d44dd4a277e822e38d044e"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="bb53a4a4205d0ab6ff3600c0035c21dd291afd17"} 2070
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="c0a374de07e707c629027bb14aaf4407f617d535"} 38
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="c7355c884208f5fe69918d41108584c0386ad59d"} 45
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="cb47214799c555f5095db2a952cdb7b9f8253d3d"} 176
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="cc85a24c3aa1c1c21a0a0368fe03c24072dd08d5"} 243
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="d4582a8a04a5f34b8928a3e38cb7c1767585df47"} 18
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="db3744a9b9b9e7a2eec8b78a6366104a9c943352"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="e5845913a3e0ed30a80550b752b556c2824ecd56"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="e726816f42831689eab9378d5d577f1d06d25716"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="eb5bd33edac69f845330876931c99d96f9606422"} 31
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="ebc272824924ea1a27ea3183dd0b9ba713494f83"} 9
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="ec2477f459cb5e598a82a210a7eb22bcd95554a3"} 61
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="f7123683e5033ae88bc1f28a37ef9c3ae4a46ea4"} 38
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="f8d5e677f1f68f8bd798752595371817f61dc532"} 251
+tendermint_p2p_peer_send_bytes_total{chID="0x40",chain_id="kava_2222-10",peer_id="fc9b2e777d71971c50ad1a992e0f72a4146826af"} 8946
+# HELP tendermint_p2p_peers Number of peers.
+# TYPE tendermint_p2p_peers gauge
+tendermint_p2p_peers{chain_id="kava_2222-10"} 44
+# HELP tendermint_state_block_processing_time Time between BeginBlock and EndBlock in ms.
+# TYPE tendermint_state_block_processing_time histogram
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="1"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="11"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="21"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="31"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="41"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="51"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="61"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="71"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="81"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="91"} 0
+tendermint_state_block_processing_time_bucket{chain_id="kava_2222-10",le="+Inf"} 11961
+tendermint_state_block_processing_time_sum{chain_id="kava_2222-10"} 1.1803762449236937e+07
+tendermint_state_block_processing_time_count{chain_id="kava_2222-10"} 11961
+# HELP tx_count tx_count
+# TYPE tx_count counter
+tx_count 58887
+# HELP tx_failed tx_failed
+# TYPE tx_failed counter
+tx_failed 703
+# HELP tx_gas_used tx_gas_used
+# TYPE tx_gas_used gauge
+tx_gas_used 266105
+# HELP tx_gas_wanted tx_gas_wanted
+# TYPE tx_gas_wanted gauge
+tx_gas_wanted 1.95e+07
+# HELP tx_msg_begin_redelegate tx_msg_begin_redelegate
+# TYPE tx_msg_begin_redelegate gauge
+tx_msg_begin_redelegate{denom="ukava"} 1.04936e+09
+# HELP tx_msg_begin_unbonding tx_msg_begin_unbonding
+# TYPE tx_msg_begin_unbonding gauge
+tx_msg_begin_unbonding{denom="ukava"} 1.260555392e+09
+# HELP tx_msg_delegate tx_msg_delegate
+# TYPE tx_msg_delegate gauge
+tx_msg_delegate{denom="ukava"} 2e+07
+# HELP tx_msg_ethereum_tx_gas_limit_per_gas_used tx_msg_ethereum_tx_gas_limit_per_gas_used
+# TYPE tx_msg_ethereum_tx_gas_limit_per_gas_used gauge
+tx_msg_ethereum_tx_gas_limit_per_gas_used{execution="call",tx_type="0"} 2
+tx_msg_ethereum_tx_gas_limit_per_gas_used{execution="create",tx_type="0"} 1
+# HELP tx_msg_ethereum_tx_gas_used_total tx_msg_ethereum_tx_gas_used_total
+# TYPE tx_msg_ethereum_tx_gas_used_total counter
+tx_msg_ethereum_tx_gas_used_total{execution="call",tx_type="0"} 2.7629004507e+10
+tx_msg_ethereum_tx_gas_used_total{execution="create",tx_type="0"} 7.5790945e+07
+# HELP tx_msg_ethereum_tx_total tx_msg_ethereum_tx_total
+# TYPE tx_msg_ethereum_tx_total counter
+tx_msg_ethereum_tx_total{execution="call",tx_type="0"} 48544
+tx_msg_ethereum_tx_total{execution="create",tx_type="0"} 54
+# HELP tx_msg_ibc_acknowledge_packet tx_msg_ibc_acknowledge_packet
+# TYPE tx_msg_ibc_acknowledge_packet counter
+tx_msg_ibc_acknowledge_packet{destination_channel="channel-143",destination_port="transfer",source_channel="channel-1",source_port="transfer"} 707
+tx_msg_ibc_acknowledge_packet{destination_channel="channel-143",destination_port="transfer",source_channel="channel-122",source_port="transfer"} 14
+tx_msg_ibc_acknowledge_packet{destination_channel="channel-277",destination_port="transfer",source_channel="channel-0",source_port="transfer"} 177
+tx_msg_ibc_acknowledge_packet{destination_channel="channel-37",destination_port="transfer",source_channel="channel-5",source_port="transfer"} 119
+tx_msg_ibc_acknowledge_packet{destination_channel="channel-83",destination_port="transfer",source_channel="channel-117",source_port="transfer"} 30
+# HELP tx_msg_ibc_recv_packet tx_msg_ibc_recv_packet
+# TYPE tx_msg_ibc_recv_packet counter
+tx_msg_ibc_recv_packet{destination_channel="channel-0",destination_port="transfer",source_channel="channel-277",source_port="transfer"} 149
+tx_msg_ibc_recv_packet{destination_channel="channel-1",destination_port="transfer",source_channel="channel-143",source_port="transfer"} 548
+tx_msg_ibc_recv_packet{destination_channel="channel-117",destination_port="transfer",source_channel="channel-83",source_port="transfer"} 219
+tx_msg_ibc_recv_packet{destination_channel="channel-122",destination_port="transfer",source_channel="channel-143",source_port="transfer"} 51
+tx_msg_ibc_recv_packet{destination_channel="channel-5",destination_port="transfer",source_channel="channel-37",source_port="transfer"} 45
+# HELP tx_msg_ibc_transfer tx_msg_ibc_transfer
+# TYPE tx_msg_ibc_transfer gauge
+tx_msg_ibc_transfer{denom="erc20/tether/usdt"} 2e+06
+tx_msg_ibc_transfer{denom="transfer/channel-0/uatom"} 2.0859632e+08
+tx_msg_ibc_transfer{denom="transfer/channel-1/uosmo"} 6.3302048e+07
+tx_msg_ibc_transfer{denom="transfer/channel-5/uakt"} 5.3115804e+07
+tx_msg_ibc_transfer{denom="ukava"} 8e+07
+# HELP tx_msg_send tx_msg_send
+# TYPE tx_msg_send gauge
+tx_msg_send{denom="hard"} 5.488159744e+09
+tx_msg_send{denom="ukava"} 6.06049984e+08
+# HELP tx_msg_withdraw_commission tx_msg_withdraw_commission
+# TYPE tx_msg_withdraw_commission gauge
+tx_msg_withdraw_commission{denom="ukava"} 2.0446668e+07
+# HELP tx_msg_withdraw_reward tx_msg_withdraw_reward
+# TYPE tx_msg_withdraw_reward gauge
+tx_msg_withdraw_reward{denom=""} 0
+tx_msg_withdraw_reward{denom="ukava"} 342625
+# HELP tx_successful tx_successful
+# TYPE tx_successful counter
+tx_successful 58184

--- a/prometheus.docker-compose.yml
+++ b/prometheus.docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  prometheus_data: {}
+
+services:
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    networks:
+      - monitoring
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    expose:
+      - 9090
+    networks:
+      - monitoring

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+scrape_configs:
+- job_name: proxy
+  scheme: https
+  metrics_path: /
+  static_configs:
+    - targets:
+      - 4efb-18-207-102-158.ngrok-free.app


### PR DESCRIPTION
## Description
- add docs on how to enable, collect and display kava app telemetry using prometheus and grafana
- add docker compose config for running prometheus and grafana services locally
- add example prometheus config for collecting metrics from remote host
- add example of telemetry emitted by application when telemetry is enabled

## Checklist
 - [x] Changelog has been updated as necessary.
