### PR TITLE
test scaffolding for evmutil conversion of BNB coin to ERC20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (validator-vesting) [#1832] Add grpc query service to replace removed legacy querier
 - (incentive) [#1836] Update x/incentive cli to use grpc query client
 - (ibc) [#1839] Add ibc packet forward middleware for ibc transfers
+- (evmutil) [#1848] Update evm native conversion logic to handle bep3 assets
 
 ## [v0.25.0]
 
@@ -327,6 +328,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1848]: https://github.com/Kava-Labs/kava/pull/1848
 [#1839]: https://github.com/Kava-Labs/kava/pull/1839
 [#1836]: https://github.com/Kava-Labs/kava/pull/1836
 [#1832]: https://github.com/Kava-Labs/kava/pull/1832

--- a/x/evmutil/keeper/conversion_evm_native_bep3.go
+++ b/x/evmutil/keeper/conversion_evm_native_bep3.go
@@ -1,0 +1,38 @@
+package keeper
+
+import (
+	"math/big"
+
+	"github.com/kava-labs/kava/x/evmutil/types"
+)
+
+var (
+	DefaultBEP3ConversionDenoms = []string{"bnb", "busd", "btcb", "xrpb"}
+)
+
+// IsEvmNativeBep3Conversion returns true if the given pair is a BEP3 conversion pair.
+func IsEvmNativeBep3Conversion(pair types.ConversionPair) bool {
+	for _, denom := range DefaultBEP3ConversionDenoms {
+		if pair.Denom == denom {
+			return true
+		}
+	}
+	return false
+}
+
+// ConvertBep3CoinAmountToERC20Amount converts a bep3 coin amount with 8 decimals
+// to the equivalent ERC20 token with 18 decimals.
+func ConvertBep3CoinAmountToERC20Amount(amount *big.Int) *big.Int {
+	multiplier := new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil)
+	result := new(big.Int).Mul(amount, multiplier) // amount * 10^10
+	return result
+}
+
+// ConvertBep3ERC20AmountToCoinAmount converts a bep3 ERC20 token with 18 decimals
+// to the equivalent coin amount with 8 decimals, and returning the remainder.
+func ConvertBep3ERC20AmountToCoinAmount(amount *big.Int) (*big.Int, *big.Int) {
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil)
+	quotient := new(big.Int).Div(amount, divisor)
+	remainder := new(big.Int).Mod(amount, divisor)
+	return quotient, remainder
+}

--- a/x/evmutil/types/errors.go
+++ b/x/evmutil/types/errors.go
@@ -4,11 +4,12 @@ import errorsmod "cosmossdk.io/errors"
 
 // errors
 var (
-	ErrABIPack                 = errorsmod.Register(ModuleName, 2, "contract ABI pack failed")
-	ErrEVMCall                 = errorsmod.Register(ModuleName, 3, "EVM call unexpected error")
-	ErrEVMConversionNotEnabled = errorsmod.Register(ModuleName, 4, "ERC20 token not enabled to convert to sdk.Coin")
-	ErrBalanceInvariance       = errorsmod.Register(ModuleName, 5, "post EVM transfer balance invariant failed")
-	ErrUnexpectedContractEvent = errorsmod.Register(ModuleName, 6, "unexpected contract event")
-	ErrInvalidCosmosDenom      = errorsmod.Register(ModuleName, 7, "invalid cosmos denom")
-	ErrSDKConversionNotEnabled = errorsmod.Register(ModuleName, 8, "sdk.Coin not enabled to convert to ERC20 token")
+	ErrABIPack                      = errorsmod.Register(ModuleName, 2, "contract ABI pack failed")
+	ErrEVMCall                      = errorsmod.Register(ModuleName, 3, "EVM call unexpected error")
+	ErrEVMConversionNotEnabled      = errorsmod.Register(ModuleName, 4, "ERC20 token not enabled to convert to sdk.Coin")
+	ErrBalanceInvariance            = errorsmod.Register(ModuleName, 5, "post EVM transfer balance invariant failed")
+	ErrUnexpectedContractEvent      = errorsmod.Register(ModuleName, 6, "unexpected contract event")
+	ErrInvalidCosmosDenom           = errorsmod.Register(ModuleName, 7, "invalid cosmos denom")
+	ErrSDKConversionNotEnabled      = errorsmod.Register(ModuleName, 8, "sdk.Coin not enabled to convert to ERC20 token")
+	ErrInsufficientConversionAmount = errorsmod.Register(ModuleName, 9, "insufficient conversion amount")
 )

--- a/x/evmutil/types/msg_test.go
+++ b/x/evmutil/types/msg_test.go
@@ -37,6 +37,15 @@ func TestMsgConvertCoinToERC20(t *testing.T) {
 			},
 		},
 		{
+			"valid-bnb",
+			"kava123fxg0l602etulhhcdm0vt7l57qya5wjcrwhzz",
+			"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+			sdk.NewCoin("bnb", sdkmath.NewInt(1234)),
+			errArgs{
+				expectPass: true,
+			},
+		},
+		{
 			"invalid - odd length hex address",
 			"kava123fxg0l602etulhhcdm0vt7l57qya5wjcrwhzz",
 			"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc",


### PR DESCRIPTION
## Description
Adds test for new functionality targeted for Kava v0.26 to convert BNB coins to ERC20 as part of BInance's BEP3 deprecation and migration roadmap.

## Checklist
 - [x] Changelog has been updated as necessary.
