### PR TITLE
feat(x/precisebank): Emit events for send/mint/burn

### DIFF
--- a/x/precisebank/keeper/burn.go
+++ b/x/precisebank/keeper/burn.go
@@ -60,7 +60,7 @@ func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	fullEmissionCoin := getFullExtendedValueAmount(amt)
+	fullEmissionCoin := types.SumExtendedCoin(amt)
 	if fullEmissionCoin.IsZero() {
 		return nil
 	}

--- a/x/precisebank/keeper/burn.go
+++ b/x/precisebank/keeper/burn.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/kava-labs/kava/x/precisebank/types"
 )
 
@@ -52,12 +53,23 @@ func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	// No more processing required if no ExtendedCoinDenom
-	if extendedAmount.IsZero() {
+	// Only burn extended coin if the amount is positive
+	if extendedAmount.IsPositive() {
+		if err := k.burnExtendedCoin(ctx, moduleName, extendedAmount); err != nil {
+			return err
+		}
+	}
+
+	fullEmissionCoin := getFullExtendedValueAmount(amt)
+	if fullEmissionCoin.IsZero() {
 		return nil
 	}
 
-	return k.burnExtendedCoin(ctx, moduleName, extendedAmount)
+	ctx.EventManager().EmitEvent(
+		banktypes.NewCoinBurnEvent(acc.GetAddress(), sdk.NewCoins(fullEmissionCoin)),
+	)
+
+	return nil
 }
 
 // burnExtendedCoin burns the fractional amount of the ExtendedCoinDenom from the module account.

--- a/x/precisebank/keeper/mint.go
+++ b/x/precisebank/keeper/mint.go
@@ -63,7 +63,7 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	fullEmissionCoin := getFullExtendedValueAmount(amt)
+	fullEmissionCoin := types.SumExtendedCoin(amt)
 	if fullEmissionCoin.IsZero() {
 		return nil
 	}

--- a/x/precisebank/keeper/mint.go
+++ b/x/precisebank/keeper/mint.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/kava-labs/kava/x/precisebank/types"
 )
@@ -55,12 +56,23 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	// No more processing required if no ExtendedCoinDenom
-	if extendedAmount.IsZero() {
+	// Only mint extended coin if the amount is positive
+	if extendedAmount.IsPositive() {
+		if err := k.mintExtendedCoin(ctx, moduleName, extendedAmount); err != nil {
+			return err
+		}
+	}
+
+	fullEmissionCoin := getFullExtendedValueAmount(amt)
+	if fullEmissionCoin.IsZero() {
 		return nil
 	}
 
-	return k.mintExtendedCoin(ctx, moduleName, extendedAmount)
+	ctx.EventManager().EmitEvent(
+		banktypes.NewCoinMintEvent(acc.GetAddress(), sdk.NewCoins(fullEmissionCoin)),
+	)
+
+	return nil
 }
 
 // mintExtendedCoin manages the minting of only extended coins. This also

--- a/x/precisebank/keeper/send.go
+++ b/x/precisebank/keeper/send.go
@@ -64,7 +64,7 @@ func (k Keeper) SendCoins(
 
 	// Get a full extended coin amount (passthrough integer + fractional) ONLY
 	// for event attributes.
-	fullEmissionCoin := getFullExtendedValueAmount(amt)
+	fullEmissionCoin := types.SumExtendedCoin(amt)
 
 	// If no passthrough integer nor fractional coins, then no event emission.
 	// We also want to emit the event with the whole equivalent extended coin
@@ -351,21 +351,4 @@ func (k Keeper) updateInsufficientFundsError(
 		"spendable balance %s is smaller than %s",
 		spendable, coin,
 	)
-}
-
-// getFullExtendedValueAmount returns a sdk.Coin of extended coin denomination
-// with all integer and fractional amounts combined. e.g. if amount contains
-// both coins of integer denom and extended denom, this will return the total
-// amount in extended coins. This is intended to get the full value to emit in
-// events.
-func getFullExtendedValueAmount(amt sdk.Coins) sdk.Coin {
-	fullEmissionCoin := sdk.NewCoin(
-		types.ExtendedCoinDenom,
-		amt.AmountOf(types.ExtendedCoinDenom),
-	)
-
-	integerAmount := amt.AmountOf(types.IntegerCoinDenom)
-	fullEmissionCoin.Amount = fullEmissionCoin.Amount.Add(integerAmount.Mul(types.ConversionFactor()))
-
-	return fullEmissionCoin
 }

--- a/x/precisebank/keeper/send.go
+++ b/x/precisebank/keeper/send.go
@@ -64,13 +64,7 @@ func (k Keeper) SendCoins(
 
 	// Get a full extended coin amount (passthrough integer + fractional) ONLY
 	// for event attributes.
-	fullEmissionCoin := sdk.NewCoin(
-		types.ExtendedCoinDenom,
-		amt.AmountOf(types.ExtendedCoinDenom),
-	)
-
-	integerAmount := amt.AmountOf(types.IntegerCoinDenom)
-	fullEmissionCoin.Amount = fullEmissionCoin.Amount.Add(integerAmount.Mul(types.ConversionFactor()))
+	fullEmissionCoin := getFullExtendedValueAmount(amt)
 
 	// If no passthrough integer nor fractional coins, then no event emission.
 	// We also want to emit the event with the whole equivalent extended coin
@@ -357,4 +351,21 @@ func (k Keeper) updateInsufficientFundsError(
 		"spendable balance %s is smaller than %s",
 		spendable, coin,
 	)
+}
+
+// getFullExtendedValueAmount returns a sdk.Coin of extended coin denomination
+// with all integer and fractional amounts combined. e.g. if amount contains
+// both coins of integer denom and extended denom, this will return the total
+// amount in extended coins. This is intended to get the full value to emit in
+// events.
+func getFullExtendedValueAmount(amt sdk.Coins) sdk.Coin {
+	fullEmissionCoin := sdk.NewCoin(
+		types.ExtendedCoinDenom,
+		amt.AmountOf(types.ExtendedCoinDenom),
+	)
+
+	integerAmount := amt.AmountOf(types.IntegerCoinDenom)
+	fullEmissionCoin.Amount = fullEmissionCoin.Amount.Add(integerAmount.Mul(types.ConversionFactor()))
+
+	return fullEmissionCoin
 }

--- a/x/precisebank/types/extended_balance.go
+++ b/x/precisebank/types/extended_balance.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// SumExtendedCoin returns a sdk.Coin of extended coin denomination
+// with all integer and fractional amounts combined. e.g. if amount contains
+// both coins of integer denom and extended denom, this will return the total
+// amount in extended coins. This is intended to get the full value to emit in
+// events.
+func SumExtendedCoin(amt sdk.Coins) sdk.Coin {
+	// ukava converted to akava
+	integerAmount := amt.AmountOf(IntegerCoinDenom).Mul(conversionFactor)
+	// akava as is
+	extendedAmount := amt.AmountOf(ExtendedCoinDenom)
+
+	// total of ukava and akava amounts
+	fullEmissionAmount := integerAmount.Add(extendedAmount)
+
+	return sdk.NewCoin(
+		ExtendedCoinDenom,
+		fullEmissionAmount,
+	)
+}

--- a/x/precisebank/types/extended_balance_test.go
+++ b/x/precisebank/types/extended_balance_test.go
@@ -1,0 +1,48 @@
+package types_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kava-labs/kava/x/precisebank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSumExtendedCoin(t *testing.T) {
+	tests := []struct {
+		name string
+		amt  sdk.Coins
+		want sdk.Coin
+	}{
+		{
+			"empty",
+			sdk.NewCoins(),
+			sdk.NewCoin(types.ExtendedCoinDenom, sdk.ZeroInt()),
+		},
+		{
+			"only integer",
+			sdk.NewCoins(sdk.NewInt64Coin(types.IntegerCoinDenom, 100)),
+			sdk.NewCoin(types.ExtendedCoinDenom, types.ConversionFactor().MulRaw(100)),
+		},
+		{
+			"only extended",
+			sdk.NewCoins(sdk.NewInt64Coin(types.ExtendedCoinDenom, 100)),
+			sdk.NewCoin(types.ExtendedCoinDenom, sdk.NewInt(100)),
+		},
+		{
+			"integer and extended",
+			sdk.NewCoins(
+				sdk.NewInt64Coin(types.IntegerCoinDenom, 100),
+				sdk.NewInt64Coin(types.ExtendedCoinDenom, 100),
+			),
+			sdk.NewCoin(types.ExtendedCoinDenom, types.ConversionFactor().MulRaw(100).AddRaw(100)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extVal := types.SumExtendedCoin(tt.amt)
+			require.Equal(t, tt.want, extVal)
+		})
+	}
+}


### PR DESCRIPTION
## Description
- Emits **only** akava amounts for **both** ukava and akava send/mint/burns. If both akava,ukava are sent (not possible via x/evm nor cosmos messages but still an edge case), then the sum is emitted.

