### PR TITLE
ci: extract separate rocksdb base image

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -50,6 +50,17 @@ jobs:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v3
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: inject go-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: go-build-cache
+
       # publish to docker hub, tag with short git hash
       - name: Build and push (goleveldb)
         uses: docker/build-push-action@v5
@@ -88,6 +99,17 @@ jobs:
         with:
           username: ${{ inputs.dockerhub-username }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v3
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: inject go-build-cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v2.1.2
+        with:
+          cache-source: go-build-cache
 
       # publish to docker hub, tag with short git hash
       - name: Build and push (rocksdb)

--- a/Dockerfile-rocksdb
+++ b/Dockerfile-rocksdb
@@ -1,23 +1,6 @@
-FROM golang:1.21-bullseye AS kava-builder
+FROM kava/rocksdb:v8.10.1-go1.21 AS kava-builder
 
-# Set up dependencies
-RUN apt-get update \
-    && apt-get install -y git make gcc libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set working directory for the build
-WORKDIR /root
-# default home directory is /root
-
-# install rocksdb
-ARG rocksdb_version=v8.10.0
-ENV ROCKSDB_VERSION=$rocksdb_version
-
-RUN git clone https://github.com/facebook/rocksdb.git \
-    && cd rocksdb \
-    && git checkout $ROCKSDB_VERSION \
-    && make -j$(nproc) install-shared \
-    && ldconfig
+RUN apt-get update
 
 WORKDIR /root/kava
 # Copy dependency files first to facilitate dependency caching

--- a/Dockerfile-rocksdb-base
+++ b/Dockerfile-rocksdb-base
@@ -1,0 +1,22 @@
+# published to https://hub.docker.com/repository/docker/kava/rocksdb/tags
+# docker buildx build --platform linux/amd64,linux/arm64 -t kava/rocksdb:v8.10.1-go1.21 -f Dockerfile-rocksdb-base . --push
+FROM golang:1.21-bullseye
+
+# Set up dependencies
+RUN apt-get update \
+    && apt-get install -y git make gcc libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory for the build
+WORKDIR /root
+# default home directory is /root
+
+# install rocksdb
+ARG rocksdb_version=v8.10.0
+ENV ROCKSDB_VERSION=$rocksdb_version
+
+RUN git clone https://github.com/facebook/rocksdb.git \
+    && cd rocksdb \
+    && git checkout $ROCKSDB_VERSION \
+    && make -j$(nproc) install-shared \
+    && ldconfig


### PR DESCRIPTION
## Description
I pulled out the golang & rocksdb installation into a base container that is published to `kava/rocksdb` docker repo. This should shorten the rocksdb container build time on merge to master by ~1.5hr.

Additionally, I updated the docker build & push CI commands to inject the go build cache into the docker building which should further shorten the Github Action CI time for merges to master.