### PR TITLE
cli: explicitly close tree in iavlviewer cmd

### DIFF
--- a/cmd/kava/cmd/iavlviewer/data.go
+++ b/cmd/kava/cmd/iavlviewer/data.go
@@ -29,6 +29,7 @@ func newDataCmd(opts ethermintserver.StartOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer tree.Close()
 
 			printKeys(tree)
 			hash := tree.Hash()

--- a/cmd/kava/cmd/iavlviewer/hash.go
+++ b/cmd/kava/cmd/iavlviewer/hash.go
@@ -27,6 +27,7 @@ func newHashCmd(opts ethermintserver.StartOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer tree.Close()
 
 			fmt.Printf("Hash: %X\n", tree.Hash())
 

--- a/cmd/kava/cmd/iavlviewer/root.go
+++ b/cmd/kava/cmd/iavlviewer/root.go
@@ -10,11 +10,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/store/wrapper"
-	ethermintserver "github.com/evmos/ethermint/server"
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/iavl"
 	iavldb "github.com/cosmos/iavl/db"
+	ethermintserver "github.com/evmos/ethermint/server"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -69,7 +68,7 @@ func openPrefixTree(opts ethermintserver.StartOptions, cmd *cobra.Command, prefi
 
 // ReadTree loads an iavl tree from the directory
 // If version is 0, load latest, otherwise, load named version
-// The prefix represents which iavl tree you want to read. The iaviwer will always set a prefix.
+// The prefix represents which iavl tree you want to read. The iaviewer will always set a prefix.
 func readTree(db dbm.DB, version int, prefix []byte) (*iavl.MutableTree, error) {
 	if len(prefix) != 0 {
 		db = dbm.NewPrefixDB(db, prefix)

--- a/cmd/kava/cmd/iavlviewer/shape.go
+++ b/cmd/kava/cmd/iavlviewer/shape.go
@@ -29,6 +29,7 @@ func newShapeCmd(opts ethermintserver.StartOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer tree.Close()
 
 			printShape(tree)
 
@@ -40,7 +41,6 @@ func newShapeCmd(opts ethermintserver.StartOptions) *cobra.Command {
 }
 
 func printShape(tree *iavl.MutableTree) {
-	// shape := tree.RenderShape("  ", nil)
 	// TODO: handle this error
 	shape, _ := tree.RenderShape("  ", nodeEncoder)
 	fmt.Println(strings.Join(shape, "\n"))

--- a/cmd/kava/cmd/iavlviewer/versions.go
+++ b/cmd/kava/cmd/iavlviewer/versions.go
@@ -22,6 +22,7 @@ func newVersionsCmd(opts ethermintserver.StartOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer tree.Close()
 
 			printVersions(tree)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
explicitly closes the IAVL tree in all iavlviewer subcommands. though not strictly necessary, it seems a worthwhile practice.

came up in discussion here: https://github.com/Kava-Labs/kava/pull/1996#discussion_r1709507465

contains no functional changes to the cmd.
