### PR TITLE
feat: add dai to internal testnet hard money markets

### DIFF
--- a/.github/scripts/seed-internal-testnet.sh
+++ b/.github/scripts/seed-internal-testnet.sh
@@ -121,6 +121,7 @@ npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$AXL_BUSD_CON
 npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$AXL_XRPB_CONTRACT_ADDRESS" "$DEV_TEST_WALLET_ADDRESS" 1000000000000000000000
 npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$AXL_BTCB_CONTRACT_ADDRESS" "$DEV_TEST_WALLET_ADDRESS" 1000000000000000000000
 npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$WBTC_CONTRACT_ADDRESS" "$DEV_TEST_WALLET_ADDRESS" 10000000000000
+npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$DAI_CONTRACT_ADDRESS" "$DEV_TEST_WALLET_ADDRESS" 10000000000000000000000000
 # seed webapp E2E whale account
 npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$AXL_WBTC_CONTRACT_ADDRESS" "$WEBAPP_E2E_WHALE_ADDRESS" 100000000000000
 npx hardhat --network "${ERC20_DEPLOYER_NETWORK_NAME}" mint-erc20 "$MULTICHAIN_wBTC_CONTRACT_ADDRESS" "$WEBAPP_E2E_WHALE_ADDRESS" 10000000000000
@@ -173,7 +174,7 @@ PARAM_CHANGE_PROP_TEMPLATE=$(
         {
             "subspace": "evmutil",
             "key": "EnabledConversionPairs",
-            "value": "[{\"kava_erc20_address\":\"MULTICHAIN_USDC_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/usdc\"},{\"kava_erc20_address\":\"MULTICHAIN_USDT_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/usdt\"},{\"kava_erc20_address\":\"MULTICHAIN_wBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/wbtc\"},{\"kava_erc20_address\":\"AXL_USDC_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/usdc\"},{\"kava_erc20_address\":\"AXL_WBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/wbtc\"},{\"kava_erc20_address\":\"wETH_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/eth\"},{\"kava_erc20_address\":\"TETHER_USDT_CONTRACT_ADDRESS\",\"denom\":\"erc20/tether/usdt\"},{\"kava_erc20_address\":\"AXL_BNB_CONTRACT_ADDRESS\",\"denom\":\"bnb\"},{\"kava_erc20_address\":\"AXL_BUSD_CONTRACT_ADDRESS\",\"denom\":\"busd\"},{\"kava_erc20_address\":\"AXL_BTCB_CONTRACT_ADDRESS\",\"denom\":\"btcb\"},{\"kava_erc20_address\":\"AXL_XRPB_CONTRACT_ADDRESS\",\"denom\":\"xrpb\"},{\"kava_erc20_address\":\"WBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/bitgo/wbtc\"}]"
+            "value": "[{\"kava_erc20_address\":\"MULTICHAIN_USDC_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/usdc\"},{\"kava_erc20_address\":\"MULTICHAIN_USDT_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/usdt\"},{\"kava_erc20_address\":\"MULTICHAIN_wBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/multichain/wbtc\"},{\"kava_erc20_address\":\"AXL_USDC_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/usdc\"},{\"kava_erc20_address\":\"AXL_WBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/wbtc\"},{\"kava_erc20_address\":\"DAI_CONTRACT_ADDRESS\",\"denom\":\"erc20/eth/dai\"},{\"kava_erc20_address\":\"wETH_CONTRACT_ADDRESS\",\"denom\":\"erc20/axelar/eth\"},{\"kava_erc20_address\":\"TETHER_USDT_CONTRACT_ADDRESS\",\"denom\":\"erc20/tether/usdt\"},{\"kava_erc20_address\":\"AXL_BNB_CONTRACT_ADDRESS\",\"denom\":\"bnb\"},{\"kava_erc20_address\":\"AXL_BUSD_CONTRACT_ADDRESS\",\"denom\":\"busd\"},{\"kava_erc20_address\":\"AXL_BTCB_CONTRACT_ADDRESS\",\"denom\":\"btcb\"},{\"kava_erc20_address\":\"AXL_XRPB_CONTRACT_ADDRESS\",\"denom\":\"xrpb\"},{\"kava_erc20_address\":\"WBTC_CONTRACT_ADDRESS\",\"denom\":\"erc20/bitgo/wbtc\"}]"
         }
     ]
 }
@@ -195,6 +196,7 @@ finalProposal="${finalProposal/AXL_BUSD_CONTRACT_ADDRESS/$AXL_BUSD_CONTRACT_ADDR
 finalProposal="${finalProposal/AXL_BTCB_CONTRACT_ADDRESS/$AXL_BTCB_CONTRACT_ADDRESS}"
 finalProposal="${finalProposal/AXL_XRPB_CONTRACT_ADDRESS/$AXL_XRPB_CONTRACT_ADDRESS}"
 finalProposal="${finalProposal/WBTC_CONTRACT_ADDRESS/$WBTC_CONTRACT_ADDRESS}"
+finalProposal="${finalProposal/DAI_CONTRACT_ADDRESS/$DAI_CONTRACT_ADDRESS}"
 
 # create unique proposal filename
 proposalFileName="$(date +%s)-proposal.json"

--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -2345,6 +2345,24 @@
             "keeper_reward_percentage": "0.020000000000000000"
           },
           {
+            "denom": "erc20/eth/dai",
+            "borrow_limit": {
+              "has_max_limit": false,
+              "maximum_limit": "0.000000000000000000",
+              "loan_to_value": "0.500000000000000000"
+            },
+            "spot_market_id": "dai:usd:30",
+            "conversion_factor": "1000000000000000000",
+            "interest_rate_model": {
+              "base_rate_apy": "0.000000000000000000",
+              "base_multiplier": "0.050000000000000000",
+              "kink": "0.800000000000000000",
+              "jump_multiplier": "5.000000000000000000"
+            },
+            "reserve_factor": "0.025000000000000000",
+            "keeper_reward_percentage": "0.020000000000000000"
+          },
+          {
             "denom": "erc20/axelar/wbtc",
             "borrow_limit": {
               "has_max_limit": true,
@@ -3308,9 +3326,27 @@
             "active": true
           },
           {
+            "market_id": "dai:usd",
+            "base_asset": "dai",
+            "quote_asset": "usd",
+            "oracles": [
+              "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h"
+            ],
+            "active": true
+          },
+          {
+            "market_id": "dai:usd:30",
+            "base_asset": "dai",
+            "quote_asset": "usd",
+            "oracles": [
+              "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h"
+            ],
+            "active": true
+          },
+          {
             "market_id": "eth:usd",
             "base_asset": "eth",
-            "quote_asset": "eth",
+            "quote_asset": "usd",
             "oracles": [
               "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h"
             ],
@@ -3576,6 +3612,18 @@
           "market_id": "btc:usd:30",
           "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
           "price": "28500.962650000000001782"
+        },
+        {
+          "expiry": "2050-01-01T00:00:00Z",
+          "market_id": "dai:usd",
+          "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
+          "price": "1.000000000000000000"
+        },
+        {
+          "expiry": "2050-01-01T00:00:00Z",
+          "market_id": "dai:usd:30",
+          "oracle_address": "kava1hdn83q3srldcpan4ex2v4npuae8hmnfrps3e6h",
+          "price": "1.000000000000000000"
         },
         {
           "expiry": "2050-01-01T00:00:00Z",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

Updates internal testnet genesis to include dai money market and associated pricefeed changes. Updates seed script to include dai as as evm conversion pair. This enables testing of 18 decimal money markets on internal testnet.
<!--- Describe your changes in detail -->

## Checklist
 - [ ] Changelog has been updated as necessary.
