### PR TITLE
cli: add --unsafe-remove-modules flag to Rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [unreleased]
 
+### Features
+- (cli) [#1954] Add `--unsafe-remove-modules` parameter flag to `rollback`
 
 ## [v0.26.1]
 
@@ -340,6 +342,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#1954]: https://github.com/Kava-Labs/kava/pull/1954
 [#1922]: https://github.com/Kava-Labs/kava/pull/1922
 [#1851]: https://github.com/Kava-Labs/kava/pull/1851
 [#1846]: https://github.com/Kava-Labs/kava/pull/1846

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/kava-labs/cometbft v0.37.4-kava.1
 	github.com/cometbft/cometbft-db => github.com/kava-labs/cometbft-db v0.9.1-kava.1
 	// Use cosmos-sdk fork with backported fix for unsafe-reset-all, staking transfer events, and custom tally handler support
-	github.com/cosmos/cosmos-sdk => github.com/kava-labs/cosmos-sdk v0.47.10-kava.1
+	github.com/cosmos/cosmos-sdk => github.com/kava-labs/cosmos-sdk v0.47.10-kava.3
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support

--- a/go.sum
+++ b/go.sum
@@ -872,8 +872,8 @@ github.com/kava-labs/cometbft v0.37.4-kava.1 h1:QRuyBieWdUBpe4pcXgzu1SdMH2lkTaqX
 github.com/kava-labs/cometbft v0.37.4-kava.1/go.mod h1:Cmg5Hp4sNpapm7j+x0xRyt2g0juQfmB752ous+pA0G8=
 github.com/kava-labs/cometbft-db v0.9.1-kava.1 h1:0KmSPdXYdRp6TsgKuMxRnMZCMEGC5ysIVjuJddYr4tw=
 github.com/kava-labs/cometbft-db v0.9.1-kava.1/go.mod h1:iliyWaoV0mRwBJoizElCwwRA9Tf7jZJOURcRZF9m60U=
-github.com/kava-labs/cosmos-sdk v0.47.10-kava.1 h1:Ycu9ep1ggcgltYNLPrwQhHd32zFjN4z1TSCvexipKM0=
-github.com/kava-labs/cosmos-sdk v0.47.10-kava.1/go.mod h1:Pu1s91xgfT6VAUmwqR5wMensfvpGPHXKwA8dXw42+gA=
+github.com/kava-labs/cosmos-sdk v0.47.10-kava.3 h1:Fi+5URpyAoNbnHHBfps9etLV1kLsdaJUlua1KfDzOK4=
+github.com/kava-labs/cosmos-sdk v0.47.10-kava.3/go.mod h1:xgOZMrQ6t8zZ1XFtEPOfzo6oYN/N1dD3qIlwD/rszCo=
 github.com/kava-labs/ethermint v0.21.0-kava-v26.2 h1:TPCwtVkYyyw4RRYkmfLk3WIZRNx1p1FPTCqAxBjPptY=
 github.com/kava-labs/ethermint v0.21.0-kava-v26.2/go.mod h1:D8MKV53Ah21b+Bk78bQUwIwnOGu03TQ19buZXHgEujE=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
bumps cosmos-sdk fork's tag to add new parameter flag to rollback.

rollback command accepts list of store keys names to forcibly delete.

this is useful for rolling back an upgrade that adds modules. rollbacks are performed by loading & committing the previous version. without this new functionality, the rollback will fail because no store version will exist for modules added during the upgrade.

to properly rollback the state, pass in a list of the added module names and they will be completely removed before the rollback of pre-existing modules takes place:
```
chain rollback --unsafe-remove-modules mynewmodule,othernewmodule
```


## Checklist
 - [x] Changelog has been updated as necessary.
