### PR TITLE
ci: add semantic pull request title linting

### DIFF
--- a/.github/workflows/ci-pr-lint.yml
+++ b/.github/workflows/ci-pr-lint.yml
@@ -1,0 +1,27 @@
+# this workflow is responsible for ensuring quality titles are given to all PRs
+# for PR checks to pass, the title must follow the Conventional Commits standard
+# https://www.conventionalcommits.org/en/v1.0.0/
+# this workflow was adapted from a similar workflow in https://github.com/cosmos/cosmos-sdk
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    permissions:
+      pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/semantic-pull-request
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
enforces following conventional commit standard in all PR titles

~~opening with bad pr title to check for failure 😄~~