### PR TITLE
Fund internal testnet e2e account with USDt

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -583,6 +583,10 @@
               "amount": "1000000000"
             },
             {
+              "denom": "erc20/tether/usdt",
+              "amount": "100000000000"
+            },
+            {
               "denom": "hard",
               "amount": "1000000000"
             },


### PR DESCRIPTION
## Description

- Adds `erc20/tether/usdt` to the account that funds internal testnet wallet used by the frontend E2E suite

