### PR TITLE
use broadcast mode sync vs block in cli scripts

### DIFF
--- a/.github/scripts/examples/force-update-module-params.sh
+++ b/.github/scripts/examples/force-update-module-params.sh
@@ -33,7 +33,7 @@ kava config chain-id "${CHAIN_ID}"
 kava config keyring-backend test
 
 # wait for transactions to be committed per CLI command
-kava config broadcast-mode block
+kava config broadcast-mode sync
 
 # setup god's wallet
 echo "${KAVA_TESTNET_GOD_MNEMONIC}" | kava keys add --recover god

--- a/.github/scripts/seed-internal-testnet.sh
+++ b/.github/scripts/seed-internal-testnet.sh
@@ -9,7 +9,7 @@ kava config chain-id "${CHAIN_ID}"
 kava config keyring-backend test
 
 # wait for transactions to be committed per CLI command
-kava config broadcast-mode block
+kava config broadcast-mode sync
 
 # setup dev wallet
 echo "${DEV_WALLET_MNEMONIC}" | kava keys add --recover dev-wallet

--- a/.github/scripts/seed-protonet.sh
+++ b/.github/scripts/seed-protonet.sh
@@ -9,7 +9,7 @@ kava config chain-id "${CHAIN_ID}"
 kava config keyring-backend test
 
 # wait for transactions to be committed per CLI command
-kava config broadcast-mode block
+kava config broadcast-mode sync
 
 # setup dev wallet
 echo "${DEV_WALLET_MNEMONIC}" | kava keys add --recover dev-wallet

--- a/contrib/devnet/init-new-chain.sh
+++ b/contrib/devnet/init-new-chain.sh
@@ -106,4 +106,4 @@ jq '.app_state.earn.params.allowed_vaults =  [
 jq '.app_state.savings.params.supported_denoms = ["bkava-kavavaloper1ffv7nhd3z6sych2qpqkk03ec6hzkmufyz4scd0"]' $DATA/config/genesis.json | sponge $DATA/config/genesis.json
 
 
-$BINARY config broadcast-mode block
+$BINARY config broadcast-mode sync


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Removes use of previously deprecated and now un-supported kava cli flag `block`
https://github.com/cosmos/cosmos-sdk/pull/12659

## Checklist
 - [x] Changelog has been updated as necessary.
