### PR TITLE
test(e2e-evm): Add CallCode tests for ABI compliance

### DIFF
--- a/tests/e2e-evm/contracts/ABI_BasicTests.sol
+++ b/tests/e2e-evm/contracts/ABI_BasicTests.sol
@@ -49,14 +49,14 @@ contract Caller {
             let result := callcode(
                 gas(), // gas
                 to, // to address
-                0, // value
+                callvalue(), // value
                 0, // in - pointer to start of input, 0 since we copied the data to 0
                 data.length, // insize - size of the input
                 0, // out
                 0 // outsize - 0 since we don't know the size of the output
             )
 
-            // Copy the returned data.
+            // Copy the returned data to memory.
             // returndatacopy(t, f, s)
             // - t: target location in memory
             // - f: source location in return data

--- a/tests/e2e-evm/contracts/ABI_CallCodeTest.sol
+++ b/tests/e2e-evm/contracts/ABI_CallCodeTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-contract TargetContract {
+contract CallCodeTestContract {
     uint256 public storageValue;
 
     function getMsgInfo() external payable returns (address, uint256) {

--- a/tests/e2e-evm/contracts/ABI_CallerTest.sol
+++ b/tests/e2e-evm/contracts/ABI_CallerTest.sol
@@ -2,7 +2,13 @@
 pragma solidity ^0.8.24;
 
 contract TargetContract {
+    uint256 public storageValue;
+
     function getMsgInfo() external payable returns (address, uint256) {
         return (msg.sender, msg.value);
+    }
+
+    function setStorageValue(uint256 value) external {
+        storageValue = value;
     }
 }

--- a/tests/e2e-evm/contracts/ABI_CallerTest.sol
+++ b/tests/e2e-evm/contracts/ABI_CallerTest.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract TargetContract {
+    function getMsgInfo() external payable returns (address, uint256) {
+        return (msg.sender, msg.value);
+    }
+}

--- a/tests/e2e-evm/test/abi_basic.test.ts
+++ b/tests/e2e-evm/test/abi_basic.test.ts
@@ -89,11 +89,11 @@ describe("ABI_BasicTests", function () {
   //
   let publicClient: PublicClient;
   let walletClient: WalletClient;
-  let caller: GetContractReturnType<ArtifactsMap["Caller"]["abi"]>;
+  let lowLevelCaller: GetContractReturnType<ArtifactsMap["Caller"]["abi"]>;
   before("setup clients", async function () {
     publicClient = await hre.viem.getPublicClient();
     walletClient = await hre.viem.getWalletClient(whaleAddress);
-    caller = await hre.viem.deployContract("Caller");
+    lowLevelCaller = await hre.viem.deployContract("Caller");
   });
 
   interface StateContext {
@@ -170,10 +170,23 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called by low level contract call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
+                args: [ctx.address, funcSelector],
+              }),
+              gas: contractCallerGas,
+            }),
+            expectedStatus: "success",
+          },
+          {
+            name: "can be called by callcode",
+            txParams: (ctx) => ({
+              to: lowLevelCaller.address,
+              data: encodeFunctionData({
+                abi: lowLevelCaller.abi,
+                functionName: "functionCallCode",
                 args: [ctx.address, funcSelector],
               }),
               gas: contractCallerGas,
@@ -205,9 +218,9 @@ describe("ABI_BasicTests", function () {
             {
               name: "can be called by static call",
               txParams: (ctx) => ({
-                to: caller.address,
+                to: lowLevelCaller.address,
                 data: encodeFunctionData({
-                  abi: caller.abi,
+                  abi: lowLevelCaller.abi,
                   functionName: "functionStaticCall",
                   args: [ctx.address, funcSelector],
                 }),
@@ -218,9 +231,9 @@ describe("ABI_BasicTests", function () {
             {
               name: "can be called by static call with extra data",
               txParams: (ctx) => ({
-                to: caller.address,
+                to: lowLevelCaller.address,
                 data: encodeFunctionData({
-                  abi: caller.abi,
+                  abi: lowLevelCaller.abi,
                   functionName: "functionStaticCall",
                   args: [ctx.address, concat([funcSelector, "0x01"])],
                 }),
@@ -258,9 +271,9 @@ describe("ABI_BasicTests", function () {
             {
               name: "can be called by high level contract call with value",
               txParams: (ctx) => ({
-                to: caller.address,
+                to: lowLevelCaller.address,
                 data: encodeFunctionData({
-                  abi: caller.abi,
+                  abi: lowLevelCaller.abi,
                   functionName: "functionCall",
                   args: [ctx.address, funcSelector],
                 }),
@@ -313,9 +326,9 @@ describe("ABI_BasicTests", function () {
             {
               name: "can not be called by high level contract call with value",
               txParams: (ctx) => ({
-                to: caller.address,
+                to: lowLevelCaller.address,
                 data: encodeFunctionData({
-                  abi: caller.abi,
+                  abi: lowLevelCaller.abi,
                   functionName: "functionCall",
                   args: [ctx.address, funcSelector],
                 }),
@@ -397,9 +410,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called by another contract with no data",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x"],
               }),
@@ -410,9 +423,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called by static call with no data",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, "0x"],
               }),
@@ -433,9 +446,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not receive zero value transfers by high level contract call with no data",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x"],
               }),
@@ -446,9 +459,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not receive zero value transfers by static call with no data",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, "0x"],
               }),
@@ -470,9 +483,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not receive plain transfers via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x"],
               }),
@@ -495,9 +508,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can receive plain transfers via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x"],
               }),
@@ -524,9 +537,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called with a non-matching function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -537,9 +550,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called with a non-matching function selector via static call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -559,9 +572,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called with an invalid (short) function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x010203"],
               }),
@@ -572,9 +585,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can be called with an invalid (short) function selector via static call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, "0x010203"],
               }),
@@ -599,9 +612,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not be called with a non-matching function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -612,9 +625,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not be called with a non-matching function selector via static call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -634,9 +647,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not be called with an invalid (short) function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x010203"],
               }),
@@ -647,9 +660,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not be called with an invalid (short) function selector via static call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionStaticCall",
                 args: [ctx.address, "0x010203"],
               }),
@@ -676,9 +689,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can receive value with a non-matching function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -702,9 +715,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can receive value with an invalid (short) function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x010203"],
               }),
@@ -733,9 +746,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not receive value with a non-matching function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, toFunctionSelector("does_not_exist()")],
               }),
@@ -759,9 +772,9 @@ describe("ABI_BasicTests", function () {
           {
             name: "can not receive value with an invalid (short) function selector via message call",
             txParams: (ctx) => ({
-              to: caller.address,
+              to: lowLevelCaller.address,
               data: encodeFunctionData({
-                abi: caller.abi,
+                abi: lowLevelCaller.abi,
                 functionName: "functionCall",
                 args: [ctx.address, "0x010203"],
               }),

--- a/tests/e2e-evm/test/abi_disabled.test.ts
+++ b/tests/e2e-evm/test/abi_disabled.test.ts
@@ -158,6 +158,13 @@ describe("ABI_DisabledTests", function () {
         gas: messageCallGas,
       },
       {
+        name: "message callcode",
+        to: () => caller.address,
+        mutateData: (data) =>
+          encodeFunctionData({ abi: caller.abi, functionName: "functionCallCode", args: [ctx.address, data] }),
+        gas: messageCallGas,
+      },
+      {
         name: "message delegatecall",
         to: () => caller.address,
         mutateData: (data) =>

--- a/tests/e2e-evm/test/callcode.test.ts
+++ b/tests/e2e-evm/test/callcode.test.ts
@@ -23,7 +23,7 @@ describe("CallCode", () => {
 
   interface CallCodeContext {
     lowLevelCaller: GetContractReturnType<ArtifactsMap["Caller"]["abi"]>;
-    implementationContract: GetContractReturnType<ArtifactsMap["TargetContract"]["abi"]>;
+    implementationContract: GetContractReturnType<ArtifactsMap["CallCodeTestContract"]["abi"]>;
   }
 
   interface callCodeTestCaseBase {
@@ -55,7 +55,7 @@ describe("CallCode", () => {
     let ctx: CallCodeContext;
 
     before("deploy called contract", async function () {
-      const contract = await hre.viem.deployContract("TargetContract");
+      const contract = await hre.viem.deployContract("CallCodeTestContract");
       ctx = {
         lowLevelCaller: lowLevelCaller,
         implementationContract: contract,
@@ -152,7 +152,7 @@ describe("CallCode", () => {
         }),
         // msg.sender is the caller contract
         wantSender: (ctx) => ctx.lowLevelCaller.address,
-        // msg.value is not preserved
+        // msg.value is not preserved via callcode
         wantValue: 0n,
       },
       {
@@ -174,6 +174,7 @@ describe("CallCode", () => {
             ],
           }),
         }),
+        // Storage in caller contract
         wantStorageContract: (ctx) => ctx.lowLevelCaller.address,
         wantStorageValue: 2n,
       },

--- a/tests/e2e-evm/test/callcode.test.ts
+++ b/tests/e2e-evm/test/callcode.test.ts
@@ -1,0 +1,221 @@
+import hre from "hardhat";
+import type { ArtifactsMap } from "hardhat/types/artifacts";
+import type { PublicClient, WalletClient, GetContractReturnType } from "@nomicfoundation/hardhat-viem/types";
+import { expect } from "chai";
+import { Address, Hex, decodeFunctionResult, encodeFunctionData, getAddress, isAddressEqual } from "viem";
+import { whaleAddress } from "./addresses";
+
+const defaultGas = 25000n;
+const contractCallerGas = defaultGas + 10000n;
+
+describe("CallCode", () => {
+  //
+  // Client + Wallet Setup
+  //
+  let publicClient: PublicClient;
+  let walletClient: WalletClient;
+  let lowLevelCaller: GetContractReturnType<ArtifactsMap["Caller"]["abi"]>;
+  before("setup clients", async function () {
+    publicClient = await hre.viem.getPublicClient();
+    walletClient = await hre.viem.getWalletClient(whaleAddress);
+    lowLevelCaller = await hre.viem.deployContract("Caller");
+  });
+
+  interface callCodeTestCase {
+    name: string;
+    fromAddress: Address;
+    value: bigint;
+    gas: bigint;
+    mutateTxData?: (calledContractAddr: Address, data: Hex) => { to: Address; data: Hex };
+
+    wantSender: () => Address;
+    wantValue: bigint;
+  }
+
+  describe("msg context", () => {
+    let calledContract: GetContractReturnType<ArtifactsMap["TargetContract"]["abi"]>;
+
+    before("deploy called contract", async function () {
+      const contract = await hre.viem.deployContract("TargetContract");
+
+      calledContract = contract;
+    });
+
+    const testCases: callCodeTestCase[] = [
+      {
+        name: "direct call",
+        fromAddress: whaleAddress,
+        value: 0n,
+        gas: defaultGas,
+        wantSender: () => whaleAddress,
+        wantValue: 0n,
+      },
+      {
+        name: "direct call with value",
+        fromAddress: whaleAddress,
+        value: 100n,
+        gas: defaultGas,
+        wantSender: () => whaleAddress,
+        wantValue: 100n,
+      },
+      {
+        name: "callcode",
+        fromAddress: whaleAddress,
+        value: 0n,
+        gas: contractCallerGas,
+        mutateTxData: (contractAddr, data) => ({
+          to: lowLevelCaller.address,
+          data: encodeFunctionData({
+            abi: lowLevelCaller.abi,
+            functionName: "functionCallCode",
+            args: [contractAddr, data],
+          }),
+        }),
+        // msg.sender is the caller contract, not the whale
+        wantSender: () => lowLevelCaller.address,
+        wantValue: 0n,
+      },
+      {
+        name: "callcode with value",
+        fromAddress: whaleAddress,
+        value: 100n,
+        gas: contractCallerGas,
+        mutateTxData: (contractAddr, data) => ({
+          to: lowLevelCaller.address,
+          data: encodeFunctionData({
+            abi: lowLevelCaller.abi,
+            functionName: "functionCallCode",
+            args: [contractAddr, data],
+          }),
+        }),
+        // msg.sender is the caller contract, and value is NOT passed
+        wantSender: () => lowLevelCaller.address,
+        wantValue: 0n,
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, async function () {
+        let toAddr = calledContract.address;
+
+        let callData = encodeFunctionData({
+          abi: calledContract.abi,
+          functionName: "getMsgInfo",
+          args: [],
+        });
+
+        // Modify the call data if needed, wraps the call in a callcode
+        if (tc.mutateTxData) {
+          const { to, data } = tc.mutateTxData(calledContract.address, callData);
+          callData = data;
+          toAddr = to;
+        }
+
+        const txData = {
+          // Transaction sender
+          account: tc.fromAddress,
+          // Target contract
+          to: toAddr,
+          data: callData,
+          gas: tc.gas,
+          value: tc.value,
+        };
+
+        const res = await publicClient.call(txData);
+        if (!res.data) {
+          // Fail this way as a type guard to ensure res.data is not undefined
+          expect.fail("no data returned");
+        }
+
+        const [returnAddress, returnValue] = decodeFunctionResult({
+          abi: calledContract.abi,
+          functionName: "getMsgInfo",
+          data: res.data,
+        });
+
+        // getAddress to ensure both are checksum encoded
+        expect(getAddress(returnAddress)).to.equal(getAddress(tc.wantSender()));
+        expect(returnValue).to.equal(tc.wantValue);
+
+        const txHash = await walletClient.sendTransaction(txData);
+        const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        expect(txReceipt.status).to.equal("success");
+        expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+      });
+    }
+
+    it("should be callable directly", async function () {
+      const callData = encodeFunctionData({
+        abi: calledContract.abi,
+        functionName: "getMsgInfo",
+        args: [],
+      });
+
+      const txData = {
+        account: whaleAddress,
+        to: calledContract.address,
+        data: callData,
+        gas: defaultGas,
+      };
+
+      const res = await publicClient.call(txData);
+      if (!res.data) {
+        // Fail this way as a type guard to ensure res.data is not undefined
+        expect.fail("no data returned");
+      }
+
+      const [returnAddress, returnValue] = decodeFunctionResult({
+        abi: calledContract.abi,
+        functionName: "getMsgInfo",
+        data: res.data,
+      });
+
+      expect(isAddressEqual(returnAddress, whaleAddress)).to.be.true;
+      expect(returnValue).to.equal(0n);
+
+      const txHash = await walletClient.sendTransaction(txData);
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      expect(txReceipt.status).to.equal("success");
+      expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+    });
+
+    it("should be callable via callcode", async function () {
+      const callData = encodeFunctionData({
+        abi: calledContract.abi,
+        functionName: "getMsgInfo",
+        args: [],
+      });
+
+      const callerData: Hex = encodeFunctionData({
+        abi: lowLevelCaller.abi,
+        functionName: "functionCallCode",
+        args: [calledContract.address, callData],
+      });
+
+      const txData = {
+        to: lowLevelCaller.address,
+        data: callerData,
+        gas: contractCallerGas + 50_000n,
+      };
+
+      const res = await publicClient.call(txData);
+      if (!res.data) {
+        expect.fail("no data returned");
+      }
+
+      const [returnAddress, returnValue] = decodeFunctionResult({
+        abi: calledContract.abi,
+        functionName: "getMsgInfo",
+        data: res.data,
+      });
+
+      expect(isAddressEqual(returnAddress, lowLevelCaller.address)).to.be.true;
+      expect(returnValue).to.equal(0n);
+
+      const txHash = await walletClient.sendTransaction(txData);
+      const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      expect(txReceipt.status).to.equal("success");
+      expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+    });
+  });
+});

--- a/tests/e2e-evm/test/callcode.test.ts
+++ b/tests/e2e-evm/test/callcode.test.ts
@@ -2,7 +2,7 @@ import hre from "hardhat";
 import type { ArtifactsMap } from "hardhat/types/artifacts";
 import type { PublicClient, WalletClient, GetContractReturnType } from "@nomicfoundation/hardhat-viem/types";
 import { expect } from "chai";
-import { Address, Hex, decodeFunctionResult, encodeFunctionData, getAddress, isAddressEqual } from "viem";
+import { Address, CallParameters, Chain, decodeFunctionResult, encodeFunctionData, getAddress } from "viem";
 import { whaleAddress } from "./addresses";
 
 const defaultGas = 25000n;
@@ -21,105 +21,112 @@ describe("CallCode", () => {
     lowLevelCaller = await hre.viem.deployContract("Caller");
   });
 
+  interface CallCodeContext {
+    lowLevelCaller: GetContractReturnType<ArtifactsMap["Caller"]["abi"]>;
+    implementationContract: GetContractReturnType<ArtifactsMap["TargetContract"]["abi"]>;
+  }
+
   interface callCodeTestCase {
     name: string;
-    fromAddress: Address;
-    value: bigint;
-    gas: bigint;
-    mutateTxData?: (calledContractAddr: Address, data: Hex) => { to: Address; data: Hex };
-
-    wantSender: () => Address;
+    txParams: (ctx: CallCodeContext) => CallParameters<Chain>;
+    wantSender: (ctx: CallCodeContext, signer: Address) => Address;
     wantValue: bigint;
   }
 
   describe("msg context", () => {
-    let calledContract: GetContractReturnType<ArtifactsMap["TargetContract"]["abi"]>;
+    let ctx: CallCodeContext;
 
     before("deploy called contract", async function () {
       const contract = await hre.viem.deployContract("TargetContract");
-
-      calledContract = contract;
+      ctx = {
+        lowLevelCaller: lowLevelCaller,
+        implementationContract: contract,
+      };
     });
 
     const testCases: callCodeTestCase[] = [
       {
         name: "direct call",
-        fromAddress: whaleAddress,
-        value: 0n,
-        gas: defaultGas,
-        wantSender: () => whaleAddress,
+        txParams: (ctx) => ({
+          to: ctx.implementationContract.address,
+          value: 0n,
+          data: encodeFunctionData({
+            abi: ctx.implementationContract.abi,
+            functionName: "getMsgInfo",
+            args: [],
+          }),
+          gas: defaultGas,
+        }),
+        wantSender: (_, signer) => signer,
         wantValue: 0n,
       },
       {
         name: "direct call with value",
-        fromAddress: whaleAddress,
-        value: 100n,
-        gas: defaultGas,
-        wantSender: () => whaleAddress,
+        txParams: (ctx) => ({
+          to: ctx.implementationContract.address,
+          value: 100n,
+          gas: defaultGas,
+          data: encodeFunctionData({
+            abi: ctx.implementationContract.abi,
+            functionName: "getMsgInfo",
+            args: [],
+          }),
+        }),
+        wantSender: (_, signer) => signer,
         wantValue: 100n,
       },
       {
         name: "callcode",
-        fromAddress: whaleAddress,
-        value: 0n,
-        gas: contractCallerGas,
-        mutateTxData: (contractAddr, data) => ({
-          to: lowLevelCaller.address,
+        txParams: (ctx) => ({
+          to: ctx.lowLevelCaller.address,
+          value: 0n,
+          gas: contractCallerGas,
           data: encodeFunctionData({
             abi: lowLevelCaller.abi,
             functionName: "functionCallCode",
-            args: [contractAddr, data],
+            args: [
+              ctx.implementationContract.address,
+              encodeFunctionData({
+                abi: ctx.implementationContract.abi,
+                functionName: "getMsgInfo",
+                args: [],
+              }),
+            ],
           }),
         }),
         // msg.sender is the caller contract, not the whale
-        wantSender: () => lowLevelCaller.address,
+        wantSender: (ctx) => ctx.lowLevelCaller.address,
         wantValue: 0n,
       },
       {
         name: "callcode with value",
-        fromAddress: whaleAddress,
-        value: 100n,
-        gas: contractCallerGas,
-        mutateTxData: (contractAddr, data) => ({
-          to: lowLevelCaller.address,
+        txParams: (ctx) => ({
+          to: ctx.lowLevelCaller.address,
+          value: 100n,
+          gas: contractCallerGas,
           data: encodeFunctionData({
             abi: lowLevelCaller.abi,
             functionName: "functionCallCode",
-            args: [contractAddr, data],
+            args: [
+              ctx.implementationContract.address,
+              encodeFunctionData({
+                abi: ctx.implementationContract.abi,
+                functionName: "getMsgInfo",
+                args: [],
+              }),
+            ],
           }),
         }),
         // msg.sender is the caller contract, and value is NOT passed
-        wantSender: () => lowLevelCaller.address,
+        wantSender: (ctx) => ctx.lowLevelCaller.address,
         wantValue: 0n,
       },
     ];
 
     for (const tc of testCases) {
       it(tc.name, async function () {
-        let toAddr = calledContract.address;
-
-        let callData = encodeFunctionData({
-          abi: calledContract.abi,
-          functionName: "getMsgInfo",
-          args: [],
-        });
-
-        // Modify the call data if needed, wraps the call in a callcode
-        if (tc.mutateTxData) {
-          const { to, data } = tc.mutateTxData(calledContract.address, callData);
-          callData = data;
-          toAddr = to;
-        }
-
-        const txData = {
-          // Transaction sender
-          account: tc.fromAddress,
-          // Target contract
-          to: toAddr,
-          data: callData,
-          gas: tc.gas,
-          value: tc.value,
-        };
+        const txData = tc.txParams(ctx);
+        txData.account = whaleAddress;
 
         const res = await publicClient.call(txData);
         if (!res.data) {
@@ -127,95 +134,27 @@ describe("CallCode", () => {
           expect.fail("no data returned");
         }
 
+        // Expect all test cases call the getMsgInfo function
         const [returnAddress, returnValue] = decodeFunctionResult({
-          abi: calledContract.abi,
+          abi: ctx.implementationContract.abi,
           functionName: "getMsgInfo",
           data: res.data,
         });
 
+        const expectedSender = tc.wantSender(ctx, whaleAddress);
+
         // getAddress to ensure both are checksum encoded
-        expect(getAddress(returnAddress)).to.equal(getAddress(tc.wantSender()));
+        expect(getAddress(returnAddress)).to.equal(getAddress(expectedSender));
         expect(returnValue).to.equal(tc.wantValue);
 
         const txHash = await walletClient.sendTransaction(txData);
         const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
         expect(txReceipt.status).to.equal("success");
-        expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+
+        if (txData.gas) {
+          expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+        }
       });
     }
-
-    it("should be callable directly", async function () {
-      const callData = encodeFunctionData({
-        abi: calledContract.abi,
-        functionName: "getMsgInfo",
-        args: [],
-      });
-
-      const txData = {
-        account: whaleAddress,
-        to: calledContract.address,
-        data: callData,
-        gas: defaultGas,
-      };
-
-      const res = await publicClient.call(txData);
-      if (!res.data) {
-        // Fail this way as a type guard to ensure res.data is not undefined
-        expect.fail("no data returned");
-      }
-
-      const [returnAddress, returnValue] = decodeFunctionResult({
-        abi: calledContract.abi,
-        functionName: "getMsgInfo",
-        data: res.data,
-      });
-
-      expect(isAddressEqual(returnAddress, whaleAddress)).to.be.true;
-      expect(returnValue).to.equal(0n);
-
-      const txHash = await walletClient.sendTransaction(txData);
-      const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
-      expect(txReceipt.status).to.equal("success");
-      expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
-    });
-
-    it("should be callable via callcode", async function () {
-      const callData = encodeFunctionData({
-        abi: calledContract.abi,
-        functionName: "getMsgInfo",
-        args: [],
-      });
-
-      const callerData: Hex = encodeFunctionData({
-        abi: lowLevelCaller.abi,
-        functionName: "functionCallCode",
-        args: [calledContract.address, callData],
-      });
-
-      const txData = {
-        to: lowLevelCaller.address,
-        data: callerData,
-        gas: contractCallerGas + 50_000n,
-      };
-
-      const res = await publicClient.call(txData);
-      if (!res.data) {
-        expect.fail("no data returned");
-      }
-
-      const [returnAddress, returnValue] = decodeFunctionResult({
-        abi: calledContract.abi,
-        functionName: "getMsgInfo",
-        data: res.data,
-      });
-
-      expect(isAddressEqual(returnAddress, lowLevelCaller.address)).to.be.true;
-      expect(returnValue).to.equal(0n);
-
-      const txHash = await walletClient.sendTransaction(txData);
-      const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
-      expect(txReceipt.status).to.equal("success");
-      expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
-    });
   });
 });

--- a/tests/e2e-evm/test/callcode.test.ts
+++ b/tests/e2e-evm/test/callcode.test.ts
@@ -150,15 +150,16 @@ describe("CallCode", () => {
             ],
           }),
         }),
-        // msg.sender is the caller contract, and value is NOT passed
+        // msg.sender is the caller contract
         wantSender: (ctx) => ctx.lowLevelCaller.address,
+        // msg.value is not preserved
         wantValue: 0n,
       },
       {
         name: "callcode with storage",
         txParams: (ctx) => ({
           to: ctx.lowLevelCaller.address,
-          value: 100n,
+          value: 0n,
           gas: contractCallerGas + 20_000n,
           data: encodeFunctionData({
             abi: lowLevelCaller.abi,

--- a/tests/e2e-evm/test/callcode.test.ts
+++ b/tests/e2e-evm/test/callcode.test.ts
@@ -2,7 +2,7 @@ import hre from "hardhat";
 import type { ArtifactsMap } from "hardhat/types/artifacts";
 import type { PublicClient, WalletClient, GetContractReturnType } from "@nomicfoundation/hardhat-viem/types";
 import { expect } from "chai";
-import { Address, CallParameters, Chain, decodeFunctionResult, encodeFunctionData, getAddress } from "viem";
+import { Address, CallParameters, Chain, decodeFunctionResult, encodeFunctionData, getAddress, pad, toHex } from "viem";
 import { whaleAddress } from "./addresses";
 
 const defaultGas = 25000n;
@@ -26,12 +26,30 @@ describe("CallCode", () => {
     implementationContract: GetContractReturnType<ArtifactsMap["TargetContract"]["abi"]>;
   }
 
-  interface callCodeTestCase {
+  interface callCodeTestCaseBase {
     name: string;
     txParams: (ctx: CallCodeContext) => CallParameters<Chain>;
+  }
+
+  // callCodeTestCaseSendAndValue is for getMsgInfo() call tests to validate
+  // expected msg.sender and msg.value
+  type callCodeTestCaseSendAndValue = callCodeTestCaseBase & {
     wantSender: (ctx: CallCodeContext, signer: Address) => Address;
     wantValue: bigint;
-  }
+    wantStorageContract?: never;
+    wantStorageValue?: never;
+  };
+
+  // callCodeTestCaseStorage is for setStorageValue() call tests to validate
+  // which contract the storage is set on and the expected storage value
+  type callCodeTestCaseStorage = callCodeTestCaseBase & {
+    wantSender?: never;
+    wantValue?: never;
+    wantStorageContract: (ctx: CallCodeContext) => Address;
+    wantStorageValue: bigint;
+  };
+
+  type callCodeTestCase = callCodeTestCaseSendAndValue | callCodeTestCaseStorage;
 
   describe("msg context", () => {
     let ctx: CallCodeContext;
@@ -74,6 +92,21 @@ describe("CallCode", () => {
         }),
         wantSender: (_, signer) => signer,
         wantValue: 100n,
+      },
+      {
+        name: "direct call with storage",
+        txParams: (ctx) => ({
+          to: ctx.implementationContract.address,
+          value: 0n,
+          gas: defaultGas + 20_000n,
+          data: encodeFunctionData({
+            abi: ctx.implementationContract.abi,
+            functionName: "setStorageValue",
+            args: [1n],
+          }),
+        }),
+        wantStorageContract: (ctx) => ctx.implementationContract.address,
+        wantStorageValue: 1n,
       },
       {
         name: "callcode",
@@ -121,31 +154,58 @@ describe("CallCode", () => {
         wantSender: (ctx) => ctx.lowLevelCaller.address,
         wantValue: 0n,
       },
+      {
+        name: "callcode with storage",
+        txParams: (ctx) => ({
+          to: ctx.lowLevelCaller.address,
+          value: 100n,
+          gas: contractCallerGas + 20_000n,
+          data: encodeFunctionData({
+            abi: lowLevelCaller.abi,
+            functionName: "functionCallCode",
+            args: [
+              ctx.implementationContract.address,
+              encodeFunctionData({
+                abi: ctx.implementationContract.abi,
+                functionName: "setStorageValue",
+                args: [2n],
+              }),
+            ],
+          }),
+        }),
+        wantStorageContract: (ctx) => ctx.lowLevelCaller.address,
+        wantStorageValue: 2n,
+      },
     ];
 
     for (const tc of testCases) {
       it(tc.name, async function () {
         const txData = tc.txParams(ctx);
+        // Signer is the whale
         txData.account = whaleAddress;
 
         const res = await publicClient.call(txData);
-        if (!res.data) {
-          // Fail this way as a type guard to ensure res.data is not undefined
-          expect.fail("no data returned");
+
+        // Check the return value for the msg.sender and msg.value if applicable
+        if (tc.wantSender && tc.wantValue) {
+          if (!res.data) {
+            // Fail this way as a type guard to ensure res.data is not undefined
+            expect.fail("no data returned");
+          }
+
+          // Expect all test cases call the getMsgInfo function
+          const [returnAddress, returnValue] = decodeFunctionResult({
+            abi: ctx.implementationContract.abi,
+            functionName: "getMsgInfo",
+            data: res.data,
+          });
+
+          const expectedSender = tc.wantSender(ctx, whaleAddress);
+
+          // getAddress to ensure both are checksum encoded
+          expect(getAddress(returnAddress)).to.equal(getAddress(expectedSender), "unexpected msg.sender");
+          expect(returnValue).to.equal(tc.wantValue, "unexpected msg.value");
         }
-
-        // Expect all test cases call the getMsgInfo function
-        const [returnAddress, returnValue] = decodeFunctionResult({
-          abi: ctx.implementationContract.abi,
-          functionName: "getMsgInfo",
-          data: res.data,
-        });
-
-        const expectedSender = tc.wantSender(ctx, whaleAddress);
-
-        // getAddress to ensure both are checksum encoded
-        expect(getAddress(returnAddress)).to.equal(getAddress(expectedSender));
-        expect(returnValue).to.equal(tc.wantValue);
 
         const txHash = await walletClient.sendTransaction(txData);
         const txReceipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
@@ -153,6 +213,18 @@ describe("CallCode", () => {
 
         if (txData.gas) {
           expect(txReceipt.gasUsed < txData.gas, "gas to not be exhausted").to.be.true;
+        }
+
+        // Storage tests if applicable
+        if (tc.wantStorageContract) {
+          const storageContract = tc.wantStorageContract(ctx);
+          const storageValue = await publicClient.getStorageAt({
+            address: storageContract,
+            slot: toHex(0),
+          });
+
+          const expectedStorage = pad(toHex(tc.wantStorageValue));
+          expect(storageValue).to.equal(expectedStorage, "unexpected storage value");
         }
       });
     }


### PR DESCRIPTION
## Description
- Add `functionCallCode` to low level caller contract
  - Document details of the inline assembly
- Test specific callcode behavior to verify `functionCallCode`
  - Verify expected `msg.sender`, `msg.value`, and storage location
- Add `callcode` use for ABI basic tests to call mock contracts. 