### PR TITLE
build: inject brew deps for MacOS rocksdb build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,13 @@ ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
   CGO_ENABLED=1
   BUILD_TAGS += rocksdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb
+	# inject brew dependencies on mac
+	# this assumes that if you are building on mac, you've installed
+	# rocksdb, snappy, lz4, and zstd via brew
+	ifeq ($(NATIVE_GO_OS),darwin)
+		export CGO_CFLAGS := -I$(shell brew --prefix rocksdb)/include
+		export CGO_LDFLAGS := -L$(shell brew --prefix rocksdb)/lib -lrocksdb -lstdc++ -lm -lz -L$(shell brew --prefix snappy)/lib -L$(shell brew --prefix lz4)/lib -L$(shell brew --prefix zstd)/lib
+	endif
 endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))

--- a/Makefile
+++ b/Makefile
@@ -162,13 +162,6 @@ ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
   CGO_ENABLED=1
   BUILD_TAGS += rocksdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb
-	# inject brew dependencies on mac
-	# this assumes that if you are building on mac, you've installed
-	# rocksdb, snappy, lz4, and zstd via brew
-	ifeq ($(NATIVE_GO_OS),darwin)
-		export CGO_CFLAGS := -I$(shell brew --prefix rocksdb)/include
-		export CGO_LDFLAGS := -L$(shell brew --prefix rocksdb)/lib -lrocksdb -lstdc++ -lm -lz -L$(shell brew --prefix snappy)/lib -L$(shell brew --prefix lz4)/lib -L$(shell brew --prefix zstd)/lib
-	endif
 endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))
@@ -202,6 +195,14 @@ endif
 
 build-linux: go.sum
 	LEDGER_ENABLED=false GOOS=linux GOARCH=amd64 $(MAKE) build
+
+# build on rocksdb-backed kava on macOS with shared libs from brew
+# this assumes you are on macOS & these deps have been installed with brew:
+# rocksdb, snappy, lz4, and zstd
+# use like `make build-rocksdb-brew COSMOS_BUILD_OPTIONS=rocksdb`
+build-rocksdb-brew:
+	export CGO_CFLAGS := -I$(shell brew --prefix rocksdb)/include
+	export CGO_LDFLAGS := -L$(shell brew --prefix rocksdb)/lib -lrocksdb -lstdc++ -lm -lz -L$(shell brew --prefix snappy)/lib -L$(shell brew --prefix lz4)/lib -L$(shell brew --prefix zstd)/lib
 
 install: go.sum
 	$(GO_BIN) install -mod=readonly $(BUILD_FLAGS) ./cmd/kava


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Handles linking necessary dependencies installed via brew when building with rocksdb on MacOS.

Not sure if having installed all these through brew is what we want to enforce on mac. This will cause build failures if you've installed any of the dependencies from source (the linker will complain that the corresponding `/opt/homebrew/opt/*` directory does not exist).

## Checklist
 - [x] ~~Changelog has been updated as necessary.~~
