### PR TITLE
chore(lint): Disable funlen for test functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,13 @@ linters:
 #    - whitespace
     - wrapcheck
 
+issues:
+  exclude-rules:
+    # Disable funlen for "func Test..." or func (suite *Suite) Test..." type functions
+    # These functions tend to be descriptive and exceed length limits.
+    - source: "^func (\\(.*\\) )?Test"
+      linters:
+        - funlen
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
This adds a regular expression that matches `func Test...` or `func (suite *Suite) Test...` style functions and disables the length check. An example from e2e tests that failed lint:

`func (suite *IntegrationTestSuite) TestEip712BasicMessageAuthorization()`

I tested with different variations locally on some existing functions and new functions.