### PR TITLE
fix(x/precisebank): Ensure exact reserve balance on integer carry when minting

### DIFF
--- a/x/precisebank/keeper/invariants.go
+++ b/x/precisebank/keeper/invariants.go
@@ -14,7 +14,7 @@ func RegisterInvariants(
 	k Keeper,
 	bk types.BankKeeper,
 ) {
-	ir.RegisterRoute(types.ModuleName, "reserve-backing-fractional", ReserveBackingFractionalInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "reserve-backs-fractions", ReserveBacksFractionsInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "balance-remainder-total", BalancedFractionalTotalInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "valid-fractional-balances", ValidFractionalAmountsInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "valid-remainder-amount", ValidRemainderAmountInvariant(k))
@@ -24,7 +24,7 @@ func RegisterInvariants(
 // AllInvariants runs all invariants of the X/precisebank module.
 func AllInvariants(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
-		res, stop := ReserveBackingFractionalInvariant(k)(ctx)
+		res, stop := ReserveBacksFractionsInvariant(k)(ctx)
 		if stop {
 			return res, stop
 		}
@@ -53,12 +53,12 @@ func AllInvariants(k Keeper) sdk.Invariant {
 	}
 }
 
-// ReserveBackingFractionalInvariant checks that the total amount of backing
+// ReserveBacksFractionsInvariant checks that the total amount of backing
 // coins in the reserve is equal to the total amount of fractional balances,
 // such that the backing is always available to redeem all fractional balances
 // and there are no extra coins in the reserve that are not backing any
 // fractional balances.
-func ReserveBackingFractionalInvariant(k Keeper) sdk.Invariant {
+func ReserveBacksFractionsInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var (
 			msg    string

--- a/x/precisebank/keeper/invariants.go
+++ b/x/precisebank/keeper/invariants.go
@@ -77,17 +77,15 @@ func ReserveBacksFractionsInvariant(k Keeper) sdk.Invariant {
 		// fractional balances + remainder amount
 		totalRequiredBacking := fractionalBalSum.Add(remainderAmount)
 
-		if !reserveExtendedBalance.Equal(totalRequiredBacking) {
-			msg = fmt.Sprintf(
-				"%s reserve balance %s mismatches %s (fractional balances %s + remainder %s)\n",
-				types.ExtendedCoinDenom,
-				reserveExtendedBalance,
-				totalRequiredBacking,
-				fractionalBalSum,
-				remainderAmount,
-			)
-			broken = true
-		}
+		broken = !reserveExtendedBalance.Equal(totalRequiredBacking)
+		msg = fmt.Sprintf(
+			"%s reserve balance %s mismatches %s (fractional balances %s + remainder %s)\n",
+			types.ExtendedCoinDenom,
+			reserveExtendedBalance,
+			totalRequiredBacking,
+			fractionalBalSum,
+			remainderAmount,
+		)
 
 		return sdk.FormatInvariant(
 			types.ModuleName, "reserve-backing-fractional",

--- a/x/precisebank/keeper/invariants.go
+++ b/x/precisebank/keeper/invariants.go
@@ -88,7 +88,7 @@ func ReserveBacksFractionsInvariant(k Keeper) sdk.Invariant {
 		)
 
 		return sdk.FormatInvariant(
-			types.ModuleName, "reserve-backing-fractional",
+			types.ModuleName, "module reserve backing total fractional balances",
 			msg,
 		), broken
 	}

--- a/x/precisebank/keeper/invariants_integration_test.go
+++ b/x/precisebank/keeper/invariants_integration_test.go
@@ -107,7 +107,7 @@ func (suite *invariantsIntegrationTestSuite) TestReserveBackingFractionalInvaria
 
 			tt.setupFn(suite.Ctx, suite.Keeper)
 
-			invariantFn := keeper.ReserveBackingFractionalInvariant(suite.Keeper)
+			invariantFn := keeper.ReserveBacksFractionsInvariant(suite.Keeper)
 			msg, broken := invariantFn(suite.Ctx)
 
 			if tt.wantBroken {

--- a/x/precisebank/keeper/invariants_integration_test.go
+++ b/x/precisebank/keeper/invariants_integration_test.go
@@ -1,0 +1,121 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kava-labs/kava/x/precisebank/keeper"
+	"github.com/kava-labs/kava/x/precisebank/testutil"
+	"github.com/kava-labs/kava/x/precisebank/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type invariantsIntegrationTestSuite struct {
+	testutil.Suite
+}
+
+func (suite *invariantsIntegrationTestSuite) SetupTest() {
+	suite.Suite.SetupTest()
+}
+
+func TestInvariantsIntegrationTest(t *testing.T) {
+	suite.Run(t, new(invariantsIntegrationTestSuite))
+}
+
+func (suite *invariantsIntegrationTestSuite) FundReserve(amt sdkmath.Int) {
+	coins := sdk.NewCoins(sdk.NewCoin(types.IntegerCoinDenom, amt))
+	err := suite.BankKeeper.MintCoins(suite.Ctx, types.ModuleName, coins)
+	suite.Require().NoError(err)
+}
+
+func (suite *invariantsIntegrationTestSuite) TestReserveBackingFractionalInvariant() {
+	tests := []struct {
+		name       string
+		setupFn    func(ctx sdk.Context, k keeper.Keeper)
+		wantBroken bool
+		wantMsg    string
+	}{
+		{
+			"valid - empty state",
+			func(_ sdk.Context, _ keeper.Keeper) {},
+			false,
+			"",
+		},
+		{
+			"valid - fractional balances, no remainder",
+			func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetFractionalBalance(ctx, sdk.AccAddress{1}, types.ConversionFactor().QuoRaw(2))
+				k.SetFractionalBalance(ctx, sdk.AccAddress{2}, types.ConversionFactor().QuoRaw(2))
+				// 1 integer backs same amount fractional
+				suite.FundReserve(sdk.NewInt(1))
+			},
+			false,
+			"",
+		},
+		{
+			"valid - fractional balances, with remainder",
+			func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetFractionalBalance(ctx, sdk.AccAddress{1}, types.ConversionFactor().QuoRaw(2))
+				k.SetRemainderAmount(ctx, types.ConversionFactor().QuoRaw(2))
+				// 1 integer backs same amount fractional including remainder
+				suite.FundReserve(sdk.NewInt(1))
+			},
+			false,
+			"",
+		},
+		{
+			"invalid - insufficient reserve backing",
+			func(ctx sdk.Context, k keeper.Keeper) {
+				amt := types.ConversionFactor().QuoRaw(2)
+
+				// 0.5 int coins x 4
+				k.SetFractionalBalance(ctx, sdk.AccAddress{1}, amt)
+				k.SetFractionalBalance(ctx, sdk.AccAddress{2}, amt)
+				k.SetFractionalBalance(ctx, sdk.AccAddress{3}, amt)
+				k.SetRemainderAmount(ctx, amt)
+
+				// Needs 2 to back 0.5 x 4
+				suite.FundReserve(sdk.NewInt(1))
+			},
+			true,
+			"precisebank: reserve-backing-fractional invariant\nakava reserve balance 1000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
+		},
+		{
+			"invalid - excess reserve backing",
+			func(ctx sdk.Context, k keeper.Keeper) {
+				amt := types.ConversionFactor().QuoRaw(2)
+
+				// 0.5 int coins x 4
+				k.SetFractionalBalance(ctx, sdk.AccAddress{1}, amt)
+				k.SetFractionalBalance(ctx, sdk.AccAddress{2}, amt)
+				k.SetFractionalBalance(ctx, sdk.AccAddress{3}, amt)
+				k.SetRemainderAmount(ctx, amt)
+
+				// Needs 2 to back 0.5 x 4
+				suite.FundReserve(sdk.NewInt(3))
+			},
+			true,
+			"precisebank: reserve-backing-fractional invariant\nakava reserve balance 3000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			// Reset each time
+			suite.SetupTest()
+
+			tt.setupFn(suite.Ctx, suite.Keeper)
+
+			invariantFn := keeper.ReserveBackingFractionalInvariant(suite.Keeper)
+			msg, broken := invariantFn(suite.Ctx)
+
+			if tt.wantBroken {
+				suite.Require().True(broken, "invariant should be broken but is not")
+				suite.Require().Equal(tt.wantMsg, msg)
+			} else {
+				suite.Require().Falsef(broken, "invariant should not be broken but is: %s", msg)
+			}
+		})
+	}
+}

--- a/x/precisebank/keeper/invariants_integration_test.go
+++ b/x/precisebank/keeper/invariants_integration_test.go
@@ -65,6 +65,14 @@ func (suite *invariantsIntegrationTestSuite) TestReserveBackingFractionalInvaria
 			"",
 		},
 		{
+			"invalid - no fractional balances, non-zero remainder",
+			func(ctx sdk.Context, k keeper.Keeper) {
+				k.SetRemainderAmount(ctx, types.ConversionFactor().QuoRaw(2))
+			},
+			true,
+			"precisebank: module reserve backing total fractional balances invariant\nakava reserve balance 0 mismatches 500000000000 (fractional balances 0 + remainder 500000000000)\n\n",
+		},
+		{
 			"invalid - insufficient reserve backing",
 			func(ctx sdk.Context, k keeper.Keeper) {
 				amt := types.ConversionFactor().QuoRaw(2)
@@ -79,7 +87,7 @@ func (suite *invariantsIntegrationTestSuite) TestReserveBackingFractionalInvaria
 				suite.FundReserve(sdk.NewInt(1))
 			},
 			true,
-			"precisebank: reserve-backing-fractional invariant\nakava reserve balance 1000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
+			"precisebank: module reserve backing total fractional balances invariant\nakava reserve balance 1000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
 		},
 		{
 			"invalid - excess reserve backing",
@@ -96,7 +104,7 @@ func (suite *invariantsIntegrationTestSuite) TestReserveBackingFractionalInvaria
 				suite.FundReserve(sdk.NewInt(3))
 			},
 			true,
-			"precisebank: reserve-backing-fractional invariant\nakava reserve balance 3000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
+			"precisebank: module reserve backing total fractional balances invariant\nakava reserve balance 3000000000000 mismatches 2000000000000 (fractional balances 1500000000000 + remainder 500000000000)\n\n",
 		},
 	}
 

--- a/x/precisebank/keeper/mint.go
+++ b/x/precisebank/keeper/mint.go
@@ -136,7 +136,15 @@ func (k Keeper) mintExtendedCoin(
 	// ----------------------------------------
 	// Update remainder & reserves to back minted fractional coins
 	prevRemainder := k.GetRemainderAmount(ctx)
-	// Deduct new remainder with minted fractional amount
+
+	// Deduct new remainder with minted fractional amount. This will result in
+	// two cases:
+	// 1. Zero or positive remainder: remainder is sufficient to back the minted
+	//   fractional amount. Reserve is also sufficient to back the minted amount
+	//   so no additional reserve integer coin is needed.
+	// 2. Negative remainder: remainder is insufficient to back the minted
+	//   fractional amount. Reserve will need to be increased to back the mint
+	//   amount.
 	newRemainder := prevRemainder.Sub(fractionalMintAmount)
 
 	// Mint an additional reserve integer coin if remainder is insufficient.

--- a/x/precisebank/keeper/mint.go
+++ b/x/precisebank/keeper/mint.go
@@ -88,8 +88,7 @@ func (k Keeper) mintExtendedCoin(
 	// fractional amounts x and y where both x and y < ConversionFactor
 	// x + y < (2 * ConversionFactor) - 2
 	// x + y < 1 integer amount + fractional amount
-	hasIntegerCarry := newFractionalBalance.GTE(types.ConversionFactor())
-	if hasIntegerCarry {
+	if newFractionalBalance.GTE(types.ConversionFactor()) {
 		// Carry should send from reserve -> account, instead of minting an
 		// extra integer coin. Otherwise doing an extra mint will require a burn
 		// from reserves to maintain exact backing.

--- a/x/precisebank/testutil/suite.go
+++ b/x/precisebank/testutil/suite.go
@@ -149,11 +149,3 @@ func ConvertCoinsToExtendedCoinDenom(coins sdk.Coins) sdk.Coins {
 
 	return coins.Sub(integerCoin).Add(extendedCoin)
 }
-
-func (suite *Suite) LogReserves() {
-	fractionalBalSum := suite.Keeper.GetTotalSumFractionalBalances(suite.Ctx)
-	remainderAmount := suite.Keeper.GetRemainderAmount(suite.Ctx)
-
-	suite.T().Logf("fractional balances sum: %s", fractionalBalSum.String())
-	suite.T().Logf("remainder amount: %s", remainderAmount.String())
-}

--- a/x/precisebank/testutil/suite.go
+++ b/x/precisebank/testutil/suite.go
@@ -149,3 +149,11 @@ func ConvertCoinsToExtendedCoinDenom(coins sdk.Coins) sdk.Coins {
 
 	return coins.Sub(integerCoin).Add(extendedCoin)
 }
+
+func (suite *Suite) LogReserves() {
+	fractionalBalSum := suite.Keeper.GetTotalSumFractionalBalances(suite.Ctx)
+	remainderAmount := suite.Keeper.GetRemainderAmount(suite.Ctx)
+
+	suite.T().Logf("fractional balances sum: %s", fractionalBalSum.String())
+	suite.T().Logf("remainder amount: %s", remainderAmount.String())
+}

--- a/x/precisebank/types/expected_keepers.go
+++ b/x/precisebank/types/expected_keepers.go
@@ -24,6 +24,7 @@ type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule string, recipientModule string, amt sdk.Coins) error
 
 	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error

--- a/x/precisebank/types/mocks/MockBankKeeper.go
+++ b/x/precisebank/types/mocks/MockBankKeeper.go
@@ -466,6 +466,55 @@ func (_c *MockBankKeeper_SendCoinsFromModuleToAccount_Call) RunAndReturn(run fun
 	return _c
 }
 
+// SendCoinsFromModuleToModule provides a mock function with given fields: ctx, senderModule, recipientModule, amt
+func (_m *MockBankKeeper) SendCoinsFromModuleToModule(ctx types.Context, senderModule string, recipientModule string, amt types.Coins) error {
+	ret := _m.Called(ctx, senderModule, recipientModule, amt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SendCoinsFromModuleToModule")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(types.Context, string, string, types.Coins) error); ok {
+		r0 = rf(ctx, senderModule, recipientModule, amt)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockBankKeeper_SendCoinsFromModuleToModule_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendCoinsFromModuleToModule'
+type MockBankKeeper_SendCoinsFromModuleToModule_Call struct {
+	*mock.Call
+}
+
+// SendCoinsFromModuleToModule is a helper method to define mock.On call
+//   - ctx types.Context
+//   - senderModule string
+//   - recipientModule string
+//   - amt types.Coins
+func (_e *MockBankKeeper_Expecter) SendCoinsFromModuleToModule(ctx interface{}, senderModule interface{}, recipientModule interface{}, amt interface{}) *MockBankKeeper_SendCoinsFromModuleToModule_Call {
+	return &MockBankKeeper_SendCoinsFromModuleToModule_Call{Call: _e.mock.On("SendCoinsFromModuleToModule", ctx, senderModule, recipientModule, amt)}
+}
+
+func (_c *MockBankKeeper_SendCoinsFromModuleToModule_Call) Run(run func(ctx types.Context, senderModule string, recipientModule string, amt types.Coins)) *MockBankKeeper_SendCoinsFromModuleToModule_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(types.Context), args[1].(string), args[2].(string), args[3].(types.Coins))
+	})
+	return _c
+}
+
+func (_c *MockBankKeeper_SendCoinsFromModuleToModule_Call) Return(_a0 error) *MockBankKeeper_SendCoinsFromModuleToModule_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockBankKeeper_SendCoinsFromModuleToModule_Call) RunAndReturn(run func(types.Context, string, string, types.Coins) error) *MockBankKeeper_SendCoinsFromModuleToModule_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SpendableCoins provides a mock function with given fields: ctx, addr
 func (_m *MockBankKeeper) SpendableCoins(ctx types.Context, addr types.AccAddress) types.Coins {
 	ret := _m.Called(ctx, addr)


### PR DESCRIPTION
## Description
- Fix reserve minting an extra coin when the recipient module both carries fractional over to integer balance AND remainder is insufficient.
- Adjusts fractional carry to simply send from reserve, instead of doing an additional mint.
- Add invariant to ensure reserve matches exactly with fractional balances + remainder, failing on both insufficient and excess funds.