### PR TITLE
chore(lint): Enable localmodule for import linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,6 +95,7 @@ linters-settings:
     sections: # defines the order of import sections
       - standard
       - default
+      - localmodule
   goconst:
     min-len: 3 # min length for string constants to be checked
     min-occurrences: 3 # min occurrences of the same constant before it's flagged


### PR DESCRIPTION
We use three sections of imports across the code base, however it has not previously been enforced by linting.

This enables https://golangci-lint.run/usage/linters/#gci to enforce this convention.