### PR TITLE
feat(x/precisebank): Emit coin_spent and coin_received events

### DIFF
--- a/x/precisebank/keeper/burn.go
+++ b/x/precisebank/keeper/burn.go
@@ -60,14 +60,15 @@ func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	fullEmissionCoin := types.SumExtendedCoin(amt)
-	if fullEmissionCoin.IsZero() {
+	fullEmissionCoins := sdk.NewCoins(types.SumExtendedCoin(amt))
+	if fullEmissionCoins.IsZero() {
 		return nil
 	}
 
-	ctx.EventManager().EmitEvent(
-		banktypes.NewCoinBurnEvent(acc.GetAddress(), sdk.NewCoins(fullEmissionCoin)),
-	)
+	ctx.EventManager().EmitEvents(sdk.Events{
+		banktypes.NewCoinBurnEvent(acc.GetAddress(), fullEmissionCoins),
+		banktypes.NewCoinSpentEvent(acc.GetAddress(), fullEmissionCoins),
+	})
 
 	return nil
 }

--- a/x/precisebank/keeper/burn_integration_test.go
+++ b/x/precisebank/keeper/burn_integration_test.go
@@ -217,20 +217,22 @@ func (suite *burnIntegrationTestSuite) TestBurnCoins() {
 			fraCoinAmt := tt.burnCoins.AmountOf(types.ExtendedCoinDenom)
 
 			totalExtCoinAmt := intCoinAmt.Add(fraCoinAmt)
+			spentCoins := sdk.NewCoins(sdk.NewCoin(
+				types.ExtendedCoinDenom,
+				totalExtCoinAmt,
+			))
 
 			events := suite.Ctx.EventManager().Events()
-			extendedEvent := banktypes.NewCoinBurnEvent(
-				recipientAddr,
-				sdk.NewCoins(sdk.NewCoin(
-					types.ExtendedCoinDenom,
-					totalExtCoinAmt,
-				)),
-			)
+
+			expBurnEvent := banktypes.NewCoinBurnEvent(recipientAddr, spentCoins)
+			expSpendEvent := banktypes.NewCoinSpentEvent(recipientAddr, spentCoins)
 
 			if totalExtCoinAmt.IsZero() {
-				suite.Require().NotContains(events, extendedEvent)
+				suite.Require().NotContains(events, expBurnEvent)
+				suite.Require().NotContains(events, expSpendEvent)
 			} else {
-				suite.Require().Contains(events, extendedEvent)
+				suite.Require().Contains(events, expBurnEvent)
+				suite.Require().Contains(events, expSpendEvent)
 			}
 		})
 	}

--- a/x/precisebank/keeper/mint.go
+++ b/x/precisebank/keeper/mint.go
@@ -63,14 +63,15 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 		}
 	}
 
-	fullEmissionCoin := types.SumExtendedCoin(amt)
-	if fullEmissionCoin.IsZero() {
+	fullEmissionCoins := sdk.NewCoins(types.SumExtendedCoin(amt))
+	if fullEmissionCoins.IsZero() {
 		return nil
 	}
 
-	ctx.EventManager().EmitEvent(
-		banktypes.NewCoinMintEvent(acc.GetAddress(), sdk.NewCoins(fullEmissionCoin)),
-	)
+	ctx.EventManager().EmitEvents(sdk.Events{
+		banktypes.NewCoinMintEvent(acc.GetAddress(), fullEmissionCoins),
+		banktypes.NewCoinReceivedEvent(acc.GetAddress(), fullEmissionCoins),
+	})
 
 	return nil
 }

--- a/x/precisebank/keeper/mint_integration_test.go
+++ b/x/precisebank/keeper/mint_integration_test.go
@@ -342,21 +342,27 @@ func (suite *mintIntegrationTestSuite) TestMintCoins() {
 				fraCoinAmt := mt.mintAmount.AmountOf(types.ExtendedCoinDenom)
 
 				totalExtCoinAmt := intCoinAmt.Add(fraCoinAmt)
+				extCoins := sdk.NewCoins(sdk.NewCoin(types.ExtendedCoinDenom, totalExtCoinAmt))
 
 				// Check for mint event
 				events := suite.Ctx.EventManager().Events()
-				extendedEvent := banktypes.NewCoinMintEvent(
+
+				expMintEvent := banktypes.NewCoinMintEvent(
 					recipientAddr,
-					sdk.NewCoins(sdk.NewCoin(
-						types.ExtendedCoinDenom,
-						totalExtCoinAmt,
-					)),
+					extCoins,
+				)
+
+				expReceivedEvent := banktypes.NewCoinReceivedEvent(
+					recipientAddr,
+					extCoins,
 				)
 
 				if totalExtCoinAmt.IsZero() {
-					suite.Require().NotContains(events, extendedEvent)
+					suite.Require().NotContains(events, expMintEvent)
+					suite.Require().NotContains(events, expReceivedEvent)
 				} else {
-					suite.Require().Contains(events, extendedEvent)
+					suite.Require().Contains(events, expMintEvent)
+					suite.Require().Contains(events, expReceivedEvent)
 				}
 			}
 		})

--- a/x/precisebank/keeper/send.go
+++ b/x/precisebank/keeper/send.go
@@ -64,12 +64,12 @@ func (k Keeper) SendCoins(
 
 	// Get a full extended coin amount (passthrough integer + fractional) ONLY
 	// for event attributes.
-	fullEmissionCoin := types.SumExtendedCoin(amt)
+	fullEmissionCoins := sdk.NewCoins(types.SumExtendedCoin(amt))
 
 	// If no passthrough integer nor fractional coins, then no event emission.
 	// We also want to emit the event with the whole equivalent extended coin
 	// if only integer coins are sent.
-	if fullEmissionCoin.IsZero() {
+	if fullEmissionCoins.IsZero() {
 		return nil
 	}
 
@@ -79,8 +79,10 @@ func (k Keeper) SendCoins(
 			banktypes.EventTypeTransfer,
 			sdk.NewAttribute(banktypes.AttributeKeyRecipient, to.String()),
 			sdk.NewAttribute(banktypes.AttributeKeySender, from.String()),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, fullEmissionCoin.String()),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, fullEmissionCoins.String()),
 		),
+		banktypes.NewCoinSpentEvent(from, fullEmissionCoins),
+		banktypes.NewCoinReceivedEvent(to, fullEmissionCoins),
 	})
 
 	return nil

--- a/x/precisebank/keeper/send_integration_test.go
+++ b/x/precisebank/keeper/send_integration_test.go
@@ -435,6 +435,7 @@ func (suite *sendIntegrationTestSuite) TestSendCoins() {
 				types.ExtendedCoinDenom,
 				sendAmountFullExtended.AmountOf(types.ExtendedCoinDenom),
 			)
+			extCoins := sdk.NewCoins(sendExtendedAmount)
 
 			// No extra events if not sending akava
 			if sendExtendedAmount.IsZero() {
@@ -448,7 +449,21 @@ func (suite *sendIntegrationTestSuite) TestSendCoins() {
 				sdk.NewAttribute(sdk.AttributeKeyAmount, sendExtendedAmount.String()),
 			)
 
-			suite.Require().Contains(suite.Ctx.EventManager().Events(), extendedEvent)
+			expReceivedEvent := banktypes.NewCoinReceivedEvent(
+				recipient,
+				extCoins,
+			)
+
+			expSentEvent := banktypes.NewCoinSpentEvent(
+				sender,
+				extCoins,
+			)
+
+			events := suite.Ctx.EventManager().Events()
+
+			suite.Require().Contains(events, extendedEvent)
+			suite.Require().Contains(events, expReceivedEvent)
+			suite.Require().Contains(events, expSentEvent)
 		})
 	}
 }


### PR DESCRIPTION
## Description
- Emit `coin_spent` and `coin_received` events. These are emitted on burn and mint respectively, as well as both on coinsend.
- Compatible with `x/bank` behavior - see use of `subUnlockedCoins` and `addCoins` https://github.com/cosmos/cosmos-sdk/blob/v0.47.13/x/bank/keeper/send.go#L234-L296

[sc-13899]