### PR TITLE
ci: dispatch run-rosetta-tests event to rosetta-kava

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -45,6 +45,9 @@ jobs:
       dockerhub-username: kavaops
       extra-image-tag: master
     secrets: inherit
+  rosetta:
+    uses: ./.github/workflows/ci-rosetta.yml
+    secrets: inherit
   post-pipeline-metrics:
     uses: ./.github/workflows/metric-pipeline.yml
     if: always() # always run so we metric failures and successes

--- a/.github/workflows/ci-rosetta.yml
+++ b/.github/workflows/ci-rosetta.yml
@@ -1,0 +1,16 @@
+name: Dispatch run-rosetta-tests event to rosetta-kava
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch run-rosetta-tests event to rosetta-kava
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.KAVA_PUBLIC_GITHUB_ACCESS_TOKEN }}
+          repository: Kava-Labs/rosetta-kava
+          event-type: run-rosetta-tests
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
PR adds new `Dispatch run-rosetta-tests event to rosetta-kava` CI workflow, which triggers re-running tests in rosetta-kava repo.

Related to:
- https://github.com/Kava-Labs/rosetta-kava/pull/69
- https://github.com/Kava-Labs/rosetta-kava/pull/70