### PR TITLE
refactor(tests/e2e-evm): Restructure ABI tests for extensibility & reduce duplication 

### DIFF
--- a/tests/e2e-evm/.solhint.json
+++ b/tests/e2e-evm/.solhint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "solhint:recommended"
+  "extends": "solhint:recommended",
+  "rules": {
+    "func-visibility": ["warn", { "ignoreConstructors": true }]
+  }
 }

--- a/tests/e2e-evm/contracts/ABI_BasicTests.sol
+++ b/tests/e2e-evm/contracts/ABI_BasicTests.sol
@@ -13,8 +13,10 @@ contract Caller {
         (bool success, bytes memory result) = to.call{value: msg.value}(data);
 
         if (!success) {
-            if (result.length == 0) revert();
+            // solhint-disable-next-line gas-custom-errors
+            if (result.length == 0) revert("reverted with no reason");
 
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 revert(add(32, result), mload(result))
             }
@@ -24,11 +26,14 @@ contract Caller {
     // TODO: Callcode
 
     function functionDelegateCall(address to, bytes calldata data) external {
+        // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory result) = to.delegatecall(data);
 
         if (!success) {
-            if (result.length == 0) revert();
+            // solhint-disable-next-line gas-custom-errors
+            if (result.length == 0) revert("reverted with no reason");
 
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 revert(add(32, result), mload(result))
             }
@@ -39,8 +44,10 @@ contract Caller {
         (bool success, bytes memory result) = to.staticcall(data);
 
         if (!success) {
-            if (result.length == 0) revert();
+            // solhint-disable-next-line gas-custom-errors
+            if (result.length == 0) revert("reverted with no reason");
 
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 revert(add(32, result), mload(result))
             }
@@ -52,7 +59,7 @@ contract Caller {
 // High level caller
 //
 contract NoopCaller {
-    NoopNoReceiveNoFallback target;
+    NoopNoReceiveNoFallback private target;
 
     constructor(NoopNoReceiveNoFallback _target) {
         target = _target;

--- a/tests/e2e-evm/contracts/ABI_DisabledTests.sol
+++ b/tests/e2e-evm/contracts/ABI_DisabledTests.sol
@@ -1,37 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import "./ABI_BasicTests.sol";
+import "./ABI_BasicTests.sol" as ABI_BasicTests;
 
 //
 // Disabled contract that is payable and callable with any calldata (receive + fallback)
 //
-contract NoopDisabledMock is NoopReceivePayableFallback{
+contract NoopDisabledMock is ABI_BasicTests.NoopReceivePayableFallback {
     // solc-ignore-next-line func-mutability
     function noopNonpayable() external {
-      mockRevert();
+        mockRevert();
     }
     function noopPayable() external payable {
-      mockRevert();
+        mockRevert();
     }
     // solc-ignore-next-line func-mutability
     function noopView() external view {
-      mockRevert();
+        mockRevert();
     }
     function noopPure() external pure {
-      mockRevert();
+        mockRevert();
     }
     receive() external payable {
-      mockRevert();
+        mockRevert();
     }
     fallback() external payable {
-      mockRevert();
+        mockRevert();
     }
 
     //
     // Mimic revert + revert reason
     //
     function mockRevert() private pure {
-      revert("call not allowed to disabled contract");
+        // solhint-disable-next-line reason-string, gas-custom-errors
+        revert("call not allowed to disabled contract");
     }
 }

--- a/tests/e2e-evm/hardhat.config.ts
+++ b/tests/e2e-evm/hardhat.config.ts
@@ -10,6 +10,7 @@ import "hardhat-ignore-warnings";
 // Chai setup
 //
 chai.use(chaiAsPromised);
+chai.config.truncateThreshold = 0;
 
 //
 // Load HRE extensions

--- a/tests/e2e-evm/test/abi_basic.test.ts
+++ b/tests/e2e-evm/test/abi_basic.test.ts
@@ -506,7 +506,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with a non-matching function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -518,7 +518,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with a non-matching function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -531,7 +531,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with a non-matching function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -547,7 +547,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with a non-matching function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -564,7 +564,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with a non-matching function selector via static call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -580,7 +580,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with a non-matching function selector via static call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -597,7 +597,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with an invalid (short) function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -609,7 +609,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with an invalid (short) function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -622,7 +622,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with an invalid (short) function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -638,7 +638,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with an invalid (short) function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -655,7 +655,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can be called with an invalid (short) function selector via static call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -671,7 +671,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not be called with an invalid (short) function selector via static call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !fallbackFunction;
       },
       txParams: (ctx) => ({
@@ -689,7 +689,7 @@ describe("ABI_BasicTests", function () {
     // Fallback payable tests
     {
       name: "can receive value with a non-matching function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability === "payable";
       },
       txParams: (ctx) => ({
@@ -703,7 +703,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not receive value with a non-matching function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability !== "payable";
       },
       txParams: (ctx) => ({
@@ -718,7 +718,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can receive value with a non-matching function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability === "payable";
       },
       txParams: (ctx) => ({
@@ -736,7 +736,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not receive value with a non-matching function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability !== "payable";
       },
       txParams: (ctx) => ({
@@ -755,7 +755,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can receive value with an invalid (short) function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability === "payable";
       },
       txParams: (ctx) => ({
@@ -769,7 +769,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not receive value with an invalid (short) function selector",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability !== "payable";
       },
       txParams: (ctx) => ({
@@ -784,7 +784,7 @@ describe("ABI_BasicTests", function () {
 
     {
       name: "can receive value with an invalid (short) function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability === "payable";
       },
       txParams: (ctx) => ({
@@ -802,7 +802,7 @@ describe("ABI_BasicTests", function () {
     },
     {
       name: "can not receive value with an invalid (short) function selector via message call",
-      shouldRun(receiveFunction, fallbackFunction) {
+      shouldRun(_, fallbackFunction) {
         return !!fallbackFunction && fallbackFunction.stateMutability !== "payable";
       },
       txParams: (ctx) => ({

--- a/tests/e2e-evm/test/abi_basic.test.ts
+++ b/tests/e2e-evm/test/abi_basic.test.ts
@@ -20,7 +20,7 @@ import { whaleAddress } from "./addresses";
 const defaultGas = 25000n;
 const contractCallerGas = defaultGas + 10000n;
 
-interface ContractTestCase<> {
+interface ContractTestCase {
   interface: keyof ArtifactsMap;
   // Ensures contract name ends with "Mock", but does not enforce the prefix
   // matches the interface.

--- a/tests/e2e-evm/test/abi_disabled.test.ts
+++ b/tests/e2e-evm/test/abi_disabled.test.ts
@@ -95,24 +95,33 @@ describe("ABI_DisabledTests", function () {
       value: bigint;
       data: Hex;
     }
-    const testCases: testCase[] = [
-      { name: "zero value transfer", value: 0n, data: "0x" },
-      { name: "value transfer", value: 1n, data: "0x" },
-      { name: "invalid function selector", value: 0n, data: "0x010203" },
-      { name: "invalid function selector with value", value: 1n, data: "0x010203" },
-      { name: "non-matching function selector", value: 0n, data: toFunctionSelector("does_not_exist()") },
-      { name: "non-matching function selector with value", value: 1n, data: toFunctionSelector("does_not_exist()") },
-      {
-        name: "non-matching function selector with extra data",
-        value: 0n,
-        data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
-      },
-      {
-        name: "non-matching function selector with value and extra data",
-        value: 1n,
-        data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
-      },
-    ];
+    const testCases: testCase[] = [];
+
+    if (receiveFunction) {
+      testCases.push(
+        { name: "zero value transfer", value: 0n, data: "0x" },
+        { name: "value transfer", value: 1n, data: "0x" },
+      );
+    }
+
+    if (fallbackFunction) {
+      testCases.push(
+        { name: "invalid function selector", value: 0n, data: "0x010203" },
+        { name: "invalid function selector with value", value: 1n, data: "0x010203" },
+        { name: "non-matching function selector", value: 0n, data: toFunctionSelector("does_not_exist()") },
+        { name: "non-matching function selector with value", value: 1n, data: toFunctionSelector("does_not_exist()") },
+        {
+          name: "non-matching function selector with extra data",
+          value: 0n,
+          data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
+        },
+        {
+          name: "non-matching function selector with value and extra data",
+          value: 1n,
+          data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
+        },
+      );
+    }
 
     for (const funcDesc of abi) {
       if (funcDesc.type !== "function") {

--- a/tests/e2e-evm/test/abi_disabled.test.ts
+++ b/tests/e2e-evm/test/abi_disabled.test.ts
@@ -1,13 +1,17 @@
 import hre from "hardhat";
 import type { ArtifactsMap } from "hardhat/types/artifacts";
-import type {
-  PublicClient,
-  WalletClient,
-  ContractName,
-  GetContractReturnType,
-} from "@nomicfoundation/hardhat-viem/types";
+import type { PublicClient, WalletClient, GetContractReturnType } from "@nomicfoundation/hardhat-viem/types";
 import { expect } from "chai";
-import { Address, BaseError, Hex, toFunctionSelector, toFunctionSignature, concat, encodeFunctionData } from "viem";
+import {
+  Address,
+  BaseError,
+  Hex,
+  toFunctionSelector,
+  toFunctionSignature,
+  concat,
+  encodeFunctionData,
+  isHex,
+} from "viem";
 import { Abi } from "abitype";
 import { getAbiFallbackFunction, getAbiReceiveFunction } from "./helpers/abi";
 import { whaleAddress } from "./addresses";
@@ -17,23 +21,23 @@ const messageCallGas = defaultGas + 10000n;
 
 interface ContractTestCase {
   interface: keyof ArtifactsMap;
-  mock: ContractName<keyof ArtifactsMap>;
+  mock: keyof ArtifactsMap;
   precompile: Address;
 }
 
 const disabledPrecompiles: Address[] = [
-  "0x9000000000000000000000000000000000000007", // noop recieve and payable fallback
+  "0x9000000000000000000000000000000000000007", // noop receive and payable fallback
 ];
 
 // ABI_DisabledTests assert ethereum + solidity transaction ABI interactions perform as expected.
 describe("ABI_DisabledTests", function () {
-  const testCases = [
+  const testCases: ContractTestCase[] = [
     {
       interface: "NoopReceivePayableFallback", // interface to test valid function selectors against
       mock: "NoopDisabledMock", // mimics how a disabled precompile would behave
-      precompile: disabledPrecompiles[0], // disabled noop recieve and payable fallback
+      precompile: disabledPrecompiles[0], // disabled noop receive and payable fallback
     },
-  ] as ContractTestCase[];
+  ];
 
   //
   // Client + Wallet Setup
@@ -84,8 +88,10 @@ describe("ABI_DisabledTests", function () {
       ctx = await getContext();
     });
 
+    // testCase is a single test case with the value and data to send. Each of
+    // these will be tested against each of the callCases.
     interface testCase {
-      name: string
+      name: string;
       value: bigint;
       data: Hex;
     }
@@ -94,61 +100,76 @@ describe("ABI_DisabledTests", function () {
       { name: "value transfer", value: 1n, data: "0x" },
       { name: "invalid function selector", value: 0n, data: "0x010203" },
       { name: "invalid function selector with value", value: 1n, data: "0x010203" },
-      { name: "non-matching function selector", value: 0n, data: toFunctionSelector("does_not_exist()")},
-      { name: "non-matching function selector with value", value: 1n, data: toFunctionSelector("does_not_exist()")},
-      { name: "non-matching function selector with extra data", value: 0n, data: concat([toFunctionSelector("does_not_exist()"), "0x01"])},
-      { name: "non-matching function selector with value and extra data", value: 1n, data: concat([toFunctionSelector("does_not_exist()"), "0x01"])},
+      { name: "non-matching function selector", value: 0n, data: toFunctionSelector("does_not_exist()") },
+      { name: "non-matching function selector with value", value: 1n, data: toFunctionSelector("does_not_exist()") },
+      {
+        name: "non-matching function selector with extra data",
+        value: 0n,
+        data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
+      },
+      {
+        name: "non-matching function selector with value and extra data",
+        value: 1n,
+        data: concat([toFunctionSelector("does_not_exist()"), "0x01"]),
+      },
     ];
 
     for (const funcDesc of abi) {
-      if (funcDesc.type !== "function") continue;
+      if (funcDesc.type !== "function") {
+        continue;
+      }
+
       const funcSelector = toFunctionSelector(toFunctionSignature(funcDesc));
-      testCases.concat([
+
+      testCases.push(
         { name: funcDesc.name, value: 0n, data: funcSelector },
         { name: `${funcDesc.name} with value`, value: 1n, data: funcSelector },
         { name: `${funcDesc.name} with extra data`, value: 0n, data: concat([funcSelector, "0x01"]) },
         { name: `${funcDesc.name} with value and extra data`, value: 1n, data: concat([funcSelector, "0x01"]) },
-      ]);
+      );
     }
 
     const callCases: {
       name: string;
-      mutateData: (tc: Hex) => Promise<Hex>;
-      to: () => Promise<Address>;
+      mutateData: (tc: Hex) => Hex;
+      to: () => Address;
       gas: bigint;
     }[] = [
       {
         name: "external call",
-        to: async () => ctx.address,
-        mutateData: async (data) => data,
+        to: () => ctx.address,
+        mutateData: (data) => data,
         gas: defaultGas,
       },
       {
         name: "message call",
-        to: async () => caller.address,
-        mutateData: async (data) => encodeFunctionData({ abi: caller.abi, functionName: "functionCall", args: [ctx.address, data] }),
+        to: () => caller.address,
+        mutateData: (data) =>
+          encodeFunctionData({ abi: caller.abi, functionName: "functionCall", args: [ctx.address, data] }),
         gas: messageCallGas,
       },
       {
         name: "message delegatecall",
-        to: async () => caller.address,
-        mutateData: async (data) => encodeFunctionData({ abi: caller.abi, functionName: "functionDelegateCall", args: [ctx.address, data] }),
+        to: () => caller.address,
+        mutateData: (data) =>
+          encodeFunctionData({ abi: caller.abi, functionName: "functionDelegateCall", args: [ctx.address, data] }),
         gas: messageCallGas,
       },
       {
         name: "message staticcall",
-        to: async () => caller.address,
-        mutateData: async (data) => encodeFunctionData({ abi: caller.abi, functionName: "functionStaticCall", args: [ctx.address, data] }),
+        to: () => caller.address,
+        mutateData: (data) =>
+          encodeFunctionData({ abi: caller.abi, functionName: "functionStaticCall", args: [ctx.address, data] }),
         gas: messageCallGas,
       },
     ];
 
     for (const tc of testCases) {
-      describe(tc.name, function() {
+      describe(tc.name, function () {
         for (const cc of callCases) {
-          it(`reverts on ${cc.name}`, async function() {
-            const to = await cc.to();
-            const data = await cc.mutateData(tc.data);
+          it(`reverts on ${cc.name}`, async function () {
+            const to = cc.to();
+            const data = cc.mutateData(tc.data);
 
             const txData = { to: to, data: data, gas: cc.gas };
             const startingBalance = await publicClient.getBalance({ address: ctx.address });
@@ -165,14 +186,16 @@ describe("ABI_DisabledTests", function () {
             let revertDetail = "";
             try {
               await call;
-            } catch(e) {
+            } catch (e) {
+              expect(e).to.be.instanceOf(BaseError, "expected error to be a BaseError");
+
               if (e instanceof BaseError) {
                 revertDetail = e.details;
               }
             }
 
-            const expectedMatch = /call not allowed to disabled contract/;
-            expect(expectedMatch.test(revertDetail), `expected ${revertDetail} to match ${expectedMatch}`).to.be.true;
+            const expectedMatch = "call not allowed to disabled contract";
+            expect(revertDetail).to.equal(revertDetail, `expected ${revertDetail} to match ${expectedMatch}`);
           });
         }
       });
@@ -198,10 +221,16 @@ describe("ABI_DisabledTests", function () {
         let deployedBytecode: Hex;
 
         before("deploy mock", async function () {
-          mockAddress = (await hre.viem.deployContract(tc.mock)).address;
-          // TODO: fix typing and do not use explicit any, unsafe assignment, or unsafe access
-          // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-          deployedBytecode = ((await hre.artifacts.readArtifact(tc.mock)) as any).deployedBytecode;
+          const mockContractName: string = tc.mock;
+
+          mockAddress = (await hre.viem.deployContract(mockContractName)).address;
+
+          const mockArtifact = await hre.artifacts.readArtifact(mockContractName);
+          if (isHex(mockArtifact.deployedBytecode)) {
+            deployedBytecode = mockArtifact.deployedBytecode;
+          } else {
+            expect.fail("deployedBytecode is not hex");
+          }
         });
 
         itHasCorrectState(() =>


### PR DESCRIPTION
## Description
- De-duplicate reused logic
- Group test cases into logical groups that run depending on the ABI function
- Resolve type issues
  - Remove type casts for test cases to allow for type checking
  - Remove unsafe assignments
