### PR TITLE
ci: start all internal testnet regardless of state

### DIFF
--- a/.github/workflows/cd-start-chain.yml
+++ b/.github/workflows/cd-start-chain.yml
@@ -63,7 +63,6 @@ jobs:
             --update-playbook-filename=$PLAYBOOK_NAME \
             --chain-id=$CHAIN_ID \
             --max-upgrade-batch-size=0 \
-            --node-states=Standby \
             --wait-for-node-sync-after-upgrade=true
         env:
           SSM_DOCUMENT_NAME: ${{ inputs.ssm-document-name }}


### PR DESCRIPTION
even if the nodes are not in standby, target them for the start job in the internal testnet deployment CI
