### PR TITLE
deps: use tagged ethermint version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ replace (
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20240719184950-8c96f0354a6d
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v26.4
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,8 @@ github.com/kava-labs/cometbft-db v0.9.1-kava.2 h1:ZQaio886ifvml9XtJB4IYHhlArgA3+
 github.com/kava-labs/cometbft-db v0.9.1-kava.2/go.mod h1:PvUZbx7zeR7I4CAvtKBoii/5ia5gXskKjDjIVpt7gDw=
 github.com/kava-labs/cosmos-sdk v0.47.10-kava.3 h1:Fi+5URpyAoNbnHHBfps9etLV1kLsdaJUlua1KfDzOK4=
 github.com/kava-labs/cosmos-sdk v0.47.10-kava.3/go.mod h1:xgOZMrQ6t8zZ1XFtEPOfzo6oYN/N1dD3qIlwD/rszCo=
-github.com/kava-labs/ethermint v0.21.1-0.20240719184950-8c96f0354a6d h1:/z7P2VZXASpqylmA3fUvc3SxHHkc5w5iwhnl9wC6bu0=
-github.com/kava-labs/ethermint v0.21.1-0.20240719184950-8c96f0354a6d/go.mod h1:wUJe3AdwUTGoyW82cgbSLfXUDxmrJyKmR59vClnkD/I=
+github.com/kava-labs/ethermint v0.21.0-kava-v26.4 h1:/b6qWXZYNuqRG4FtQI5gPbsq/FuKaF6/h0e/3lXewLI=
+github.com/kava-labs/ethermint v0.21.0-kava-v26.4/go.mod h1:wUJe3AdwUTGoyW82cgbSLfXUDxmrJyKmR59vClnkD/I=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
NOTE: the tag references the exact same ethermint commit as the v0.26.2 release. this commit simply updates go.mod to refer to the tag instead of the hardcoded commit version.
