### PR TITLE
ci: prefer checkout action to manual pull

### DIFF
--- a/.github/workflows/cd-seed-chain.yml
+++ b/.github/workflows/cd-seed-chain.yml
@@ -35,12 +35,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-      - name: checkout version of kava used by network
+      - name: get desired version of network
+        id: kava-version
         run: |
-          git pull -p
-          git checkout $(cat ${KAVA_VERSION_FILEPATH})
+          echo "KAVA_VERSION=$(cat ./ci/env/kava-internal-testnet/KAVA.VERSION)" >> $GITHUB_OUTPUT
         env:
           KAVA_VERSION_FILEPATH: ${{ inputs.kava_version_filepath }}
+      - name: checkout version of kava used by network
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.kava-version.outputs.KAVA_VERSION }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
for internal testnet deployment, record the desired deployment version as an action variable that can be used by the checkout action instead of using manual pull & checkout commands

