### PR TITLE
chore(ci): update internal testnet genesis and seed to support committee voting

### DIFF
--- a/.github/scripts/seed-internal-testnet.sh
+++ b/.github/scripts/seed-internal-testnet.sh
@@ -185,6 +185,23 @@ sleep $AVG_SECONDS_BETWEEN_BLOCKS
 updatedEvmUtilParams=$(curl https://api.app.internal.testnet.us-east.production.kava.io/kava/evmutil/v1beta1/params)
 printf "updated evm util module params\n %s" , "$updatedEvmUtilParams"
 
+# submit a kava token committee proposal
+COMMITTEE_PROP_TEMPLATE=$(
+  cat <<'END_HEREDOC'
+{
+    "@type": "/cosmos.gov.v1beta1.TextProposal",
+    "title": "The next big thing signaling proposal.",
+    "description": "The purpose of this proposal is to signal support/opposition to the next big thing"
+}
+END_HEREDOC
+)
+committeeProposalFileName="$(date +%s)-committee-proposal.json"
+touch $committeeProposalFileName
+echo "$COMMITTEE_PROP_TEMPLATE" >$committeeProposalFileName
+
+# committee 4 is the hard token committee
+kava tx committee submit-proposal 4 "$committeeProposalFileName" --gas 2000000 --gas-prices 0.01ukava --from god -y
+
 # if adding more cosmos coins -> er20s, ensure that the deployment order below remains the same.
 # convert 1 HARD to an erc20. doing this ensures the contract is deployed.
 kava tx evmutil convert-cosmos-coin-to-erc20 \

--- a/.github/scripts/seed-internal-testnet.sh
+++ b/.github/scripts/seed-internal-testnet.sh
@@ -196,11 +196,9 @@ COMMITTEE_PROP_TEMPLATE=$(
 END_HEREDOC
 )
 committeeProposalFileName="$(date +%s)-committee-proposal.json"
-touch $committeeProposalFileName
 echo "$COMMITTEE_PROP_TEMPLATE" >$committeeProposalFileName
-
-# committee 4 is the hard token committee
-kava tx committee submit-proposal 4 "$committeeProposalFileName" --gas 2000000 --gas-prices 0.01ukava --from god -y
+tokenCommitteeId=4
+kava tx committee submit-proposal "$tokenCommitteeId" "$committeeProposalFileName" --gas auto --gas-adjustment 1.5 --gas-prices 0.01ukava --from god -y
 
 # if adding more cosmos coins -> er20s, ensure that the deployment order below remains the same.
 # convert 1 HARD to an erc20. doing this ensures the contract is deployed.

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -993,8 +993,7 @@
             "check_collateralization_index_count": "10",
             "conversion_factor": "6"
           }
-        ]
-        ,
+        ],
         "debt_auction_lot": "10000000000",
         "debt_auction_threshold": "100000000000",
         "debt_param": {
@@ -2064,6 +2063,25 @@
               {
                 "name": "payment",
                 "type": "Coin"
+              }
+            ],
+            "nested_types": []
+          },
+          {
+            "msg_type_url": "/kava.committee.v1beta1.MsgVote",
+            "msg_value_type_name": "MsgValueCommitteeVote",
+            "value_types": [
+              {
+                "name": "proposal_id",
+                "type": "uint64"
+              },
+              {
+                "name": "voter",
+                "type": "string"
+              },
+              {
+                "name": "vote_type",
+                "type": "int32"
               }
             ],
             "nested_types": []

--- a/ci/env/kava-protonet/genesis.json
+++ b/ci/env/kava-protonet/genesis.json
@@ -2172,7 +2172,7 @@
         "max_deposit_period": "172800s"
       },
       "voting_params": {
-        "voting_period": "600s"
+        "voting_period": "604800s"
       },
       "tally_params": {
         "quorum": "0.334000000000000000",
@@ -2187,7 +2187,7 @@
           }
         ],
         "max_deposit_period": "172800s",
-        "voting_period": "600s",
+        "voting_period": "604800s",
         "quorum": "0.334000000000000000",
         "threshold": "0.500000000000000000",
         "veto_threshold": "0.334000000000000000",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
- Adds committee MsgVote to evm `eip712_allowed_msgs` to allow for committee voting.
- Updates internal testnet seed script to submit a committee proposal for testing purposes.
- Changes gov voting period to 7 days to help with testing active proposals.
