### PR TITLE
chore(make): Allow docker comamnd override and error if not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ print-version:
 ################################################################################
 LEDGER_ENABLED ?= true
 
-DOCKER:=docker
+DOCKER ?= docker
 ifeq ($(shell command -v $(DOCKER)),)
 $(error "Docker command '$(DOCKER)' not found. Please install Docker.")
 endif

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,12 @@ print-version:
 ###                             Project Settings                             ###
 ################################################################################
 LEDGER_ENABLED ?= true
+
 DOCKER:=docker
+ifeq ($(shell command -v $(DOCKER)),)
+$(error "Docker command '$(DOCKER)' not found. Please install Docker.")
+endif
+
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 HTTPS_GIT := https://github.com/Kava-Labs/kava.git
 


### PR DESCRIPTION
This updates the makefile to allow the command used for docker to be overridden with the DOCKER variable, and adds a check that fails if docker is not installed.  Tested with `make DOCKER=foo`.