### PR TITLE
target all internal testnet instances on update

### DIFF
--- a/.github/workflows/cd-reset-internal-testnet.yml
+++ b/.github/workflows/cd-reset-internal-testnet.yml
@@ -67,7 +67,6 @@ jobs:
             --update-playbook-filename=$PLAYBOOK_NAME \
             --chain-id=$CHAIN_ID \
             --max-upgrade-batch-size=0 \
-            --node-states=Standby \
             --wait-for-node-sync-after-upgrade=false
         env:
           SSM_DOCUMENT_NAME: ${{ inputs.ssm-document-name }}


### PR DESCRIPTION
## Description
partial successes from multiple deploys (now less likely thanks to #1842) would result in instances that needed resetting to not get targeted. this removes the condition and force resets & updates all internal testnet instances, regardless of current state.

i ran the resulting command locally and it successfully reset the entire network 👍 
