### PR TITLE
fix(e2e): Use docker compose V2 for kvtool and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,10 @@ build-docker-local-kava:
 # Run a 4-node testnet locally
 localnet-start: build-linux localnet-stop
 	@if ! [ -f build/node0/kvd/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/kvd:Z kava/kavanode testnet --v 4 -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
-	docker-compose up -d
+	$(DOCKER) compose up -d
 
 localnet-stop:
-	docker-compose down
+	$(DOCKER) compose down
 
 # Launch a new single validator chain
 start:
@@ -346,7 +346,7 @@ start-remote-sims:
 	# submit an array job on AWS Batch, using 1000 seeds, spot instances
 	aws batch submit-job \
 		-—job-name "master-$(VERSION)" \
-		-—job-queue “simulation-1-queue-spot" \
+		-—job-queue "simulation-1-queue-spot" \
 		-—array-properties size=1000 \
 		-—job-definition kava-sim-master \
 		-—container-override environment=[{SIM_NAME=master-$(VERSION)}]


### PR DESCRIPTION
This updates the kvtool submodule to the latest master, brining in @pirtleshell's fix for docker compose v2.  In addition, updates the makefile commands to also use V2 instead of V1.

This fixes failing e2e tests in actions without the `docker-compose` alias.

More details: https://docs.docker.com/compose/migrate/

KVTool Fix - https://github.com/Kava-Labs/kvtool/pull/201