### PR TITLE
feat(cli): support CLI completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 - (precisebank) [#1906] Add new `x/precisebank` module with bank decimal extension for EVM usage.
 - (cli) [#1922] Add `iavlviewer` CLI command for low-level iavl db debugging.
+- (cli) [#2017] Support CLI `completion` for bash, zsh, fish, & powershell.
 
 ### Improvements
 - (rocksdb) [#1903] Bump cometbft-db dependency for use with rocksdb v8.10.0
@@ -338,6 +339,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+[#2017]: https://github.com/Kava-Labs/kava/pull/2017
 [#1988]: https://github.com/Kava-Labs/kava/pull/1988
 [#1922]: https://github.com/Kava-Labs/kava/pull/1922
 [#1906]: https://github.com/Kava-Labs/kava/pull/1906

--- a/cmd/kava/cmd/root.go
+++ b/cmd/kava/cmd/root.go
@@ -7,7 +7,6 @@ import (
 
 	dbm "github.com/cometbft/cometbft-db"
 	tmcfg "github.com/cometbft/cometbft/config"
-	tmcli "github.com/cometbft/cometbft/libs/cli"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/debug"
@@ -114,8 +113,6 @@ func addSubCmds(rootCmd *cobra.Command, encodingConfig params.EncodingConfig, de
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, defaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(defaultNodeHome),
-		tmcli.NewCompletionCmd(rootCmd, true), // TODO add other shells, drop tmcli dependency, unhide?
-		// testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}), // TODO add
 		debug.Cmd(),
 		config.Cmd(),
 	)


### PR DESCRIPTION
## Description

enables the underlying cobra CLI completion scripts.

supported shells:
* Bash
* Zsh
* Fish
* PowerShell

this replaces (and un-hides) the previously-existing tendermint completion command that only supported bash & zsh.

see `kava completion <shell> --help` for specifics

```
❯ kava completion --help
Generate the autocompletion script for kava for the specified shell.
See each sub-command's help for details on how to use the generated script.

Usage:
  kava completion [command]

Available Commands:
  bash        Generate the autocompletion script for bash
  fish        Generate the autocompletion script for fish
  powershell  Generate the autocompletion script for powershell
  zsh         Generate the autocompletion script for zsh
```


<!--- Describe your changes in detail -->

## Checklist
 - [x] Changelog has been updated as necessary.
