### PR TITLE
ci: Add dai to x/issuance genesis params for internal-testnet

### DIFF
--- a/ci/env/kava-internal-testnet/genesis.json
+++ b/ci/env/kava-internal-testnet/genesis.json
@@ -3179,6 +3179,18 @@
           },
           {
             "owner": "kava1vlpsrmdyuywvaqrv7rx6xga224sqfwz3fyfhwq",
+            "denom": "erc20/eth/dai",
+            "blocked_addresses": [],
+            "paused": false,
+            "blockable": false,
+            "rate_limit": {
+              "active": false,
+              "limit": "0",
+              "time_period": "0"
+            }
+          },
+          {
+            "owner": "kava1vlpsrmdyuywvaqrv7rx6xga224sqfwz3fyfhwq",
             "denom": "hard",
             "blocked_addresses": [],
             "paused": false,


### PR DESCRIPTION
## Description
- Add `"erc20/eth/dai"` to x/issuance genesis params for internal testnet

### Notes
Internal testnet was **manually reset** via https://github.com/Kava-Labs/infrastructure/tree/dl-internal-testnet-reset then seeded locally via `act`

The internal testnet reset workflows have been disabled in the UI before they are upgraded to new infrastructure as they fail to reset the chain and to prevent this change from resetting the chain:

https://github.com/Kava-Labs/kava/actions/workflows/cd-internal-testnet.yml  
https://github.com/Kava-Labs/kava/actions/workflows/cd-internal-testnet-manual.yml