### PR TITLE
add github action for manually triggering protonet cd

### DIFF
--- a/.github/workflows/cd-protonet-manual.yml
+++ b/.github/workflows/cd-protonet-manual.yml
@@ -1,0 +1,56 @@
+name: Manual Deployment (Protonet)
+# allow to be triggered manually
+on: workflow_dispatch
+
+jobs:
+# in order:
+  # enter standby (prevents autoscaling group from killing node during deploy)
+  # stop kava
+  # take ebs + zfs snapshots
+  # download updated binary and genesis
+  # reset application database state (only done on internal testnet)
+  reset-chain-to-zero-state:
+    # only start cd pipeline if last ci run was successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/cd-reset-internal-testnet.yml
+    with:
+      aws-region: us-east-1
+      chain-id: proto_2221-17000
+      ssm-document-name: kava-testnet-internal-node-update
+      playbook-name: reset-protonet-playbook.yml
+      playbook-infrastructure-branch: master
+    secrets: inherit
+
+  # start kava with new binary and genesis state on api, peer and seed nodes, place nodes in service once they start and are synched to live
+  start-chain-api:
+    uses: ./.github/workflows/cd-start-chain.yml
+    with:
+      aws-region: us-east-1
+      chain-id: proto_2221-17000
+      ssm-document-name: kava-testnet-internal-node-update
+      playbook-name: start-chain-api-playbook.yml
+      playbook-infrastructure-branch: master
+    secrets: inherit
+    needs: [reset-chain-to-zero-state]
+
+  # setup test and development accounts and balances, deploy contracts by calling the chain's api
+  seed-chain-state:
+    uses: ./.github/workflows/cd-seed-chain.yml
+    with:
+      chain-api-url: https://rpc.app.protonet.us-east.production.kava.io:443
+      chain-id: proto_2221-17000
+      seed-script-filename: seed-protonet.sh
+      erc20-deployer-network-name: protonet
+      genesis_validator_addresses: "kavavaloper14w4avgdvqrlpww6l5dhgj4egfn6ln7gmtp7r2m"
+      kava_version_filepath:  ./ci/env/kava-protonet/KAVA.VERSION
+    secrets: inherit
+    needs: [start-chain-api]
+  post-pipeline-metrics:
+    uses: ./.github/workflows/metric-pipeline.yml
+    if: always() # always run so we metric failures and successes
+    with:
+      aws-region: us-east-1
+      metric-name: kava.deploys.testnet.proto
+      namespace: Kava/ContinuousDeployment
+    secrets: inherit
+    needs: [seed-chain-state]


### PR DESCRIPTION
- provides an alternative to premature merging to master in order to test out code changes on a live network ([e.g. #1814](https://github.com/Kava-Labs/kava/pull/1814))