### PR TITLE
Change e2e kvtool config template back to master

### DIFF
--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -8,7 +8,7 @@ E2E_RUN_KVTOOL_NETWORKS=true
 
 # E2E_KVTOOL_KAVA_CONFIG_TEMPLATE is the kvtool template used to start the chain. See the `kava.configTemplate` flag in kvtool.
 # Note that the config tempalte must support overriding the docker image tag via the KAVA_TAG variable.
-E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="v0.26"
+E2E_KVTOOL_KAVA_CONFIG_TEMPLATE="master"
 
 # E2E_INCLUDE_IBC_TESTS when true will start a 2nd chain & open an IBC channel. It will enable all IBC tests.
 E2E_INCLUDE_IBC_TESTS=true


### PR DESCRIPTION
Change the e2e template back to master. This was incorrectly changed to v26 in https://github.com/Kava-Labs/kava/pull/1811