### PR TITLE
chore(lint): Update local make lint to match CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ out
 # Ignore build cache dir
 build/.cache
 
+# Ignore make lint cache
+build/.golangci-lint
+
 # Ignore installed binaires
 build/bin
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ include $(BUILD_DIR)/deps.mk
 include $(BUILD_DIR)/proto.mk
 include $(BUILD_DIR)/proto-deps.mk
 
+include $(BUILD_DIR)/lint.mk
+
 #export GO111MODULE = on
 # process build tags
 build_tags = netgo
@@ -229,13 +231,6 @@ link-check:
 	@$(GO_BIN) get -u github.com/raviqqe/liche@f57a5d1c5be4856454cb26de155a65a4fd856ee3
 	liche -r . --exclude "^http://127.*|^https://riot.im/app*|^http://kava-testnet*|^https://testnet-dex*|^https://kava3.data.kava.io*|^https://ipfs.io*|^https://apps.apple.com*|^https://kava.quicksync.io*"
 
-
-lint:
-	golangci-lint run
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
-	$(GO_BIN) mod verify
-.PHONY: lint
-
 format:
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -name '*.pb.go' | xargs gofmt -w -s
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -name '*.pb.go' | xargs misspell -w
@@ -356,4 +351,4 @@ update-kvtool:
 	git submodule update
 	cd tests/e2e/kvtool && make install
 
-.PHONY: all build-linux install clean build test test-cli test-all test-rest test-basic test-fuzz start-remote-sims
+.PHONY: all build-linux install build test test-cli test-all test-rest test-basic test-fuzz start-remote-sims

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -1,0 +1,38 @@
+################################################################################
+###                             Required Variables                           ###
+################################################################################
+ifndef DOCKER
+$(error DOCKER not set)
+endif
+
+ifndef BUILD_CACHE_DIR
+$(error BUILD_CACHE_DIR not set)
+endif
+
+################################################################################
+###                             Lint Settings                                ###
+################################################################################
+
+LINT_FROM_REV ?= $(shell git merge-base origin/master HEAD)
+
+GOLANGCI_VERSION ?= $(shell cat .golangci-version)
+GOLANGCI_IMAGE_TAG ?= golangci/golangci-lint:$(GOLANGCI_VERSION)
+
+GOLANGCI_CACHE_DIR ?= $(CURDIR)/$(BUILD_CACHE_DIR)/golangci-lint/$(GOLANGCI_VERSION)
+
+################################################################################
+###                             Lint Target                                  ###
+################################################################################
+
+.PHONY: lint
+lint: $(GOLANGCI_CACHE_DIR)
+	@echo "Running lint from rev $(LINT_FROM_REV), use LINT_FROM_REV var to override."
+	$(DOCKER) run -t --rm \
+		-v $(GOLANGCI_CACHE_DIR):/root/cache \
+		-v $(CURDIR):/app \
+		-w /app \
+		$(GOLANGCI_IMAGE_TAG) \
+		golangci-lint run -v --timeout 10m --new-from-rev $(LINT_FROM_REV)
+
+$(GOLANGCI_CACHE_DIR):
+	@mkdir -p $@

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -28,7 +28,7 @@ GOLANGCI_CACHE_DIR ?= $(CURDIR)/$(BUILD_CACHE_DIR)/golangci-lint/$(GOLANGCI_VERS
 lint: $(GOLANGCI_CACHE_DIR)
 	@echo "Running lint from rev $(LINT_FROM_REV), use LINT_FROM_REV var to override."
 	$(DOCKER) run -t --rm \
-		-v $(GOLANGCI_CACHE_DIR):/root/cache \
+		-v $(GOLANGCI_CACHE_DIR):/root/.cache \
 		-v $(CURDIR):/app \
 		-w /app \
 		$(GOLANGCI_IMAGE_TAG) \

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -5,8 +5,8 @@ ifndef DOCKER
 $(error DOCKER not set)
 endif
 
-ifndef BUILD_CACHE_DIR
-$(error BUILD_CACHE_DIR not set)
+ifndef BUILD_DIR
+$(error BUILD_DIR not set)
 endif
 
 ################################################################################
@@ -18,21 +18,28 @@ LINT_FROM_REV ?= $(shell git merge-base origin/master HEAD)
 GOLANGCI_VERSION ?= $(shell cat .golangci-version)
 GOLANGCI_IMAGE_TAG ?= golangci/golangci-lint:$(GOLANGCI_VERSION)
 
-GOLANGCI_CACHE_DIR ?= $(CURDIR)/$(BUILD_CACHE_DIR)/golangci-lint/$(GOLANGCI_VERSION)
+GOLANGCI_DIR ?= $(CURDIR)/$(BUILD_DIR)/.golangci-lint
+
+GOLANGCI_CACHE_DIR ?= $(GOLANGCI_DIR)/$(GOLANGCI_VERSION)-cache
+GOLANGCI_MOD_CACHE_DIR ?= $(GOLANGCI_DIR)/go-mod
 
 ################################################################################
 ###                             Lint Target                                  ###
 ################################################################################
 
 .PHONY: lint
-lint: $(GOLANGCI_CACHE_DIR)
+lint: $(GOLANGCI_CACHE_DIR) $(GOLANGCI_MOD_CACHE_DIR)
 	@echo "Running lint from rev $(LINT_FROM_REV), use LINT_FROM_REV var to override."
 	$(DOCKER) run -t --rm \
 		-v $(GOLANGCI_CACHE_DIR):/root/.cache \
+		-v $(GOLANGCI_MOD_CACHE_DIR):/go/pkg/mod \
 		-v $(CURDIR):/app \
 		-w /app \
 		$(GOLANGCI_IMAGE_TAG) \
 		golangci-lint run -v --new-from-rev $(LINT_FROM_REV)
 
 $(GOLANGCI_CACHE_DIR):
+	@mkdir -p $@
+
+$(GOLANGCI_MOD_CACHE_DIR):
 	@mkdir -p $@

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -32,7 +32,7 @@ lint: $(GOLANGCI_CACHE_DIR)
 		-v $(CURDIR):/app \
 		-w /app \
 		$(GOLANGCI_IMAGE_TAG) \
-		golangci-lint run -v --timeout 10m --new-from-rev $(LINT_FROM_REV)
+		golangci-lint run -v --new-from-rev $(LINT_FROM_REV)
 
 $(GOLANGCI_CACHE_DIR):
 	@mkdir -p $@


### PR DESCRIPTION
# Description

This updates the `make lint` behavior to match the command being run in CI.

In addition, we refactor the make lint command to use docker in order to to ease cross platform install, use a local build cache that integrates with make clean, use the same version file, and encapsulate the logic in its own make include.

We also remove the old lint logic as to not introduce a duplicate target and avoid confusion from a difference in behavior.

While solutions like act for running GitHub actions locally work, it is not as straightforward, is slower, ~~and uses a clone instead of the local repository (though I am not sure how the checkout step works within act)~~.  Edit: Act by default skips the clone and used `docker cp` to copy the local repository into the runner container.

Using `act -W '.github/workflows/ci-lint.yml' -j golangci-lint` took about 26 seconds on a fresh EC2 instance after caching was warmed.

Using `make lint` took 1.9 seconds on a fresh EC2 instance after cache was warmed.

In general as well, act is quite verbose and I couldn't find an option to hide a lot of the logs as well as show color for the golangci-lint output.

# Using
`make lint`
`LINT_FROM_REV=HEAD~1 make lint`

# Testing
I tested against lint errors locally and verified the --new-from-rev behavior works as expected.