### PR TITLE
emulate block broadcast mode in seed scripts 

### DIFF
--- a/.github/workflows/cd-seed-chain.yml
+++ b/.github/workflows/cd-seed-chain.yml
@@ -76,8 +76,8 @@ jobs:
       - name: compile default erc20 contracts
         run: make compile-contracts
         working-directory: kava-bridge
-      - name: download seed script from master
-        run: wget https://raw.githubusercontent.com/Kava-Labs/kava/master/.github/scripts/${SEED_SCRIPT_FILENAME} && chmod +x ${SEED_SCRIPT_FILENAME}
+      - name: download seed script from current commit
+        run: wget https://raw.githubusercontent.com/Kava-Labs/kava/${GITHUB_SHA}/.github/scripts/${SEED_SCRIPT_FILENAME} && chmod +x ${SEED_SCRIPT_FILENAME}
         working-directory: kava-bridge/contract
         env:
           SEED_SCRIPT_FILENAME: ${{ inputs.seed-script-filename }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
With the Kava 16 release, `block` broadcast mode is no longer supported in the CLI. In order to allow the seed script for protonet and internal testnet to continue to function, those scripts have been updated to sleep one (average) block time in between tx's to avoid race conditions / account sequence number mismatches.

## Checklist
 - [x] Changelog has been updated as necessary.
