### PR TITLE
fix(docker): Ignore local build and lint cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,10 @@ docs/
 networks/
 scratch/
 
+# Ignore build cache directories to avoid
+# errors when addings these to docker images
+build/.cache
+build/.golangci-lint
+
 go.work
 go.work.sum


### PR DESCRIPTION
These should not be replicated to docker contexts as they are local to the build host.  In addition, the golangci-lint currently doesn't assume the host user nor add other group read permissions when writing files, so this causes permission errors when other docker processes attempt to copy the files.

This caused a failure locally when running e2e tests for me and was caused by the addition of the golangci-lint local cache.  These can be safely ignored.
