### PR TITLE
test(ante): Add test to cover various EIP712Domain fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (rocksdb) [#1903] Bump cometbft-db dependency for use with rocksdb v8.10.0
 - (deps) [#1988] Bump cometbft to v0.37.9-kava.1
 
+### Bug Fixes
+- (deps) [#2021] Bump Ethermint dependency to exclude incorrect and unnecessary
+  fields `verifyingContract` and `salt` from `EIP712Domain` to resolve MetaMask
+  signing errors.
+
 ## [v0.26.0]
 
 ### Features
@@ -340,6 +345,7 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
   large-scale simulations remotely using aws-batch
 
 [#2017]: https://github.com/Kava-Labs/kava/pull/2017
+[#2021]: https://github.com/Kava-Labs/kava/pull/2021
 [#1988]: https://github.com/Kava-Labs/kava/pull/1988
 [#1922]: https://github.com/Kava-Labs/kava/pull/1922
 [#1906]: https://github.com/Kava-Labs/kava/pull/1906

--- a/app/ante/eip712_test.go
+++ b/app/ante/eip712_test.go
@@ -47,6 +47,7 @@ const (
 	ChainID       = app.TestChainId
 	USDCCoinDenom = "erc20/usdc"
 	USDCCDPType   = "erc20-usdc"
+	TxGas         = uint64(sims.DefaultGenTxGas * 10)
 )
 
 type EIP712TestSuite struct {
@@ -75,7 +76,6 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	from sdk.AccAddress,
 	priv cryptotypes.PrivKey,
 	chainID string,
-	gas uint64,
 	gasAmount sdk.Coins,
 	msgs []sdk.Msg,
 	customDomain *apitypes.TypedDataDomain,
@@ -90,7 +90,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	ethChainID := pc.Uint64()
 
 	// GenerateTypedData TypedData
-	fee := legacytx.NewStdFee(gas, gasAmount)
+	fee := legacytx.NewStdFee(TxGas, gasAmount)
 	accNumber := suite.tApp.GetAccountKeeper().GetAccount(suite.ctx, from).GetAccountNumber()
 
 	data := eip712.ConstructUntypedEIP712Data(chainID, accNumber, nonce, 0, fee, msgs, "", nil)
@@ -141,7 +141,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 
 	builder.SetExtensionOptions(option)
 	builder.SetFeeAmount(gasAmount)
-	builder.SetGasLimit(gas)
+	builder.SetGasLimit(TxGas)
 
 	sigsV2 := signing.SignatureV2{
 		PubKey: pubKey,
@@ -164,7 +164,6 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 	from sdk.AccAddress,
 	priv cryptotypes.PrivKey,
 	chainID string,
-	gas uint64,
 	gasAmount sdk.Coins,
 	msgs []sdk.Msg,
 ) client.TxBuilder {
@@ -172,7 +171,6 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 		from,
 		priv,
 		chainID,
-		gas,
 		gasAmount,
 		msgs,
 		nil,
@@ -634,7 +632,6 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 					suite.testAddr,
 					suite.testPrivKey,
 					"kavatest_12-1",
-					uint64(sims.DefaultGenTxGas*10),
 					gasAmt,
 					msgs,
 				)
@@ -652,7 +649,6 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 					suite.testAddr2,
 					suite.testPrivKey2,
 					ChainID,
-					uint64(sims.DefaultGenTxGas*10),
 					gasAmt,
 					msgs,
 				)
@@ -707,7 +703,6 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 					suite.testAddr,
 					suite.testPrivKey,
 					ChainID,
-					uint64(sims.DefaultGenTxGas*10),
 					gasAmt,
 					msgs,
 					&domain,
@@ -766,7 +761,6 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 					suite.testAddr,
 					suite.testPrivKey,
 					ChainID,
-					uint64(sims.DefaultGenTxGas*10),
 					gasAmt,
 					msgs,
 					&domain,
@@ -821,7 +815,6 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 					suite.testAddr,
 					suite.testPrivKey,
 					ChainID,
-					uint64(sims.DefaultGenTxGas*10),
 					gasAmt,
 					msgs,
 					&domain,
@@ -865,7 +858,11 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 
 			gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 			txBuilder := suite.createTestEIP712CosmosTxBuilder(
-				suite.testAddr, suite.testPrivKey, ChainID, uint64(sims.DefaultGenTxGas*10), gasAmt, msgs,
+				suite.testAddr,
+				suite.testPrivKey,
+				ChainID,
+				gasAmt,
+				msgs,
 			)
 			if tc.updateTx != nil {
 				txBuilder = tc.updateTx(txBuilder, msgs)
@@ -951,7 +948,11 @@ func (suite *EIP712TestSuite) TestEIP712Tx_DepositAndWithdraw() {
 	// deliver deposit msg
 	gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 	txBuilder := suite.createTestEIP712CosmosTxBuilder(
-		suite.testAddr, suite.testPrivKey, ChainID, uint64(sims.DefaultGenTxGas*10), gasAmt, depositMsgs,
+		suite.testAddr,
+		suite.testPrivKey,
+		ChainID,
+		gasAmt,
+		depositMsgs,
 	)
 	txBytes, err := encodingConfig.TxConfig.TxEncoder()(txBuilder.GetTx())
 	suite.Require().NoError(err)
@@ -996,7 +997,11 @@ func (suite *EIP712TestSuite) TestEIP712Tx_DepositAndWithdraw() {
 
 	// deliver withdraw msg
 	txBuilder = suite.createTestEIP712CosmosTxBuilder(
-		suite.testAddr, suite.testPrivKey, ChainID, uint64(sims.DefaultGenTxGas*10), gasAmt, withdrawMsgs,
+		suite.testAddr,
+		suite.testPrivKey,
+		ChainID,
+		gasAmt,
+		withdrawMsgs,
 	)
 	txBytes, err = encodingConfig.TxConfig.TxEncoder()(txBuilder.GetTx())
 	suite.Require().NoError(err)

--- a/app/ante/eip712_test.go
+++ b/app/ante/eip712_test.go
@@ -90,7 +90,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	ethChainID := pc.Uint64()
 
 	// GenerateTypedData TypedData
-	fee := legacytx.NewStdFee(TxGas, gasAmount)
+	fee := legacytx.NewStdFee(TxGas, gasAmount) //nolint:staticcheck // Deprecated but EIP712 still uses legacytx
 	accNumber := suite.tApp.GetAccountKeeper().GetAccount(suite.ctx, from).GetAccountNumber()
 
 	data := eip712.ConstructUntypedEIP712Data(chainID, accNumber, nonce, 0, fee, msgs, "", nil)

--- a/app/ante/eip712_test.go
+++ b/app/ante/eip712_test.go
@@ -17,8 +17,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/tmhash"
@@ -70,11 +72,17 @@ func (suite *EIP712TestSuite) getEVMAmount(amount int64) sdkmath.Int {
 	return sdkmath.NewInt(amount).Mul(sdkmath.NewIntFromUint64(incr.Uint64()))
 }
 
-func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
-	from sdk.AccAddress, priv cryptotypes.PrivKey, chainId string, gas uint64, gasAmount sdk.Coins, msgs []sdk.Msg,
+func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
+	from sdk.AccAddress,
+	priv cryptotypes.PrivKey,
+	chainId string,
+	gas uint64,
+	gasAmount sdk.Coins,
+	msgs []sdk.Msg,
+	customDomain *apitypes.TypedDataDomain,
+	customDomainTypes []apitypes.Type,
 ) client.TxBuilder {
-	var err error
-
+	// Get required info
 	nonce, err := suite.tApp.GetAccountKeeper().GetSequence(suite.ctx, from)
 	suite.Require().NoError(err)
 
@@ -87,14 +95,32 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 	accNumber := suite.tApp.GetAccountKeeper().GetAccount(suite.ctx, from).GetAccountNumber()
 
 	data := eip712.ConstructUntypedEIP712Data(chainId, accNumber, nonce, 0, fee, msgs, "", nil)
-	typedData, err := eip712.WrapTxToTypedData(ethChainId, msgs, data, &eip712.FeeDelegationOptions{
-		FeePayer: from,
-	}, suite.tApp.GetEvmKeeper().GetParams(suite.ctx))
+	typedData, err := eip712.WrapTxToTypedData(
+		ethChainId,
+		msgs,
+		data,
+		&eip712.FeeDelegationOptions{
+			FeePayer: from,
+		},
+		suite.tApp.GetEvmKeeper().GetParams(suite.ctx),
+	)
 	suite.Require().NoError(err)
+
+	// Override Domain if provided, this will modify the hash to sign
+	if customDomain != nil {
+		typedData.Domain = *customDomain
+	}
+
+	// Override EIP712Domain types if provided
+	if customDomainTypes != nil {
+		typedData.Types["EIP712Domain"] = customDomainTypes
+	}
+
+	// Compute sigHash to sign
 	sigHash, err := eip712.ComputeTypedDataHash(typedData)
 	suite.Require().NoError(err)
 
-	// Sign typedData
+	// Sign sighHash
 	keyringSigner := tests.NewSigner(priv)
 	signature, pubKey, err := keyringSigner.SignByAddress(from, sigHash)
 	suite.Require().NoError(err)
@@ -133,6 +159,26 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 	suite.Require().NoError(err)
 
 	return builder
+}
+
+func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
+	from sdk.AccAddress,
+	priv cryptotypes.PrivKey,
+	chainId string,
+	gas uint64,
+	gasAmount sdk.Coins,
+	msgs []sdk.Msg,
+) client.TxBuilder {
+	return suite.createTestEIP712CosmosTxBuilderWithDomain(
+		from,
+		priv,
+		chainId,
+		gas,
+		gasAmount,
+		msgs,
+		nil,
+		nil,
+	)
 }
 
 func (suite *EIP712TestSuite) SetupTest() {
@@ -594,6 +640,177 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 				)
 			},
 		},
+		{
+			name:           "passes when domain matches expected fields",
+			usdcDepositAmt: 100,
+			usdxToMintAmt:  90,
+			failCheckTx:    false,
+			errMsg:         "",
+			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
+
+				pc, err := etherminttypes.ParseChainID(ChainID)
+				suite.Require().NoError(err)
+				ethChainId := pc.Int64()
+
+				// Expected domain used in Ethermint ante handler
+				// These are explicitly set in this test to ensure Ethermint
+				// is using the expected domain for signature verification
+				domain := apitypes.TypedDataDomain{
+					Name:    "Kava Cosmos",
+					Version: "1.0.0",
+					ChainId: math.NewHexOrDecimal256(ethChainId),
+
+					// Both should be ommitted
+					Salt:              "",
+					VerifyingContract: "",
+				}
+
+				// Must be in order as defined in EIP-712
+				// https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator
+				// Internally the data is written in order of the types
+				domainTypes := []apitypes.Type{
+					{
+						Name: "name",
+						Type: "string",
+					},
+					{
+						Name: "version",
+						Type: "string",
+					},
+					{
+						Name: "chainId",
+						Type: "uint256",
+					},
+					// Exclude empty fields
+				}
+
+				return suite.createTestEIP712CosmosTxBuilderWithDomain(
+					suite.testAddr,
+					suite.testPrivKey,
+					ChainID,
+					uint64(sims.DefaultGenTxGas*10),
+					gasAmt,
+					msgs,
+					&domain,
+					domainTypes,
+				)
+			},
+		},
+		{
+			name:           "fails when domain.verifyingContract is non-empty string type",
+			usdcDepositAmt: 100,
+			usdxToMintAmt:  90,
+			failCheckTx:    true,
+			errMsg:         "signature verification failed",
+			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
+
+				pc, err := etherminttypes.ParseChainID(ChainID)
+				suite.Require().NoError(err)
+				ethChainId := pc.Int64()
+
+				// Domain and types are **not** included in the tx data.
+				// Both signature creation on client & verification in ante
+				// should match to produce a matching signature hash.
+				domain := apitypes.TypedDataDomain{
+					Name:    "Kava Cosmos",
+					Version: "1.0.0",
+					ChainId: math.NewHexOrDecimal256(ethChainId),
+
+					Salt: "",
+					// Original value with string type instead of address.
+					// This has been changed to expect empty field
+					VerifyingContract: "kavaCosmos",
+				}
+
+				domainTypes := []apitypes.Type{
+					{
+						Name: "name",
+						Type: "string",
+					},
+					{
+						Name: "version",
+						Type: "string",
+					},
+					{
+						Name: "chainId",
+						Type: "uint256",
+					},
+					{
+						Name: "verifyingContract",
+						// Incorrect! but old type in kava <= v0.26.0
+						Type: "string",
+					},
+				}
+
+				return suite.createTestEIP712CosmosTxBuilderWithDomain(
+					suite.testAddr,
+					suite.testPrivKey,
+					ChainID,
+					uint64(sims.DefaultGenTxGas*10),
+					gasAmt,
+					msgs,
+					&domain,
+					domainTypes,
+				)
+			},
+		},
+		{
+			name:           "fails when domain.verifyingContract is non-empty address type",
+			usdcDepositAmt: 100,
+			usdxToMintAmt:  90,
+			failCheckTx:    true,
+			errMsg:         "signature verification failed",
+			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
+
+				pc, err := etherminttypes.ParseChainID(ChainID)
+				suite.Require().NoError(err)
+				ethChainId := pc.Int64()
+
+				domain := apitypes.TypedDataDomain{
+					Name:    "Kava Cosmos",
+					Version: "1.0.0",
+					ChainId: math.NewHexOrDecimal256(ethChainId),
+
+					Salt: "",
+					// Address type
+					VerifyingContract: "0xc6d953c98f260cb7c3667cac87e5d508a0a81277",
+				}
+
+				domainTypes := []apitypes.Type{
+					{
+						Name: "name",
+						Type: "string",
+					},
+					{
+						Name: "version",
+						Type: "string",
+					},
+					{
+						Name: "chainId",
+						Type: "uint256",
+					},
+					{
+						Name: "verifyingContract",
+						// Correct type, but is value is not empty when its expected to be
+						Type: "address",
+					},
+				}
+
+				return suite.createTestEIP712CosmosTxBuilderWithDomain(
+					suite.testAddr,
+					suite.testPrivKey,
+					ChainID,
+					uint64(sims.DefaultGenTxGas*10),
+					gasAmt,
+					msgs,
+					&domain,
+					domainTypes,
+				)
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -670,13 +887,13 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 				suite.Require().True(found)
 				suite.Require().Equal(suite.testAddr, cdp.Owner)
 				suite.Require().Equal(sdk.NewCoin(USDCCoinDenom, suite.getEVMAmount(100)), cdp.Collateral)
-				suite.Require().Equal(sdk.NewCoin("usdx", sdkmath.NewInt(99_000_000)), cdp.Principal)
+				suite.Require().Equal(sdk.NewCoin("usdx", usdxAmt), cdp.Principal)
 
 				// validate hard
 				hardDeposit, found := suite.tApp.GetHardKeeper().GetDeposit(suite.ctx, suite.testAddr)
 				suite.Require().True(found)
 				suite.Require().Equal(suite.testAddr, hardDeposit.Depositor)
-				suite.Require().Equal(sdk.NewCoins(sdk.NewCoin("usdx", sdkmath.NewInt(99_000_000))), hardDeposit.Amount)
+				suite.Require().Equal(sdk.NewCoins(sdk.NewCoin("usdx", usdxAmt)), hardDeposit.Amount)
 			} else {
 				suite.Require().NotEqual(resDeliverTx.Code, uint32(0), resCheckTx.Log)
 				suite.Require().Contains(resDeliverTx.Log, tc.errMsg)

--- a/app/ante/eip712_test.go
+++ b/app/ante/eip712_test.go
@@ -6,6 +6,11 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	tmversion "github.com/cometbft/cometbft/proto/tendermint/version"
+	"github.com/cometbft/cometbft/version"
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -21,12 +26,6 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/crypto/tmhash"
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	tmversion "github.com/cometbft/cometbft/proto/tendermint/version"
-	"github.com/cometbft/cometbft/version"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"github.com/evmos/ethermint/ethereum/eip712"
 	"github.com/evmos/ethermint/tests"
@@ -75,7 +74,7 @@ func (suite *EIP712TestSuite) getEVMAmount(amount int64) sdkmath.Int {
 func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	from sdk.AccAddress,
 	priv cryptotypes.PrivKey,
-	chainId string,
+	chainID string,
 	gas uint64,
 	gasAmount sdk.Coins,
 	msgs []sdk.Msg,
@@ -86,17 +85,17 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	nonce, err := suite.tApp.GetAccountKeeper().GetSequence(suite.ctx, from)
 	suite.Require().NoError(err)
 
-	pc, err := etherminttypes.ParseChainID(chainId)
+	pc, err := etherminttypes.ParseChainID(chainID)
 	suite.Require().NoError(err)
-	ethChainId := pc.Uint64()
+	ethChainID := pc.Uint64()
 
 	// GenerateTypedData TypedData
 	fee := legacytx.NewStdFee(gas, gasAmount)
 	accNumber := suite.tApp.GetAccountKeeper().GetAccount(suite.ctx, from).GetAccountNumber()
 
-	data := eip712.ConstructUntypedEIP712Data(chainId, accNumber, nonce, 0, fee, msgs, "", nil)
+	data := eip712.ConstructUntypedEIP712Data(chainID, accNumber, nonce, 0, fee, msgs, "", nil)
 	typedData, err := eip712.WrapTxToTypedData(
-		ethChainId,
+		ethChainID,
 		msgs,
 		data,
 		&eip712.FeeDelegationOptions{
@@ -130,7 +129,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 	var option *codectypes.Any
 	option, err = codectypes.NewAnyWithValue(&etherminttypes.ExtensionOptionsWeb3Tx{
 		FeePayer:         from.String(),
-		TypedDataChainID: ethChainId,
+		TypedDataChainID: ethChainID,
 		FeePayerSig:      signature,
 	})
 	suite.Require().NoError(err)
@@ -164,7 +163,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilderWithDomain(
 func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 	from sdk.AccAddress,
 	priv cryptotypes.PrivKey,
-	chainId string,
+	chainID string,
 	gas uint64,
 	gasAmount sdk.Coins,
 	msgs []sdk.Msg,
@@ -172,7 +171,7 @@ func (suite *EIP712TestSuite) createTestEIP712CosmosTxBuilder(
 	return suite.createTestEIP712CosmosTxBuilderWithDomain(
 		from,
 		priv,
-		chainId,
+		chainID,
 		gas,
 		gasAmount,
 		msgs,
@@ -375,7 +374,7 @@ func (suite *EIP712TestSuite) SetupTest() {
 	tApp.GetStakingKeeper().SetValidator(ctx, validator)
 
 	// Deploy an ERC20 contract for USDC
-	contractAddr := suite.deployUSDCERC20(tApp, ctx)
+	contractAddr := suite.deployUSDCERC20()
 	pair := evmutiltypes.NewConversionPair(
 		contractAddr,
 		USDCCoinDenom,
@@ -468,21 +467,22 @@ func (suite *EIP712TestSuite) SetupTest() {
 			},
 		},
 	}
-	evmKeeper.SetParams(suite.ctx, params)
+	err = evmKeeper.SetParams(suite.ctx, params)
+	suite.Require().NoError(err)
 
 	// give test address 50k erc20 usdc to begin with
 	initBal := suite.getEVMAmount(50_000)
 	err = suite.evmutilKeeper.MintERC20(
 		ctx,
 		pair.GetAddress(), // contractAddr
-		suite.testEVMAddr, //receiver
+		suite.testEVMAddr, // receiver
 		initBal.BigInt(),
 	)
 	suite.Require().NoError(err)
 	err = suite.evmutilKeeper.MintERC20(
 		ctx,
 		pair.GetAddress(),  // contractAddr
-		suite.testEVMAddr2, //receiver
+		suite.testEVMAddr2, // receiver
 		initBal.BigInt(),
 	)
 	suite.Require().NoError(err)
@@ -498,7 +498,7 @@ func (suite *EIP712TestSuite) SetupTest() {
 func (suite *EIP712TestSuite) Commit() {
 	_ = suite.tApp.Commit()
 	header := suite.ctx.BlockHeader()
-	header.Height += 1
+	header.Height++
 	suite.tApp.BeginBlock(abci.RequestBeginBlock{
 		Header: header,
 	})
@@ -507,13 +507,14 @@ func (suite *EIP712TestSuite) Commit() {
 	suite.ctx = suite.tApp.NewContext(false, header)
 }
 
-func (suite *EIP712TestSuite) deployUSDCERC20(app app.TestApp, ctx sdk.Context) evmutiltypes.InternalEVMAddress {
+func (suite *EIP712TestSuite) deployUSDCERC20() evmutiltypes.InternalEVMAddress {
 	// make sure module account is created
-	suite.tApp.FundModuleAccount(
+	err := suite.tApp.FundModuleAccount(
 		suite.ctx,
 		evmutiltypes.ModuleName,
 		sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(0))),
 	)
+	suite.Require().NoError(err)
 
 	contractAddr, err := suite.evmutilKeeper.DeployTestMintableERC20Contract(suite.ctx, "USDC", "USDC", uint8(18))
 	suite.Require().NoError(err)
@@ -590,13 +591,14 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    true,
 			errMsg:         "tx intended signer does not match the given signer",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
-				var option *codectypes.Any
-				option, _ = codectypes.NewAnyWithValue(&etherminttypes.ExtensionOptionsWeb3Tx{
+			updateTx: func(txBuilder client.TxBuilder, _ []sdk.Msg) client.TxBuilder {
+				option, err := codectypes.NewAnyWithValue(&etherminttypes.ExtensionOptionsWeb3Tx{
 					FeePayer:         suite.testAddr.String(),
 					TypedDataChainID: 2221,
 					FeePayerSig:      []byte("sig"),
 				})
+				suite.Require().NoError(err)
+
 				builder, _ := txBuilder.(authtx.ExtensionOptionsTxBuilder)
 				builder.SetExtensionOptions(option)
 				return txBuilder
@@ -607,10 +609,16 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdcDepositAmt: 100,
 			usdxToMintAmt:  90,
 			errMsg:         "insufficient funds",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(txBuilder client.TxBuilder, _ []sdk.Msg) client.TxBuilder {
 				bk := suite.tApp.GetBankKeeper()
 				gasCoins := bk.GetBalance(suite.ctx, suite.testAddr, "ukava")
-				suite.tApp.GetBankKeeper().SendCoins(suite.ctx, suite.testAddr, suite.testAddr2, sdk.NewCoins(gasCoins))
+				err := suite.tApp.GetBankKeeper().SendCoins(
+					suite.ctx,
+					suite.testAddr,
+					suite.testAddr2,
+					sdk.NewCoins(gasCoins),
+				)
+				suite.Require().NoError(err)
 				return txBuilder
 			},
 		},
@@ -620,10 +628,15 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    true,
 			errMsg:         "invalid chain-id",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(_ client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
 				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 				return suite.createTestEIP712CosmosTxBuilder(
-					suite.testAddr, suite.testPrivKey, "kavatest_12-1", uint64(sims.DefaultGenTxGas*10), gasAmt, msgs,
+					suite.testAddr,
+					suite.testPrivKey,
+					"kavatest_12-1",
+					uint64(sims.DefaultGenTxGas*10),
+					gasAmt,
+					msgs,
 				)
 			},
 		},
@@ -633,10 +646,15 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    true,
 			errMsg:         "invalid pubkey",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(_ client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
 				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 				return suite.createTestEIP712CosmosTxBuilder(
-					suite.testAddr2, suite.testPrivKey2, ChainID, uint64(sims.DefaultGenTxGas*10), gasAmt, msgs,
+					suite.testAddr2,
+					suite.testPrivKey2,
+					ChainID,
+					uint64(sims.DefaultGenTxGas*10),
+					gasAmt,
+					msgs,
 				)
 			},
 		},
@@ -646,12 +664,12 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    false,
 			errMsg:         "",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(_ client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
 				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 
 				pc, err := etherminttypes.ParseChainID(ChainID)
 				suite.Require().NoError(err)
-				ethChainId := pc.Int64()
+				ethChainID := pc.Int64()
 
 				// Expected domain used in Ethermint ante handler
 				// These are explicitly set in this test to ensure Ethermint
@@ -659,9 +677,9 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 				domain := apitypes.TypedDataDomain{
 					Name:    "Kava Cosmos",
 					Version: "1.0.0",
-					ChainId: math.NewHexOrDecimal256(ethChainId),
+					ChainId: math.NewHexOrDecimal256(ethChainID),
 
-					// Both should be ommitted
+					// Both should be omitted
 					Salt:              "",
 					VerifyingContract: "",
 				}
@@ -703,12 +721,12 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    true,
 			errMsg:         "signature verification failed",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(_ client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
 				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 
 				pc, err := etherminttypes.ParseChainID(ChainID)
 				suite.Require().NoError(err)
-				ethChainId := pc.Int64()
+				ethChainID := pc.Int64()
 
 				// Domain and types are **not** included in the tx data.
 				// Both signature creation on client & verification in ante
@@ -716,7 +734,7 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 				domain := apitypes.TypedDataDomain{
 					Name:    "Kava Cosmos",
 					Version: "1.0.0",
-					ChainId: math.NewHexOrDecimal256(ethChainId),
+					ChainId: math.NewHexOrDecimal256(ethChainID),
 
 					Salt: "",
 					// Original value with string type instead of address.
@@ -762,17 +780,17 @@ func (suite *EIP712TestSuite) TestEIP712Tx() {
 			usdxToMintAmt:  90,
 			failCheckTx:    true,
 			errMsg:         "signature verification failed",
-			updateTx: func(txBuilder client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
+			updateTx: func(_ client.TxBuilder, msgs []sdk.Msg) client.TxBuilder {
 				gasAmt := sdk.NewCoins(sdk.NewCoin("ukava", sdkmath.NewInt(20)))
 
 				pc, err := etherminttypes.ParseChainID(ChainID)
 				suite.Require().NoError(err)
-				ethChainId := pc.Int64()
+				ethChainID := pc.Int64()
 
 				domain := apitypes.TypedDataDomain{
 					Name:    "Kava Cosmos",
 					Version: "1.0.0",
-					ChainId: math.NewHexOrDecimal256(ethChainId),
+					ChainId: math.NewHexOrDecimal256(ethChainID),
 
 					Salt: "",
 					// Address type

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ replace (
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
 	// Tracking kava-labs/etheremint master branch
 	// TODO: Tag before release
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20240919184235-65384e03c3e7
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ replace (
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
 	// Tracking kava-labs/etheremint master branch
 	// TODO: Tag before release
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20240802224012-586960857184
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.sum
+++ b/go.sum
@@ -894,8 +894,8 @@ github.com/kava-labs/cometbft-db v0.9.1-kava.2 h1:ZQaio886ifvml9XtJB4IYHhlArgA3+
 github.com/kava-labs/cometbft-db v0.9.1-kava.2/go.mod h1:PvUZbx7zeR7I4CAvtKBoii/5ia5gXskKjDjIVpt7gDw=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.1 h1:vQwrm3sdAG1pkwrsi2mmCHSGDje5fzUR6vApEux/nVA=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.1/go.mod h1:OwLYEBcsnijCLE8gYkwQ7jycZZ/Acd+a83pJU+V+MKw=
-github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df h1:Z2mlz3g5EAB4FdPSci76oxnkM3Iy9g28/wC9PPEl3w0=
-github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df/go.mod h1:kbyr3La2Co3Hy3U3N2EvVk7W1srQ2x88JUpgsu2KrXo=
+github.com/kava-labs/ethermint v0.21.1-0.20240919184235-65384e03c3e7 h1:9C57WGVV7RdyVZpLsiGwdpFnZzhLHdBD4dGofXs3GQg=
+github.com/kava-labs/ethermint v0.21.1-0.20240919184235-65384e03c3e7/go.mod h1:kbyr3La2Co3Hy3U3N2EvVk7W1srQ2x88JUpgsu2KrXo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/go.sum
+++ b/go.sum
@@ -894,8 +894,8 @@ github.com/kava-labs/cometbft-db v0.9.1-kava.2 h1:ZQaio886ifvml9XtJB4IYHhlArgA3+
 github.com/kava-labs/cometbft-db v0.9.1-kava.2/go.mod h1:PvUZbx7zeR7I4CAvtKBoii/5ia5gXskKjDjIVpt7gDw=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.1 h1:vQwrm3sdAG1pkwrsi2mmCHSGDje5fzUR6vApEux/nVA=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.1/go.mod h1:OwLYEBcsnijCLE8gYkwQ7jycZZ/Acd+a83pJU+V+MKw=
-github.com/kava-labs/ethermint v0.21.1-0.20240802224012-586960857184 h1:MWwCXFnkagXk93QiiD41I+S9wyrHZUQWLRFKo2tXL6A=
-github.com/kava-labs/ethermint v0.21.1-0.20240802224012-586960857184/go.mod h1:kbyr3La2Co3Hy3U3N2EvVk7W1srQ2x88JUpgsu2KrXo=
+github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df h1:Z2mlz3g5EAB4FdPSci76oxnkM3Iy9g28/wC9PPEl3w0=
+github.com/kava-labs/ethermint v0.21.1-0.20240910233453-a9b525ab00df/go.mod h1:kbyr3La2Co3Hy3U3N2EvVk7W1srQ2x88JUpgsu2KrXo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
## Description
- Explicitly tests EIP712Domain values for both expected and unexpected
  - Ensure expected domain exclude `verifyingContract` and `salt` fields

Depends on Ethermint PR: https://github.com/Kava-Labs/ethermint/pull/75

Also manually tested EIP712 transaction with the expected EIP712Domain fields with MetaMask.

## Checklist
 - [x] Changelog has been updated as necessary.
