### PR TITLE
cli: refactor shard command & add recovery options

### DIFF
--- a/cmd/kava/cmd/app.go
+++ b/cmd/kava/cmd/app.go
@@ -31,6 +31,7 @@ import (
 const (
 	flagMempoolEnableAuth    = "mempool.enable-authentication"
 	flagMempoolAuthAddresses = "mempool.authorized-addresses"
+	flagSkipLoadLatest       = "skip-load-latest"
 )
 
 // appCreator holds functions used by the sdk server to control the kava app.
@@ -101,10 +102,15 @@ func (ac appCreator) newApp(
 		chainID = appGenesis.ChainID
 	}
 
+	skipLoadLatest := false
+	if appOpts.Get(flagSkipLoadLatest) != nil {
+		skipLoadLatest = cast.ToBool(appOpts.Get(flagSkipLoadLatest))
+	}
+
 	return app.NewApp(
 		logger, db, homeDir, traceStore, ac.encodingConfig,
 		app.Options{
-			SkipLoadLatest:        false,
+			SkipLoadLatest:        skipLoadLatest,
 			SkipUpgradeHeights:    skipUpgradeHeights,
 			SkipGenesisInvariants: cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants)),
 			InvariantCheckPeriod:  cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),

--- a/cmd/kava/cmd/shard.go
+++ b/cmd/kava/cmd/shard.go
@@ -63,7 +63,9 @@ $ kava shard --home path/to/.kava --start 5000000 --end -1
 Prune first 1M blocks _without_ affecting blockstore or cometBFT state:
 $ kava shard --home path/to/.kava --start 1000000 --end -1 --only-app-state`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// read & validate flags
+			//////////////////////////
+			// parse & validate flags
+			//////////////////////////
 			startBlock, err := cmd.Flags().GetInt64(flagShardStartBlock)
 			if err != nil {
 				return err
@@ -93,6 +95,9 @@ $ kava shard --home path/to/.kava --start 1000000 --end -1 --only-app-state`,
 			ctx := server.GetServerContextFromCmd(cmd)
 			ctx.Config.SetRoot(clientCtx.HomeDir)
 
+			////////////////////////
+			// manage db connection
+			////////////////////////
 			// connect to database
 			db, err := opts.DBOpener(ctx.Viper, clientCtx.HomeDir, server.GetAppDBBackend(ctx.Viper))
 			if err != nil {
@@ -106,6 +111,9 @@ $ kava shard --home path/to/.kava --start 1000000 --end -1 --only-app-state`,
 				}
 			}()
 
+			///////////////////
+			// load multistore
+			///////////////////
 			// create app in order to load the multistore
 			// skip loading the latest version so the desired height can be manually loaded
 			ctx.Viper.Set("skip-load-latest", true)

--- a/cmd/kava/cmd/shard.go
+++ b/cmd/kava/cmd/shard.go
@@ -37,7 +37,7 @@ const (
 
 func newShardCmd(opts ethermintserver.StartOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "shard --home <path-to-home-dir> --start <start-block> --end <end-block> [--only-app-state] [--force-app-version <app-version>]",
+		Use:   "shard --home <path-to-home-dir> --start <start-block> --end <end-block> [--only-app-state] [--only-cometbft-state] [--force-app-version <app-version>]",
 		Short: "Strip all blocks from the database outside of a given range",
 		Long: `shard opens a local kava home directory's databases and removes all blocks outside a range defined by --start and --end. The range is inclusive of the end block.
 

--- a/cmd/kava/cmd/shard.go
+++ b/cmd/kava/cmd/shard.go
@@ -253,10 +253,14 @@ func shardCometBftDbs(blockStore *store.BlockStore, stateStore tmstate.Store, st
 	// rollback tendermint db
 	height := latest
 	for height > endBlock {
+		beforeRollbackHeight := height
 		printRollbackProgress(height - 1)
 		height, _, err = tmstate.Rollback(blockStore, stateStore, true)
 		if err != nil {
-			return fmt.Errorf("failed to rollback tendermint state: %w", err)
+			return fmt.Errorf("failed to rollback cometbft state: %w", err)
+		}
+		if beforeRollbackHeight == height {
+			return fmt.Errorf("attempting to rollback cometbft state height %d failed (no rollback performed)", height)
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Adds some flags that help recover from prematurely terminated shard command runs:
* `--only-cometbft-state` - like `--only-app-state` but for only sharding blockstore & state dbs. useful when shard command is terminated after application.db is sharded but before sharding of cometbft dbs finishes
* `--force-app-version` - load the application.db from a specific state. also useful for recovering from cancelled runs. when the blockstore's latest version is different from the application stores, app creation will panic at the `LoadLatestVersion` call. bypass that by forcibly loading the multistore at a specified height
     * to support this, i needed to expose the existing SkipLoadLatest option in appOpts 

Also refactors command into more clearly defined steps:
1. shard application.db
2. shard blockstore.db and state.db

