### PR TITLE
fix: update gov voting period for protonet and internal testnet

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -567,7 +567,6 @@
               "denom": "usdx",
               "amount": "103000000000"
             },
-
             {
               "denom": "xrpb",
               "amount": "1000000000000000"
@@ -2284,7 +2283,9 @@
       "votes": [],
       "proposals": [],
       "deposit_params": null,
-      "voting_params": null,
+      "voting_params": {
+        "voting_period": "604800s"
+      },
       "tally_params": null,
       "params": {
         "min_deposit": [
@@ -2294,7 +2295,7 @@
           }
         ],
         "max_deposit_period": "172800s",
-        "voting_period": "600s",
+        "voting_period": "604800s",
         "quorum": "0.334000000000000000",
         "threshold": "0.500000000000000000",
         "veto_threshold": "0.334000000000000000",

--- a/ci/env/kava-protonet/genesis.json
+++ b/ci/env/kava-protonet/genesis.json
@@ -2172,7 +2172,7 @@
         "max_deposit_period": "172800s"
       },
       "voting_params": {
-        "voting_period": "604800s"
+        "voting_period": "600s"
       },
       "tally_params": {
         "quorum": "0.334000000000000000",
@@ -2187,7 +2187,7 @@
           }
         ],
         "max_deposit_period": "172800s",
-        "voting_period": "604800s",
+        "voting_period": "600s",
         "quorum": "0.334000000000000000",
         "threshold": "0.500000000000000000",
         "veto_threshold": "0.334000000000000000",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
https://github.com/Kava-Labs/kava/pull/2008 incorrectly updated the protonet gov voting period instead of internal testnet. This PR fixes this and updates internal testnet voting period to 7d and reverted protonet voting period to 10min.
