### PR TITLE
Set the CDP Block Interval to 100 during v0.26.x upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -123,6 +123,16 @@ func upgradeHandler(
 		// dedicated x/consensus module.
 		baseapp.MigrateParams(ctx, baseAppLegacySS, &app.consensusParamsKeeper)
 
-		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		// run migrations for all modules and return new consensus version map
+		versionMap, err := app.mm.RunMigrations(ctx, app.configurator, fromVM)
+
+		// Set risky CDP's to sync interest and liquidate every 100 blocks instead
+		// of every block.  This significantly improves performance as this cdp
+		// process is a signification porition of time spent during block execution.
+		cdpParams := app.cdpKeeper.GetParams(ctx)
+		cdpParams.LiquidationBlockInterval = int64(100)
+		app.cdpKeeper.SetParams(ctx, cdpParams)
+
+		return versionMap, err
 	}
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -27,6 +27,8 @@ import (
 const (
 	UpgradeName_Mainnet = "v0.26.0"
 	UpgradeName_Testnet = "v0.26.0-alpha.0"
+
+	CDPLiquidationBlockInterval = int64(50)
 )
 
 // RegisterUpgradeHandlers registers the upgrade handlers for the app.
@@ -130,7 +132,7 @@ func upgradeHandler(
 		// of every block.  This significantly improves performance as this cdp
 		// process is a signification porition of time spent during block execution.
 		cdpParams := app.cdpKeeper.GetParams(ctx)
-		cdpParams.LiquidationBlockInterval = int64(100)
+		cdpParams.LiquidationBlockInterval = CDPLiquidationBlockInterval
 		app.cdpKeeper.SetParams(ctx, cdpParams)
 
 		return versionMap, err

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	cdptypes "github.com/kava-labs/kava/x/cdp/types"
 )
 
 func (suite *IntegrationTestSuite) TestUpgradeParams_SDK() {
@@ -96,6 +97,26 @@ func (suite *IntegrationTestSuite) TestUpgradeParams_Consensus() {
 		Version: nil,
 	}
 	suite.Require().Equal(expectedParams, *paramsAfter.Params, "x/consensus params after upgrade should be as expected")
+}
+
+func (suite *IntegrationTestSuite) TestUpgradeParams_CDP_Interval() {
+	suite.SkipIfUpgradeDisabled()
+
+	beforeUpgradeCtx := suite.Kava.Grpc.CtxAtHeight(suite.UpgradeHeight - 1)
+	afterUpgradeCtx := suite.Kava.Grpc.CtxAtHeight(suite.UpgradeHeight)
+
+	grpcClient := suite.Kava.Grpc
+
+	paramsBefore, err := grpcClient.Query.Cdp.Params(beforeUpgradeCtx, &cdptypes.QueryParamsRequest{})
+	suite.Require().NoError(err)
+	paramsAfter, err := grpcClient.Query.Cdp.Params(afterUpgradeCtx, &cdptypes.QueryParamsRequest{})
+	suite.Require().NoError(err)
+
+	expectedParams := paramsBefore.Params
+	expectedParams.LiquidationBlockInterval = int64(100)
+
+	suite.Require().Equal(expectedParams, paramsAfter.Params,
+		"expected cdp parameters to equal previous parameters with a liquidation block interval of 100")
 }
 
 func mustParseDuration(s string) *time.Duration {

--- a/tests/e2e/e2e_upgrade_handler_test.go
+++ b/tests/e2e/e2e_upgrade_handler_test.go
@@ -113,7 +113,7 @@ func (suite *IntegrationTestSuite) TestUpgradeParams_CDP_Interval() {
 	suite.Require().NoError(err)
 
 	expectedParams := paramsBefore.Params
-	expectedParams.LiquidationBlockInterval = int64(100)
+	expectedParams.LiquidationBlockInterval = int64(50)
 
 	suite.Require().Equal(expectedParams, paramsAfter.Params,
 		"expected cdp parameters to equal previous parameters with a liquidation block interval of 100")


### PR DESCRIPTION
This updates the CDP parameters to have a liquidation block interval of 100, instead of the default value of 1.

Since the interest synchronization and the liquidation process makes up a substantial portion of block time, this has a significant impact on block execution performance.

The included E2E ensures that no other parameters are changed from before upgrade along with verifying that the liquidation interval is correctly set.
