### PR TITLE
feat(x/precisebank): Display 0 reserve balance to module consumers

### DIFF
--- a/x/precisebank/keeper/burn_integration_test.go
+++ b/x/precisebank/keeper/burn_integration_test.go
@@ -261,7 +261,7 @@ func (suite *burnIntegrationTestSuite) TestBurnCoins_Remainder() {
 
 	// Burn 0.1 until balance is 0
 	for {
-		reserveBalBefore := suite.Keeper.GetBalance(
+		reserveBalBefore := suite.BankKeeper.GetBalance(
 			suite.Ctx,
 			reserveAddr,
 			types.IntegerCoinDenom,
@@ -291,7 +291,7 @@ func (suite *burnIntegrationTestSuite) TestBurnCoins_Remainder() {
 			moduleAddr,
 			types.ExtendedCoinDenom,
 		)
-		reserveBalAfter := suite.Keeper.GetBalance(
+		reserveBalAfter := suite.BankKeeper.GetBalance(
 			suite.Ctx,
 			reserveAddr,
 			types.IntegerCoinDenom,
@@ -357,7 +357,7 @@ func (suite *burnIntegrationTestSuite) TestBurnCoins_Spread_Remainder() {
 
 	// Burn 0.1 from each account
 	for _, addr := range addrs {
-		reserveBalBefore := suite.Keeper.GetBalance(
+		reserveBalBefore := suite.BankKeeper.GetBalance(
 			suite.Ctx,
 			reserveAddr,
 			types.IntegerCoinDenom,
@@ -395,7 +395,7 @@ func (suite *burnIntegrationTestSuite) TestBurnCoins_Spread_Remainder() {
 			addr,
 			types.ExtendedCoinDenom,
 		)
-		reserveBalAfter := suite.Keeper.GetBalance(
+		reserveBalAfter := suite.BankKeeper.GetBalance(
 			suite.Ctx,
 			reserveAddr,
 			types.IntegerCoinDenom,

--- a/x/precisebank/keeper/view.go
+++ b/x/precisebank/keeper/view.go
@@ -14,13 +14,18 @@ func (k Keeper) GetBalance(
 	addr sdk.AccAddress,
 	denom string,
 ) sdk.Coin {
-	// Module balance should display as empty. Module balances are **only** for
-	// the reserve which backs the fractional balances. This showing the backing
-	// balances would result in a double counting of the fractional balances.
+	// Module balance should display as empty for reserve denoms. Module
+	// balances are **only** for the reserve which backs the fractional
+	// balances. Returning the backing balances would result in a double
+	// counting of the fractional balances.
+	// While it should not be possible for x/precisebank to receive any coins
+	// of any denoms, we still check for the reserve denom to be safe.
 	// The reserve should be transparent to consumers and x/bank is to be used
 	// for fetching the **true** underlying balances.
-	if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
-		return sdk.NewCoin(denom, sdkmath.ZeroInt())
+	if denom == types.ExtendedCoinDenom || denom == types.IntegerCoinDenom {
+		if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
+			return sdk.NewCoin(denom, sdkmath.ZeroInt())
+		}
 	}
 
 	// Pass through to x/bank for denoms except ExtendedCoinDenom
@@ -52,8 +57,10 @@ func (k Keeper) SpendableCoin(
 	denom string,
 ) sdk.Coin {
 	// Same as GetBalance, reserve balances are transparent to consumers.
-	if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
-		return sdk.NewCoin(denom, sdkmath.ZeroInt())
+	if denom == types.ExtendedCoinDenom || denom == types.IntegerCoinDenom {
+		if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
+			return sdk.NewCoin(denom, sdkmath.ZeroInt())
+		}
 	}
 
 	// Pass through to x/bank for denoms except ExtendedCoinDenom

--- a/x/precisebank/keeper/view.go
+++ b/x/precisebank/keeper/view.go
@@ -14,18 +14,12 @@ func (k Keeper) GetBalance(
 	addr sdk.AccAddress,
 	denom string,
 ) sdk.Coin {
-	// Module balance should display as empty for reserve denoms. Module
+	// Module balance should display as empty for extended denom. Module
 	// balances are **only** for the reserve which backs the fractional
-	// balances. Returning the backing balances would result in a double
-	// counting of the fractional balances.
-	// While it should not be possible for x/precisebank to receive any coins
-	// of any denoms, we still check for the reserve denom to be safe.
-	// The reserve should be transparent to consumers and x/bank is to be used
-	// for fetching the **true** underlying balances.
-	if denom == types.ExtendedCoinDenom || denom == types.IntegerCoinDenom {
-		if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
-			return sdk.NewCoin(denom, sdkmath.ZeroInt())
-		}
+	// balances. Returning the backing balances if querying extended denom would
+	// result in a double counting of the fractional balances.
+	if denom == types.ExtendedCoinDenom && addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
+		return sdk.NewCoin(denom, sdkmath.ZeroInt())
 	}
 
 	// Pass through to x/bank for denoms except ExtendedCoinDenom
@@ -56,11 +50,9 @@ func (k Keeper) SpendableCoin(
 	addr sdk.AccAddress,
 	denom string,
 ) sdk.Coin {
-	// Same as GetBalance, reserve balances are transparent to consumers.
-	if denom == types.ExtendedCoinDenom || denom == types.IntegerCoinDenom {
-		if addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
-			return sdk.NewCoin(denom, sdkmath.ZeroInt())
-		}
+	// Same as GetBalance, extended denom balances are transparent to consumers.
+	if denom == types.ExtendedCoinDenom && addr.Equals(k.ak.GetModuleAddress(types.ModuleName)) {
+		return sdk.NewCoin(denom, sdkmath.ZeroInt())
 	}
 
 	// Pass through to x/bank for denoms except ExtendedCoinDenom

--- a/x/precisebank/keeper/view_integration_test.go
+++ b/x/precisebank/keeper/view_integration_test.go
@@ -140,53 +140,63 @@ func (suite *viewIntegrationTestSuite) TestKeeper_HiddenReserve() {
 	// Make the reserve hold a non-zero balance
 	// Mint fractional coins to an account, which should cause a mint of 1
 	// integer coin to the reserve to back it.
+	extCoin := sdk.NewCoin(types.ExtendedCoinDenom, types.ConversionFactor().AddRaw(1000))
 	unrelatedCoin := sdk.NewCoin("unrelated", sdk.NewInt(1000))
 	suite.MintToAccount(
 		addr1,
 		sdk.NewCoins(
-			sdk.NewCoin(types.ExtendedCoinDenom, sdk.NewInt(1000)),
+			extCoin,
 			unrelatedCoin,
 		),
 	)
 
 	// Check underlying x/bank balance for reserve
 	reserveIntCoin := suite.BankKeeper.GetBalance(suite.Ctx, moduleAddr, types.IntegerCoinDenom)
-	suite.Require().Equal(sdkmath.NewInt(1), reserveIntCoin.Amount, "reserve should hold 1 integer coin")
+	suite.Require().Equal(
+		sdkmath.NewInt(1),
+		reserveIntCoin.Amount,
+		"reserve should hold 1 integer coin",
+	)
 
-	// x/precisebank queries for reserve show as 0
-	denom := types.ExtendedCoinDenom
+	tests := []struct {
+		name       string
+		giveAddr   sdk.AccAddress
+		giveDenom  string
+		wantAmount sdkmath.Int
+	}{
+		{
+			"reserve account - hidden extended denom",
+			moduleAddr,
+			types.ExtendedCoinDenom,
+			sdkmath.ZeroInt(),
+		},
+		{
+			"reserve account - visible integer denom",
+			moduleAddr,
+			types.IntegerCoinDenom,
+			sdkmath.OneInt(),
+		},
+		{
+			"user account - visible extended denom",
+			addr1,
+			types.ExtendedCoinDenom,
+			extCoin.Amount,
+		},
+		{
+			"user account - visible integer denom",
+			addr1,
+			types.IntegerCoinDenom,
+			extCoin.Amount.Quo(types.ConversionFactor()),
+		},
+	}
 
-	suite.Run("GetBalance()", func() {
-		coin := suite.Keeper.GetBalance(suite.Ctx, moduleAddr, denom)
-		suite.Require().Equal(denom, coin.Denom)
-		suite.Require().Equal(sdkmath.ZeroInt(), coin.Amount)
-	})
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			coin := suite.Keeper.GetBalance(suite.Ctx, tt.giveAddr, tt.giveDenom)
+			suite.Require().Equal(tt.wantAmount.Int64(), coin.Amount.Int64())
 
-	suite.Run("SpendableCoin()", func() {
-		spendableCoin := suite.Keeper.SpendableCoin(suite.Ctx, moduleAddr, denom)
-		suite.Require().Equal(denom, spendableCoin.Denom)
-		suite.Require().Equal(sdkmath.ZeroInt(), spendableCoin.Amount)
-	})
-
-	suite.Run("GetBalance() unrelated denom", func() {
-		// Not affecting module account
-		moduleCoin := suite.Keeper.GetBalance(suite.Ctx, moduleAddr, "unrelated")
-		suite.Require().Equal(unrelatedCoin.Denom, moduleCoin.Denom)
-		suite.Require().Equal(sdkmath.ZeroInt(), moduleCoin.Amount)
-
-		// Still visible in user account balance
-		accCoin := suite.Keeper.GetBalance(suite.Ctx, addr1, "unrelated")
-		suite.Require().Equal(unrelatedCoin, accCoin)
-	})
-
-	suite.Run("SpendableCoin() unrelated denom", func() {
-		// Not affecting module account
-		moduleCoin := suite.Keeper.SpendableCoin(suite.Ctx, moduleAddr, "unrelated")
-		suite.Require().Equal(unrelatedCoin.Denom, moduleCoin.Denom)
-		suite.Require().Equal(sdkmath.ZeroInt(), moduleCoin.Amount)
-
-		// Still visible in user account balance
-		accCoin := suite.Keeper.SpendableCoin(suite.Ctx, addr1, "unrelated")
-		suite.Require().Equal(unrelatedCoin, accCoin)
-	})
+			spendableCoin := suite.Keeper.SpendableCoin(suite.Ctx, tt.giveAddr, tt.giveDenom)
+			suite.Require().Equal(tt.wantAmount.Int64(), spendableCoin.Amount.Int64())
+		})
+	}
 }

--- a/x/precisebank/keeper/view_test.go
+++ b/x/precisebank/keeper/view_test.go
@@ -92,7 +92,7 @@ func TestKeeper_GetBalance(t *testing.T) {
 			tk.keeper.SetFractionalBalance(tk.ctx, addr, tt.giveFractionalBal)
 
 			// Checks address if its a reserve denom
-			if tt.giveDenom == types.ExtendedCoinDenom || tt.giveDenom == types.IntegerCoinDenom {
+			if tt.giveDenom == types.ExtendedCoinDenom {
 				tk.ak.EXPECT().GetModuleAddress(types.ModuleName).
 					Return(authtypes.NewModuleAddress(types.ModuleName)).
 					Once()
@@ -207,7 +207,7 @@ func TestKeeper_SpendableCoin(t *testing.T) {
 			tk.keeper.SetFractionalBalance(tk.ctx, addr, tt.giveFractionalBal)
 
 			// If its a reserve denom, module address is checked
-			if tt.giveDenom == types.ExtendedCoinDenom || tt.giveDenom == types.IntegerCoinDenom {
+			if tt.giveDenom == types.ExtendedCoinDenom {
 				tk.ak.EXPECT().GetModuleAddress(types.ModuleName).
 					Return(authtypes.NewModuleAddress(types.ModuleName)).
 					Once()
@@ -253,18 +253,19 @@ func TestHiddenReserve(t *testing.T) {
 	// a handler for getting underlying balance.
 
 	tests := []struct {
-		name  string
-		denom string
+		name            string
+		denom           string
+		expectedBalance sdk.Coin
 	}{
-		{"akava", types.ExtendedCoinDenom},
-		{"ukava", types.IntegerCoinDenom},
-		{"unrelated denom", "cat"},
+		{"akava", types.ExtendedCoinDenom, sdk.NewCoin(types.ExtendedCoinDenom, sdkmath.ZeroInt())},
+		{"ukava", types.IntegerCoinDenom, sdk.NewCoin(types.IntegerCoinDenom, sdkmath.NewInt(1))},
+		{"unrelated denom", "cat", sdk.NewCoin("cat", sdkmath.ZeroInt())},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// 2 calls for GetBalance and SpendableCoin, only for reserve coins
-			if tt.denom == "akava" || tt.denom == "ukava" {
+			if tt.denom == "akava" {
 				tk.ak.EXPECT().GetModuleAddress(types.ModuleName).
 					Return(moduleAddr).
 					Twice()


### PR DESCRIPTION
Module reserve represents fractional balances, so it should be hidden to consumers to not have a misleading total balance that doubles the fractional balances.

This modifies `GetBalance()` and `SpendableCoin()` to always return zero coins when fetching the reserve address balance.