### PR TITLE
test(insolvency): add tests for Kava lend insolvency check

### DIFF
--- a/x/hard/keeper/borrow.go
+++ b/x/hard/keeper/borrow.go
@@ -7,7 +7,6 @@ import (
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
 	"github.com/kava-labs/kava/x/hard/types"
 )
 

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -837,7 +836,6 @@ func (suite *KeeperTestSuite) TestValidateBorrow() {
 		sdk.NewCoins(sdk.NewCoin("ukava", availableToBorrow.AmountOf("ukava"))),
 	)
 	suite.Require().Error(err)
-	fmt.Println("err: ", err)
 	suite.Require().True(strings.Contains(err.Error(), "protocol reserves exceed available cash"))
 
 	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(blockDuration))

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -25,18 +25,15 @@ const (
 
 func (suite *KeeperTestSuite) TestBorrow() {
 	type setupArgs struct {
-		usdxBorrowLimit sdk.Dec
-		priceKAVA       sdk.Dec
-		loanToValueKAVA sdk.Dec
-		priceBTCB       sdk.Dec
-		loanToValueBTCB sdk.Dec
-		priceBNB        sdk.Dec
-		loanToValueBNB  sdk.Dec
-		borrower        sdk.AccAddress
-		depositCoins    []sdk.Coin
-		wantDepositErr  string
-
-		// renamed this to be more clear
+		usdxBorrowLimit    sdk.Dec
+		priceKAVA          sdk.Dec
+		loanToValueKAVA    sdk.Dec
+		priceBTCB          sdk.Dec
+		loanToValueBTCB    sdk.Dec
+		priceBNB           sdk.Dec
+		loanToValueBNB     sdk.Dec
+		borrower           sdk.AccAddress
+		depositCoins       []sdk.Coin
 		initialBorrowCoins sdk.Coins
 	}
 
@@ -640,9 +637,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			suite.keeper = keeper
 			// Run BeginBlocker once to transition MoneyMarkets
 			hard.BeginBlocker(suite.ctx, suite.keeper)
-			if err = suite.keeper.Deposit(suite.ctx, tc.setup.borrower, tc.setup.depositCoins); err != nil {
-				suite.Require().Equal(tc.setup.wantDepositErr, err.Error())
-			}
+			suite.Require().NoError(suite.keeper.Deposit(suite.ctx, tc.setup.borrower, tc.setup.depositCoins)
 			// Execute user's previous borrows
 			if err = suite.keeper.Borrow(suite.ctx, tc.setup.borrower, tc.setup.initialBorrowCoins); tc.setup.initialBorrowCoins.IsZero() {
 				suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -24,594 +25,659 @@ const (
 )
 
 func (suite *KeeperTestSuite) TestBorrow() {
-	type args struct {
-		usdxBorrowLimit           sdk.Dec
-		priceKAVA                 sdk.Dec
-		loanToValueKAVA           sdk.Dec
-		priceBTCB                 sdk.Dec
-		loanToValueBTCB           sdk.Dec
-		priceBNB                  sdk.Dec
-		loanToValueBNB            sdk.Dec
-		borrower                  sdk.AccAddress
-		depositCoins              []sdk.Coin
-		previousBorrowCoins       sdk.Coins
-		borrowCoins               sdk.Coins
+	type setupArgs struct {
+		usdxBorrowLimit sdk.Dec
+		priceKAVA       sdk.Dec
+		loanToValueKAVA sdk.Dec
+		priceBTCB       sdk.Dec
+		loanToValueBTCB sdk.Dec
+		priceBNB        sdk.Dec
+		loanToValueBNB  sdk.Dec
+		borrower        sdk.AccAddress
+		depositCoins    []sdk.Coin
+		wantDepositErr  string
+
+		// renamed this to be more clear
+		initialBorrowCoins sdk.Coins
+	}
+
+	type borrowArgs struct {
+		borrowCoins sdk.Coins
+		wantErr     string
+	}
+	type expected struct {
 		expectedAccountBalance    sdk.Coins
 		expectedModAccountBalance sdk.Coins
-		wantDepositErr            string
-	}
-	type errArgs struct {
+
 		expectPass bool
 		contains   string
 	}
+
 	type borrowTest struct {
-		name    string
-		args    []args
-		errArgs []errArgs
+		name     string
+		setup    setupArgs
+		borrows  []borrowArgs
+		expected []expected
 	}
+
 	testCases := []borrowTest{
 		{
 			name: "valid",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+
+					expectPass: true,
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: loan-to-value limited",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))}, // 20 KAVA x $5.00 price = $100
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))},  // 20 KAVA x $5.00 price = $100
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(61*USDX_CF))), // 61 USDX x $1 price = $61
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
-				},
-			},
-			errArgs: []errArgs{
-				{
+
 					expectPass: false,
 					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+				},
+			},
+			borrows: []borrowArgs{
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(61*USDX_CF))), // 61 USDX x $1 price = $61
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "valid: multiple deposits",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.80"),
+				priceBTCB:          sdk.MustNewDecFromStr("10000.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.10"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
-					priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(99.9*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(20*USDX_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+
+					expectPass: true,
+
+					contains: "exceeds the allowable amount as determined by the collateralization ratio",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: multiple deposits",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.80"),
+				priceBTCB:          sdk.MustNewDecFromStr("10000.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.10"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
-					priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(181*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
-				},
-			},
-			errArgs: []errArgs{
-				{
+
 					expectPass: false,
 					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+				},
+			},
+			borrows: []borrowArgs{
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(181*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "valid: multiple previous borrows",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("5.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.8"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
+				initialBorrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
-					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
+
+					expectPass: true,
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: over loan-to-value with multiple previous borrows",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("5.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.8"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
+				initialBorrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
-					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "exceeds the allowable amount as determined by the collateralization ratio",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: false,
-					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: no price for asset",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-				},
-			},
-			errArgs: []errArgs{
-				{
+
 					expectPass: false,
 					contains:   "no price found for market",
+				},
+			},
+			borrows: []borrowArgs{
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: borrow exceed module account balance",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(101*BUSD_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "exceeds borrowable module account balance",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: false,
-					contains:   "exceeds borrowable module account balance",
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(101*BUSD_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: over global asset borrow limit",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "fails global asset borrow limit validation",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: false,
-					contains:   "fails global asset borrow limit validation",
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: borrowing an individual coin type results in a borrow that's under the minimum USD borrow limit",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "below the minimum borrow limit",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: false,
-					contains:   "below the minimum borrow limit",
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "invalid: borrowing multiple coins results in a borrow that's under the minimum USD borrow limit",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("20000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(),
 					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "below the minimum borrow limit",
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: false,
-					contains:   "below the minimum borrow limit",
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "valid borrow multiple blocks",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+
+					expectPass: true,
 				},
 				{
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(10*KAVA_CF))},
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(40*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1060*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					expectPass:                true,
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					wantErr:     "",
 				},
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "first valid borrow, second insufficient funds blocks",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.6"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("0.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.01"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+				initialBorrowCoins: sdk.NewCoins(),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
-					previousBorrowCoins:       sdk.NewCoins(),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+
+					expectPass: true,
 				},
 				{
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))}, // too much
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(40*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1060*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-					wantDepositErr:            "insufficient funds: the requested deposit amount of 100000000ukava exceeds the total available account funds of 20000000ukava: exceeds module account balance",
+					expectPass:                true,
 				},
 			},
-			errArgs: []errArgs{
+			borrows: []borrowArgs{
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					wantErr:     "",
 				},
 				{
-					expectPass: true,
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "valid borrow followed by protocol reserves exceed available cash for busd when borrowing from ukava(incorrect)",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("5.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("5.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.8"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
-				},
-				{
-					borrower:    sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1*KAVA_CF))),
-				},
-			},
-			errArgs: []errArgs{
-				{
+
 					expectPass: true,
 				},
 				{
-					// THIS SHOULDN'T FAIL
-					expectPass: false,
-					contains:   "insolvency - protocol reserves exceed available cash",
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "insolvency - protocol reserves exceed available cash",
+				},
+			},
+			borrows: []borrowArgs{
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					wantErr:     "",
+				},
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1*KAVA_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 		{
 			name: "valid borrow followed by protocol reserves exceed available cash for busd when borrowing from busd",
-			args: []args{
+			setup: setupArgs{
+				usdxBorrowLimit:    sdk.MustNewDecFromStr("100000000000"),
+				priceKAVA:          sdk.MustNewDecFromStr("2.00"),
+				loanToValueKAVA:    sdk.MustNewDecFromStr("0.8"),
+				priceBTCB:          sdk.MustNewDecFromStr("0.00"),
+				loanToValueBTCB:    sdk.MustNewDecFromStr("0.01"),
+				priceBNB:           sdk.MustNewDecFromStr("5.00"),
+				loanToValueBNB:     sdk.MustNewDecFromStr("0.8"),
+				borrower:           sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+				depositCoins:       sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+				initialBorrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			},
+			expected: []expected{
 				{
-					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
 					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
 					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
-				},
-				{
-					borrower:    sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-					borrowCoins: sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-				},
-			},
-			errArgs: []errArgs{
-				{
+
 					expectPass: true,
 				},
 				{
-					expectPass: false,
-					contains:   "insolvency - protocol reserves exceed available cash",
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+					expectPass:                false,
+					contains:                  "insolvency - protocol reserves exceed available cash",
+				},
+			},
+			borrows: []borrowArgs{
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					wantErr:     "",
+				},
+				{
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					wantErr:     "",
 				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			suite.Require().Len(tc.args, len(tc.errArgs), "malformed test setup, args should have same number of indexes as errArgs")
-			var (
-				ctx  sdk.Context
-				tApp app.TestApp
+			// Initialize test app and set context
+			tApp := app.NewTestApp()
+			ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
+
+			// Auth module genesis state
+			authGS := app.NewFundedGenStateWithCoins(
+				tApp.AppCodec(),
+				[]sdk.Coins{
+					sdk.NewCoins(
+						sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF)),
+						sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)),
+						sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)),
+						sdk.NewCoin("xyz", sdkmath.NewInt(1)),
+					),
+				},
+				[]sdk.AccAddress{tc.setup.borrower},
 			)
-			for i, arg := range tc.args {
-				if i == 0 {
-					// Initialize test app and set context
-					tApp = app.NewTestApp()
-					ctx = tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 
-					// Auth module genesis state
-					authGS := app.NewFundedGenStateWithCoins(
-						tApp.AppCodec(),
-						[]sdk.Coins{
-							sdk.NewCoins(
-								sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF)),
-								sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)),
-								sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)),
-								sdk.NewCoin("xyz", sdkmath.NewInt(1)),
-							),
-						},
-						[]sdk.AccAddress{arg.borrower},
-					)
+			// hard module genesis state
+			hardGS := types.NewGenesisState(types.NewParams(
+				types.MoneyMarkets{
+					types.NewMoneyMarket("usdx", types.NewBorrowLimit(true, tc.setup.usdxBorrowLimit, sdk.MustNewDecFromStr("1")), "usdx:usd", sdkmath.NewInt(USDX_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+					types.NewMoneyMarket("busd", types.NewBorrowLimit(false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1")), "busd:usd", sdkmath.NewInt(BUSD_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+					types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(100000000*KAVA_CF), tc.setup.loanToValueKAVA), "kava:usd", sdkmath.NewInt(KAVA_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.99"), sdk.ZeroDec()),
+					types.NewMoneyMarket("btcb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BTCB_CF), tc.setup.loanToValueBTCB), "btcb:usd", sdkmath.NewInt(BTCB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+					types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BNB_CF), tc.setup.loanToValueBNB), "bnb:usd", sdkmath.NewInt(BNB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+					types.NewMoneyMarket("xyz", types.NewBorrowLimit(false, sdk.NewDec(1), tc.setup.loanToValueBNB), "xyz:usd", sdkmath.NewInt(1), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+				},
+				sdk.NewDec(10),
+			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
+				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
+			)
 
-					// hard module genesis state
-					hardGS := types.NewGenesisState(types.NewParams(
-						types.MoneyMarkets{
-							types.NewMoneyMarket("usdx", types.NewBorrowLimit(true, arg.usdxBorrowLimit, sdk.MustNewDecFromStr("1")), "usdx:usd", sdkmath.NewInt(USDX_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-							types.NewMoneyMarket("busd", types.NewBorrowLimit(false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1")), "busd:usd", sdkmath.NewInt(BUSD_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-							types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(100000000*KAVA_CF), arg.loanToValueKAVA), "kava:usd", sdkmath.NewInt(KAVA_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.99"), sdk.ZeroDec()),
-							types.NewMoneyMarket("btcb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BTCB_CF), arg.loanToValueBTCB), "btcb:usd", sdkmath.NewInt(BTCB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-							types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BNB_CF), arg.loanToValueBNB), "bnb:usd", sdkmath.NewInt(BNB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-							types.NewMoneyMarket("xyz", types.NewBorrowLimit(false, sdk.NewDec(1), arg.loanToValueBNB), "xyz:usd", sdkmath.NewInt(1), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-						},
-						sdk.NewDec(10),
-					), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
-						types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
-					)
+			// Pricefeed module genesis state
+			pricefeedGS := pricefeedtypes.GenesisState{
+				Params: pricefeedtypes.Params{
+					Markets: []pricefeedtypes.Market{
+						{MarketID: "usdx:usd", BaseAsset: "usdx", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+						{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+						{MarketID: "kava:usd", BaseAsset: "kava", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+						{MarketID: "btcb:usd", BaseAsset: "btcb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+						{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+						{MarketID: "xyz:usd", BaseAsset: "xyz", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+					},
+				},
+				PostedPrices: []pricefeedtypes.PostedPrice{
+					{
+						MarketID:      "usdx:usd",
+						OracleAddress: sdk.AccAddress{},
+						Price:         sdk.MustNewDecFromStr("1.00"),
+						Expiry:        time.Now().Add(1 * time.Hour),
+					},
+					{
+						MarketID:      "busd:usd",
+						OracleAddress: sdk.AccAddress{},
+						Price:         sdk.MustNewDecFromStr("1.00"),
+						Expiry:        time.Now().Add(1 * time.Hour),
+					},
+					{
+						MarketID:      "kava:usd",
+						OracleAddress: sdk.AccAddress{},
+						Price:         tc.setup.priceKAVA,
+						Expiry:        time.Now().Add(1 * time.Hour),
+					},
+					{
+						MarketID:      "btcb:usd",
+						OracleAddress: sdk.AccAddress{},
+						Price:         tc.setup.priceBTCB,
+						Expiry:        time.Now().Add(1 * time.Hour),
+					},
+					{
+						MarketID:      "bnb:usd",
+						OracleAddress: sdk.AccAddress{},
+						Price:         tc.setup.priceBNB,
+						Expiry:        time.Now().Add(1 * time.Hour),
+					},
+				},
+			}
 
-					// Pricefeed module genesis state
-					pricefeedGS := pricefeedtypes.GenesisState{
-						Params: pricefeedtypes.Params{
-							Markets: []pricefeedtypes.Market{
-								{MarketID: "usdx:usd", BaseAsset: "usdx", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-								{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-								{MarketID: "kava:usd", BaseAsset: "kava", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-								{MarketID: "btcb:usd", BaseAsset: "btcb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-								{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-								{MarketID: "xyz:usd", BaseAsset: "xyz", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-							},
-						},
-						PostedPrices: []pricefeedtypes.PostedPrice{
-							{
-								MarketID:      "usdx:usd",
-								OracleAddress: sdk.AccAddress{},
-								Price:         sdk.MustNewDecFromStr("1.00"),
-								Expiry:        time.Now().Add(1 * time.Hour),
-							},
-							{
-								MarketID:      "busd:usd",
-								OracleAddress: sdk.AccAddress{},
-								Price:         sdk.MustNewDecFromStr("1.00"),
-								Expiry:        time.Now().Add(1 * time.Hour),
-							},
-							{
-								MarketID:      "kava:usd",
-								OracleAddress: sdk.AccAddress{},
-								Price:         arg.priceKAVA,
-								Expiry:        time.Now().Add(1 * time.Hour),
-							},
-							{
-								MarketID:      "btcb:usd",
-								OracleAddress: sdk.AccAddress{},
-								Price:         arg.priceBTCB,
-								Expiry:        time.Now().Add(1 * time.Hour),
-							},
-							{
-								MarketID:      "bnb:usd",
-								OracleAddress: sdk.AccAddress{},
-								Price:         arg.priceBNB,
-								Expiry:        time.Now().Add(1 * time.Hour),
-							},
-						},
-					}
+			// Initialize test application
+			tApp.InitializeFromGenesisStates(authGS,
+				app.GenesisState{pricefeedtypes.ModuleName: tApp.AppCodec().MustMarshalJSON(&pricefeedGS)},
+				app.GenesisState{types.ModuleName: tApp.AppCodec().MustMarshalJSON(&hardGS)})
+			// Mint coins to hard module account
+			bankKeeper := tApp.GetBankKeeper()
+			hardMaccCoins := sdk.NewCoins(
+				sdk.NewCoin("ukava", sdkmath.NewInt(1000*KAVA_CF)),
+				sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)),
+				sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)),
+			)
+			err := bankKeeper.MintCoins(ctx, types.ModuleAccountName, hardMaccCoins)
+			suite.Require().NoError(err)
 
-					// Initialize test application
-					tApp.InitializeFromGenesisStates(authGS,
-						app.GenesisState{pricefeedtypes.ModuleName: tApp.AppCodec().MustMarshalJSON(&pricefeedGS)},
-						app.GenesisState{types.ModuleName: tApp.AppCodec().MustMarshalJSON(&hardGS)})
-					// Mint coins to hard module account
-					bankKeeper := tApp.GetBankKeeper()
-					hardMaccCoins := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1000*KAVA_CF)),
-						sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)))
-					err := bankKeeper.MintCoins(ctx, types.ModuleAccountName, hardMaccCoins)
-					suite.Require().NoError(err)
+			keeper := tApp.GetHardKeeper()
+			suite.app = tApp
+			suite.ctx = ctx
+			suite.keeper = keeper
+			// Run BeginBlocker once to transition MoneyMarkets
+			hard.BeginBlocker(suite.ctx, suite.keeper)
+			if err = suite.keeper.Deposit(suite.ctx, tc.setup.borrower, tc.setup.depositCoins); err != nil {
+				suite.Require().Equal(tc.setup.wantDepositErr, err.Error())
+			}
+			// Execute user's previous borrows
+			if err = suite.keeper.Borrow(suite.ctx, tc.setup.borrower, tc.setup.initialBorrowCoins); tc.setup.initialBorrowCoins.IsZero() {
+				suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))
+			} else {
+				suite.Require().NoError(err)
+			}
 
-					keeper := tApp.GetHardKeeper()
-					suite.app = tApp
-					suite.ctx = ctx
-					suite.keeper = keeper
-					// Run BeginBlocker once to transition MoneyMarkets
-					hard.BeginBlocker(suite.ctx, suite.keeper)
-					if err = suite.keeper.Deposit(suite.ctx, arg.borrower, arg.depositCoins); err != nil {
-						suite.Require().Equal(arg.wantDepositErr, err.Error())
-					}
-					// Execute user's previous borrows
-					if err = suite.keeper.Borrow(suite.ctx, arg.borrower, arg.previousBorrowCoins); arg.previousBorrowCoins.IsZero() {
-						suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))
-					} else {
-						suite.Require().NoError(err)
-					}
-					// keep running original first case
-				} else {
-					//suite.Require().NoError(suite.keeper.Withdraw(suite.ctx, arg.borrower, arg.depositCoins))
-					blockDuration := time.Second * 3600 * 30 // long blocks to accumulate larger interest
-					runAtTime := suite.ctx.BlockTime().Add(blockDuration)
-					suite.ctx = suite.ctx.WithBlockTime(runAtTime)
-					// Run BeginBlocker once to transition MoneyMarkets
-					hard.BeginBlocker(suite.ctx, suite.keeper)
-				}
+			for i, borrow := range tc.borrows {
 				// Now that our state is properly set up, execute the last borrow
-				err := suite.keeper.Borrow(suite.ctx, arg.borrower, arg.borrowCoins)
-				if tc.errArgs[i].expectPass {
+				err = suite.keeper.Borrow(suite.ctx, tc.setup.borrower, borrow.borrowCoins)
+				if tc.expected[i].expectPass {
 					suite.Require().NoError(err)
 
 					// Check borrower balance
-					acc := suite.getAccount(arg.borrower)
-					suite.Require().Equal(arg.expectedAccountBalance, suite.getAccountCoins(acc))
+					acc := suite.getAccount(tc.setup.borrower)
+					suite.Require().Equal(tc.expected[i].expectedAccountBalance, suite.getAccountCoins(acc))
 
 					// Check module account balance
 					mAcc := suite.getModuleAccount(types.ModuleAccountName)
-					suite.Require().Equal(arg.expectedModAccountBalance, suite.getAccountCoins(mAcc))
+					suite.Require().Equal(tc.expected[i].expectedModAccountBalance, suite.getAccountCoins(mAcc))
 
 					// Check that borrow struct is in store
-					_, f := suite.keeper.GetBorrow(suite.ctx, arg.borrower)
+					_, f := suite.keeper.GetBorrow(suite.ctx, tc.setup.borrower)
 					suite.Require().True(f)
 				} else {
 					suite.Require().Error(err)
-					suite.Require().True(strings.Contains(err.Error(), tc.errArgs[i].contains))
+					suite.Require().True(strings.Contains(err.Error(), tc.expected[i].contains))
 				}
+				blockDuration := time.Second * 3600 * 30 // long blocks to accumulate larger interest
+				runAtTime := suite.ctx.BlockTime().Add(blockDuration)
+				suite.ctx = suite.ctx.WithBlockTime(runAtTime)
+				// Run BeginBlocker once to transition MoneyMarkets
+				hard.BeginBlocker(suite.ctx, suite.keeper)
+
 			}
 		})
 	}
@@ -759,24 +825,30 @@ func (suite *KeeperTestSuite) TestValidateBorrow() {
 		sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
 	)
 	suite.Require().Error(err)
+	suite.Require().True(strings.Contains(err.Error(), "available to borrow: exceeds module account balance"))
 
 	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(blockDuration))
 	hard.BeginBlocker(suite.ctx, suite.keeper)
 
 	// Should error since ukava has become insolvent at this point
-	suite.Require().Error(suite.keeper.Borrow(
+	err = suite.keeper.Borrow(
 		suite.ctx,
 		borrower,
 		sdk.NewCoins(sdk.NewCoin("ukava", availableToBorrow.AmountOf("ukava"))),
-	))
+	)
+	suite.Require().Error(err)
+	fmt.Println("err: ", err)
+	suite.Require().True(strings.Contains(err.Error(), "protocol reserves exceed available cash"))
 
 	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(blockDuration))
 	hard.BeginBlocker(suite.ctx, suite.keeper)
 
 	// TODO: this is wrong, since usdk is not insolvent, ukava is.
-	suite.Require().Error(suite.keeper.Borrow(
+	err = suite.keeper.Borrow(
 		suite.ctx,
 		borrower,
 		sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
-	))
+	)
+	suite.Require().Error(err)
+	suite.Require().True(strings.Contains(err.Error(), "protocol reserves exceed available cash"))
 }

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -431,7 +431,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				{
 					// THIS SHOULDN'T FAIL
 					expectPass: false,
-					contains:   "reserves 2638559busd,12306usdx > cash 3000000000bnb,1050000000ukava,100000000usdx: insolvency - protocol reserves exceed available cash",
+					contains:   "insolvency - protocol reserves exceed available cash",
 				},
 			},
 		},
@@ -464,7 +464,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 				},
 				{
 					expectPass: false,
-					contains:   "reserves 2638559busd,12306usdx > cash 3000000000bnb,1050000000ukava,100000000usdx: insolvency - protocol reserves exceed available cash",
+					contains:   "insolvency - protocol reserves exceed available cash",
 				},
 			},
 		},

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -9,7 +9,6 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	tmtime "github.com/cometbft/cometbft/types/time"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/hard"
 	"github.com/kava-labs/kava/x/hard/types"
@@ -39,6 +38,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 		borrowCoins               sdk.Coins
 		expectedAccountBalance    sdk.Coins
 		expectedModAccountBalance sdk.Coins
+		wantDepositErr            string
 	}
 	type errArgs struct {
 		expectPass bool
@@ -46,382 +46,572 @@ func (suite *KeeperTestSuite) TestBorrow() {
 	}
 	type borrowTest struct {
 		name    string
-		args    args
-		errArgs errArgs
+		args    []args
+		errArgs []errArgs
 	}
 	testCases := []borrowTest{
 		{
-			"valid",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			name: "valid",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
 			},
-			errArgs{
-				expectPass: true,
-				contains:   "",
-			},
-		},
-		{
-			"invalid: loan-to-value limited",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))},  // 20 KAVA x $5.00 price = $100
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(61*USDX_CF))), // 61 USDX x $1 price = $61
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
 			},
 		},
 		{
-			"valid: multiple deposits",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
-				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(99.9*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(20*USDX_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			name: "invalid: loan-to-value limited",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))},  // 20 KAVA x $5.00 price = $100
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(61*USDX_CF))), // 61 USDX x $1 price = $61
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
 			},
-			errArgs{
-				expectPass: true,
-				contains:   "",
-			},
-		},
-		{
-			"invalid: multiple deposits",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
-				priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(181*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+				},
 			},
 		},
 		{
-			"valid: multiple previous borrows",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
-				previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
+			name: "valid: multiple deposits",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
+					priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(99.9*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(180*USDX_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(20*USDX_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
 			},
-			errArgs{
-				expectPass: true,
-				contains:   "",
-			},
-		},
-		{
-			"invalid: over loan-to-value with multiple previous borrows",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("5.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
-				previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
 			},
 		},
 		{
-			"invalid: no price for asset",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("xyz", sdkmath.NewInt(1))),
-				expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
-				expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+			name: "invalid: multiple deposits",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.80"),
+					priceBTCB:                 sdk.MustNewDecFromStr("10000.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.10"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(0.1*BTCB_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(181*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
 			},
-			errArgs{
-				expectPass: false,
-				contains:   "no price found for market",
-			},
-		},
-		{
-			"invalid: borrow exceed module account balance",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(101*BUSD_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "exceeds borrowable module account balance",
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+				},
 			},
 		},
 		{
-			"invalid: over global asset borrow limit",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
+			name: "valid: multiple previous borrows",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
+					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
+				},
 			},
-			errArgs{
-				expectPass: false,
-				contains:   "fails global asset borrow limit validation",
-			},
-		},
-		{
-			"invalid: borrowing an individual coin type results in a borrow that's under the minimum USD borrow limit",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "below the minimum borrow limit",
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
 			},
 		},
 		{
-			"invalid: borrowing multiple coins results in a borrow that's under the minimum USD borrow limit",
-			args{
-				usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
-				priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
-				loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
-				priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
-				loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
-				priceBNB:                  sdk.MustNewDecFromStr("0.00"),
-				loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
-				borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
-				depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
-				previousBorrowCoins:       sdk.NewCoins(),
-				borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
-				expectedAccountBalance:    sdk.NewCoins(),
-				expectedModAccountBalance: sdk.NewCoins(),
+			name: "invalid: over loan-to-value with multiple previous borrows",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))), // (50 KAVA x $2.00 price = $100) + (30 BNB x $5.00 price = $150) = $250
+					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
 			},
-			errArgs{
-				expectPass: false,
-				contains:   "below the minimum borrow limit",
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "exceeds the allowable amount as determined by the collateralization ratio",
+				},
+			},
+		},
+		{
+			name: "invalid: no price for asset",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "no price found for market",
+				},
+			},
+		},
+		{
+			name: "invalid: borrow exceed module account balance",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(101*BUSD_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "exceeds borrowable module account balance",
+				},
+			},
+		},
+		{
+			name: "invalid: over global asset borrow limit",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "fails global asset borrow limit validation",
+				},
+			},
+		},
+		{
+			name: "invalid: borrowing an individual coin type results in a borrow that's under the minimum USD borrow limit",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "below the minimum borrow limit",
+				},
+			},
+		},
+		{
+			name: "invalid: borrowing multiple coins results in a borrow that's under the minimum USD borrow limit",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("20000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(5*USDX_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(),
+					expectedModAccountBalance: sdk.NewCoins(),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: false,
+					contains:   "below the minimum borrow limit",
+				},
+			},
+		},
+		{
+			name: "valid borrow multiple blocks",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
+				{
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(10*KAVA_CF))},
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(40*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1060*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
+				{
+					expectPass: true,
+				},
+			},
+		},
+		{
+			name: "first valid borrow, second insufficient funds blocks",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.6"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("0.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.01"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))},
+					previousBorrowCoins:       sdk.NewCoins(),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1080*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
+				{
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              []sdk.Coin{sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF))}, // too much
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20*KAVA_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(40*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1060*KAVA_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					wantDepositErr:            "insufficient funds: the requested deposit amount of 100000000ukava exceeds the total available account funds of 20000000ukava: exceeds module account balance",
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
+				{
+					expectPass: true,
+				},
+			},
+		},
+		{
+			name: "valid borrow followed by protocol reserves exceed available cash for busd when borrowing from ukava(incorrect)",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("5.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
+				},
+				{
+					borrower:    sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1*KAVA_CF))),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
+				{
+					// THIS SHOULDN'T FAIL
+					expectPass: false,
+					contains:   "reserves 2638559busd,12306usdx > cash 3000000000bnb,1050000000ukava,100000000usdx: insolvency - protocol reserves exceed available cash",
+				},
+			},
+		},
+		{
+			name: "valid borrow followed by protocol reserves exceed available cash for busd when borrowing from busd",
+			args: []args{
+				{
+					usdxBorrowLimit:           sdk.MustNewDecFromStr("100000000000"),
+					priceKAVA:                 sdk.MustNewDecFromStr("2.00"),
+					loanToValueKAVA:           sdk.MustNewDecFromStr("0.8"),
+					priceBTCB:                 sdk.MustNewDecFromStr("0.00"),
+					loanToValueBTCB:           sdk.MustNewDecFromStr("0.01"),
+					priceBNB:                  sdk.MustNewDecFromStr("5.00"),
+					loanToValueBNB:            sdk.MustNewDecFromStr("0.8"),
+					borrower:                  sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					depositCoins:              sdk.NewCoins(sdk.NewCoin("bnb", sdkmath.NewInt(30*BNB_CF)), sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF))),
+					previousBorrowCoins:       sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+					borrowCoins:               sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(1*USDX_CF))),
+					expectedAccountBalance:    sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(50*KAVA_CF)), sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(70*BNB_CF)), sdk.NewCoin("xyz", sdkmath.NewInt(1))),
+					expectedModAccountBalance: sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1050*KAVA_CF)), sdk.NewCoin("bnb", sdkmath.NewInt(30*BUSD_CF)), sdk.NewCoin("usdx", sdkmath.NewInt(100*USDX_CF))),
+				},
+				{
+					borrower:    sdk.AccAddress(crypto.AddressHash([]byte("test"))),
+					borrowCoins: sdk.NewCoins(sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF))),
+				},
+			},
+			errArgs: []errArgs{
+				{
+					expectPass: true,
+				},
+				{
+					expectPass: false,
+					contains:   "reserves 2638559busd,12306usdx > cash 3000000000bnb,1050000000ukava,100000000usdx: insolvency - protocol reserves exceed available cash",
+				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			// Initialize test app and set context
-			tApp := app.NewTestApp()
-			ctx := tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
-
-			// Auth module genesis state
-			authGS := app.NewFundedGenStateWithCoins(
-				tApp.AppCodec(),
-				[]sdk.Coins{
-					sdk.NewCoins(
-						sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF)),
-						sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)),
-						sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)),
-						sdk.NewCoin("xyz", sdkmath.NewInt(1)),
-					),
-				},
-				[]sdk.AccAddress{tc.args.borrower},
+			suite.Require().Len(tc.args, len(tc.errArgs), "malformed test setup, args should have same number of indexes as errArgs")
+			var (
+				ctx  sdk.Context
+				tApp app.TestApp
 			)
+			for i, arg := range tc.args {
+				if i == 0 {
+					// Initialize test app and set context
+					tApp = app.NewTestApp()
+					ctx = tApp.NewContext(true, tmproto.Header{Height: 1, Time: tmtime.Now()})
 
-			// hard module genesis state
-			hardGS := types.NewGenesisState(types.NewParams(
-				types.MoneyMarkets{
-					types.NewMoneyMarket("usdx", types.NewBorrowLimit(true, tc.args.usdxBorrowLimit, sdk.MustNewDecFromStr("1")), "usdx:usd", sdkmath.NewInt(USDX_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-					types.NewMoneyMarket("busd", types.NewBorrowLimit(false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1")), "busd:usd", sdkmath.NewInt(BUSD_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-					types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(100000000*KAVA_CF), tc.args.loanToValueKAVA), "kava:usd", sdkmath.NewInt(KAVA_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-					types.NewMoneyMarket("btcb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BTCB_CF), tc.args.loanToValueBTCB), "btcb:usd", sdkmath.NewInt(BTCB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-					types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BNB_CF), tc.args.loanToValueBNB), "bnb:usd", sdkmath.NewInt(BNB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-					types.NewMoneyMarket("xyz", types.NewBorrowLimit(false, sdk.NewDec(1), tc.args.loanToValueBNB), "xyz:usd", sdkmath.NewInt(1), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
-				},
-				sdk.NewDec(10),
-			), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
-				types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
-			)
+					// Auth module genesis state
+					authGS := app.NewFundedGenStateWithCoins(
+						tApp.AppCodec(),
+						[]sdk.Coins{
+							sdk.NewCoins(
+								sdk.NewCoin("ukava", sdkmath.NewInt(100*KAVA_CF)),
+								sdk.NewCoin("btcb", sdkmath.NewInt(100*BTCB_CF)),
+								sdk.NewCoin("bnb", sdkmath.NewInt(100*BNB_CF)),
+								sdk.NewCoin("xyz", sdkmath.NewInt(1)),
+							),
+						},
+						[]sdk.AccAddress{arg.borrower},
+					)
 
-			// Pricefeed module genesis state
-			pricefeedGS := pricefeedtypes.GenesisState{
-				Params: pricefeedtypes.Params{
-					Markets: []pricefeedtypes.Market{
-						{MarketID: "usdx:usd", BaseAsset: "usdx", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-						{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-						{MarketID: "kava:usd", BaseAsset: "kava", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-						{MarketID: "btcb:usd", BaseAsset: "btcb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-						{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-						{MarketID: "xyz:usd", BaseAsset: "xyz", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
-					},
-				},
-				PostedPrices: []pricefeedtypes.PostedPrice{
-					{
-						MarketID:      "usdx:usd",
-						OracleAddress: sdk.AccAddress{},
-						Price:         sdk.MustNewDecFromStr("1.00"),
-						Expiry:        time.Now().Add(1 * time.Hour),
-					},
-					{
-						MarketID:      "busd:usd",
-						OracleAddress: sdk.AccAddress{},
-						Price:         sdk.MustNewDecFromStr("1.00"),
-						Expiry:        time.Now().Add(1 * time.Hour),
-					},
-					{
-						MarketID:      "kava:usd",
-						OracleAddress: sdk.AccAddress{},
-						Price:         tc.args.priceKAVA,
-						Expiry:        time.Now().Add(1 * time.Hour),
-					},
-					{
-						MarketID:      "btcb:usd",
-						OracleAddress: sdk.AccAddress{},
-						Price:         tc.args.priceBTCB,
-						Expiry:        time.Now().Add(1 * time.Hour),
-					},
-					{
-						MarketID:      "bnb:usd",
-						OracleAddress: sdk.AccAddress{},
-						Price:         tc.args.priceBNB,
-						Expiry:        time.Now().Add(1 * time.Hour),
-					},
-				},
-			}
+					// hard module genesis state
+					hardGS := types.NewGenesisState(types.NewParams(
+						types.MoneyMarkets{
+							types.NewMoneyMarket("usdx", types.NewBorrowLimit(true, arg.usdxBorrowLimit, sdk.MustNewDecFromStr("1")), "usdx:usd", sdkmath.NewInt(USDX_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+							types.NewMoneyMarket("busd", types.NewBorrowLimit(false, sdk.NewDec(100000000*BUSD_CF), sdk.MustNewDecFromStr("1")), "busd:usd", sdkmath.NewInt(BUSD_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+							types.NewMoneyMarket("ukava", types.NewBorrowLimit(false, sdk.NewDec(100000000*KAVA_CF), arg.loanToValueKAVA), "kava:usd", sdkmath.NewInt(KAVA_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.99"), sdk.ZeroDec()),
+							types.NewMoneyMarket("btcb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BTCB_CF), arg.loanToValueBTCB), "btcb:usd", sdkmath.NewInt(BTCB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+							types.NewMoneyMarket("bnb", types.NewBorrowLimit(false, sdk.NewDec(100000000*BNB_CF), arg.loanToValueBNB), "bnb:usd", sdkmath.NewInt(BNB_CF), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+							types.NewMoneyMarket("xyz", types.NewBorrowLimit(false, sdk.NewDec(1), arg.loanToValueBNB), "xyz:usd", sdkmath.NewInt(1), types.NewInterestRateModel(sdk.MustNewDecFromStr("0.05"), sdk.MustNewDecFromStr("2"), sdk.MustNewDecFromStr("0.8"), sdk.MustNewDecFromStr("10")), sdk.MustNewDecFromStr("0.05"), sdk.ZeroDec()),
+						},
+						sdk.NewDec(10),
+					), types.DefaultAccumulationTimes, types.DefaultDeposits, types.DefaultBorrows,
+						types.DefaultTotalSupplied, types.DefaultTotalBorrowed, types.DefaultTotalReserves,
+					)
 
-			// Initialize test application
-			tApp.InitializeFromGenesisStates(authGS,
-				app.GenesisState{pricefeedtypes.ModuleName: tApp.AppCodec().MustMarshalJSON(&pricefeedGS)},
-				app.GenesisState{types.ModuleName: tApp.AppCodec().MustMarshalJSON(&hardGS)})
+					// Pricefeed module genesis state
+					pricefeedGS := pricefeedtypes.GenesisState{
+						Params: pricefeedtypes.Params{
+							Markets: []pricefeedtypes.Market{
+								{MarketID: "usdx:usd", BaseAsset: "usdx", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+								{MarketID: "busd:usd", BaseAsset: "busd", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+								{MarketID: "kava:usd", BaseAsset: "kava", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+								{MarketID: "btcb:usd", BaseAsset: "btcb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+								{MarketID: "bnb:usd", BaseAsset: "bnb", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+								{MarketID: "xyz:usd", BaseAsset: "xyz", QuoteAsset: "usd", Oracles: []sdk.AccAddress{}, Active: true},
+							},
+						},
+						PostedPrices: []pricefeedtypes.PostedPrice{
+							{
+								MarketID:      "usdx:usd",
+								OracleAddress: sdk.AccAddress{},
+								Price:         sdk.MustNewDecFromStr("1.00"),
+								Expiry:        time.Now().Add(1 * time.Hour),
+							},
+							{
+								MarketID:      "busd:usd",
+								OracleAddress: sdk.AccAddress{},
+								Price:         sdk.MustNewDecFromStr("1.00"),
+								Expiry:        time.Now().Add(1 * time.Hour),
+							},
+							{
+								MarketID:      "kava:usd",
+								OracleAddress: sdk.AccAddress{},
+								Price:         arg.priceKAVA,
+								Expiry:        time.Now().Add(1 * time.Hour),
+							},
+							{
+								MarketID:      "btcb:usd",
+								OracleAddress: sdk.AccAddress{},
+								Price:         arg.priceBTCB,
+								Expiry:        time.Now().Add(1 * time.Hour),
+							},
+							{
+								MarketID:      "bnb:usd",
+								OracleAddress: sdk.AccAddress{},
+								Price:         arg.priceBNB,
+								Expiry:        time.Now().Add(1 * time.Hour),
+							},
+						},
+					}
 
-			// Mint coins to hard module account
-			bankKeeper := tApp.GetBankKeeper()
-			hardMaccCoins := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1000*KAVA_CF)),
-				sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)))
-			err := bankKeeper.MintCoins(ctx, types.ModuleAccountName, hardMaccCoins)
-			suite.Require().NoError(err)
+					// Initialize test application
+					tApp.InitializeFromGenesisStates(authGS,
+						app.GenesisState{pricefeedtypes.ModuleName: tApp.AppCodec().MustMarshalJSON(&pricefeedGS)},
+						app.GenesisState{types.ModuleName: tApp.AppCodec().MustMarshalJSON(&hardGS)})
+					// Mint coins to hard module account
+					bankKeeper := tApp.GetBankKeeper()
+					hardMaccCoins := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(1000*KAVA_CF)),
+						sdk.NewCoin("usdx", sdkmath.NewInt(200*USDX_CF)), sdk.NewCoin("busd", sdkmath.NewInt(100*BUSD_CF)))
+					err := bankKeeper.MintCoins(ctx, types.ModuleAccountName, hardMaccCoins)
+					suite.Require().NoError(err)
 
-			keeper := tApp.GetHardKeeper()
-			suite.app = tApp
-			suite.ctx = ctx
-			suite.keeper = keeper
+					keeper := tApp.GetHardKeeper()
+					suite.app = tApp
+					suite.ctx = ctx
+					suite.keeper = keeper
+					// Run BeginBlocker once to transition MoneyMarkets
+					hard.BeginBlocker(suite.ctx, suite.keeper)
+					if err = suite.keeper.Deposit(suite.ctx, arg.borrower, arg.depositCoins); err != nil {
+						suite.Require().Equal(arg.wantDepositErr, err.Error())
+					}
+					// Execute user's previous borrows
+					if err = suite.keeper.Borrow(suite.ctx, arg.borrower, arg.previousBorrowCoins); arg.previousBorrowCoins.IsZero() {
+						suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))
+					} else {
+						suite.Require().NoError(err)
+					}
+					// keep running original first case
+				} else {
+					//suite.Require().NoError(suite.keeper.Withdraw(suite.ctx, arg.borrower, arg.depositCoins))
+					blockDuration := time.Second * 3600 * 30 // long blocks to accumulate larger interest
+					runAtTime := suite.ctx.BlockTime().Add(blockDuration)
+					suite.ctx = suite.ctx.WithBlockTime(runAtTime)
+					// Run BeginBlocker once to transition MoneyMarkets
+					hard.BeginBlocker(suite.ctx, suite.keeper)
+				}
+				// Now that our state is properly set up, execute the last borrow
+				err := suite.keeper.Borrow(suite.ctx, arg.borrower, arg.borrowCoins)
+				if tc.errArgs[i].expectPass {
+					suite.Require().NoError(err)
 
-			// Run BeginBlocker once to transition MoneyMarkets
-			hard.BeginBlocker(suite.ctx, suite.keeper)
+					// Check borrower balance
+					acc := suite.getAccount(arg.borrower)
+					suite.Require().Equal(arg.expectedAccountBalance, suite.getAccountCoins(acc))
 
-			err = suite.keeper.Deposit(suite.ctx, tc.args.borrower, tc.args.depositCoins)
-			suite.Require().NoError(err)
+					// Check module account balance
+					mAcc := suite.getModuleAccount(types.ModuleAccountName)
+					suite.Require().Equal(arg.expectedModAccountBalance, suite.getAccountCoins(mAcc))
 
-			// Execute user's previous borrows
-			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.previousBorrowCoins)
-			if tc.args.previousBorrowCoins.IsZero() {
-				suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))
-			} else {
-				suite.Require().NoError(err)
-			}
-
-			// Now that our state is properly set up, execute the last borrow
-			err = suite.keeper.Borrow(suite.ctx, tc.args.borrower, tc.args.borrowCoins)
-
-			if tc.errArgs.expectPass {
-				suite.Require().NoError(err)
-
-				// Check borrower balance
-				acc := suite.getAccount(tc.args.borrower)
-				suite.Require().Equal(tc.args.expectedAccountBalance, suite.getAccountCoins(acc))
-
-				// Check module account balance
-				mAcc := suite.getModuleAccount(types.ModuleAccountName)
-				suite.Require().Equal(tc.args.expectedModAccountBalance, suite.getAccountCoins(mAcc))
-
-				// Check that borrow struct is in store
-				_, f := suite.keeper.GetBorrow(suite.ctx, tc.args.borrower)
-				suite.Require().True(f)
-			} else {
-				suite.Require().Error(err)
-				suite.Require().True(strings.Contains(err.Error(), tc.errArgs.contains))
+					// Check that borrow struct is in store
+					_, f := suite.keeper.GetBorrow(suite.ctx, arg.borrower)
+					suite.Require().True(f)
+				} else {
+					suite.Require().Error(err)
+					suite.Require().True(strings.Contains(err.Error(), tc.errArgs[i].contains))
+				}
 			}
 		})
 	}
@@ -561,4 +751,32 @@ func (suite *KeeperTestSuite) TestValidateBorrow() {
 		sdk.NewCoins(sdk.NewCoin("ukava", availableToBorrow.AmountOf("ukava"))),
 	)
 	suite.Require().NoError(err)
+
+	// now that it's all that you can borrow, we shouldn't be able to borrow anything
+	err = suite.keeper.Borrow(
+		suite.ctx,
+		borrower,
+		sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(2*USDX_CF))),
+	)
+	suite.Require().Error(err)
+
+	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(blockDuration))
+	hard.BeginBlocker(suite.ctx, suite.keeper)
+
+	// Should error since ukava has become insolvent at this point
+	suite.Require().Error(suite.keeper.Borrow(
+		suite.ctx,
+		borrower,
+		sdk.NewCoins(sdk.NewCoin("ukava", availableToBorrow.AmountOf("ukava"))),
+	))
+
+	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(blockDuration))
+	hard.BeginBlocker(suite.ctx, suite.keeper)
+
+	// TODO: this is wrong, since usdk is not insolvent, ukava is.
+	suite.Require().Error(suite.keeper.Borrow(
+		suite.ctx,
+		borrower,
+		sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(25*USDX_CF))),
+	))
 }

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -637,7 +637,7 @@ func (suite *KeeperTestSuite) TestBorrow() {
 			suite.keeper = keeper
 			// Run BeginBlocker once to transition MoneyMarkets
 			hard.BeginBlocker(suite.ctx, suite.keeper)
-			suite.Require().NoError(suite.keeper.Deposit(suite.ctx, tc.setup.borrower, tc.setup.depositCoins)
+			suite.Require().NoError(suite.keeper.Deposit(suite.ctx, tc.setup.borrower, tc.setup.depositCoins))
 			// Execute user's previous borrows
 			if err = suite.keeper.Borrow(suite.ctx, tc.setup.borrower, tc.setup.initialBorrowCoins); tc.setup.initialBorrowCoins.IsZero() {
 				suite.Require().True(strings.Contains(err.Error(), "cannot borrow zero coins"))

--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -54,6 +54,13 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 			}
 		}
 	}
+	//1081000000
+	//2000000000ukava
+	// fundsAvailableToBorrow:  10000000000busd,1079999775ukava,200000000usdx
+	//hardMaccCoins:  10000000000busd,1080000001ukava,200000000usdx
+	//hardMaccCoins:  10000000000busd,1080000001ukava,200000000usdx
+
+	// fundsAvailableToBorrow:  10000000000busd,1079999775ukava,200000000usdx
 	if err != nil {
 		return err
 	}

--- a/x/hard/keeper/deposit.go
+++ b/x/hard/keeper/deposit.go
@@ -54,13 +54,6 @@ func (k Keeper) Deposit(ctx sdk.Context, depositor sdk.AccAddress, coins sdk.Coi
 			}
 		}
 	}
-	//1081000000
-	//2000000000ukava
-	// fundsAvailableToBorrow:  10000000000busd,1079999775ukava,200000000usdx
-	//hardMaccCoins:  10000000000busd,1080000001ukava,200000000usdx
-	//hardMaccCoins:  10000000000busd,1080000001ukava,200000000usdx
-
-	// fundsAvailableToBorrow:  10000000000busd,1079999775ukava,200000000usdx
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
[closes](https://app.shortcut.com/kava-labs/story/13867/write-failing-test-for-global-insolvency-check)
[security questionnaire
](https://app.shortcut.com/kava-labs/story/13868/fill-out-security-questionnaire-for-hard-insolvency-check-fix)<!--- Describe your changes in detail -->

When a user borrows funds from Kava Lend, the system checks if there are sufficient funds to process the request. A lack of sufficient funds indicates insolvency, meaning that bad debt has accumulated in a particular money market, resulting in liabilities exceeding deposits.

The current check is global. For example, if a user wants to borrow ATOM, the `ValidateBorrow` function will throw an error if the BNB market is insolvent. We want to change this check to be local, so that an insolvency error is only thrown if the specific money market being borrowed from is insolvent, not another unrelated market.

This PR adds tests to highlight the current issue with the borrowing functionality in Kava Lend. The current global insolvency check causes borrow requests to fail even if the specific market being borrowed from is solvent. These tests demonstrate the problem and will serve as the basis for a follow-up PR to fix the issue.

* Added new tests to:
  * Attempt to borrow funds from an insolvent market (should fail).
  * Attempt to borrow funds from a solvent market when there is also an insolvent market (currently does not fail but should).
* Example:
    * Money market x is solvent
    * Money market y is insolvent
    * User goes to borrow from money market x - it fails.
    * User goes to borrow from money market y - it fails.
    * Once the logic is fixed, the test for money market x should pass, and the test for money market y should continue to fail. 

* Additional Notes
  * These tests are designed to pass once the issue is fixed in a follow-up PR.

## Checklist
 - [ ] Changelog has been updated as necessary.
 

