### PR TITLE
deps: bump ethermint to fix indexer infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [unreleased]
 
+### Bug Fixes
+
+* (ethermint) Fix infinite loop edge cases in evm indexer
+  * [ethermint#77] Wait for chain to start syncing when in statesync before starting evm indexer
+  * [ethermint#82] Wait after failed attempts to fetch block or block results in evm indexer
+
+
 ## [v0.26.2-iavl-v1-alpha.0]
 
 This is the first release candidate for Kava on IAVL V1.
@@ -385,6 +392,9 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 - [#257](https://github.com/Kava-Labs/kava/pulls/257) Include scripts to run
   large-scale simulations remotely using aws-batch
 
+
+[ethermint#82]: https://github.com/Kava-Labs/ethermint/pull/82
+[ethermint#77]: https://github.com/Kava-Labs/ethermint/pull/77
 [#1973]: https://github.com/Kava-Labs/kava/pull/1973
 [#1967]: https://github.com/Kava-Labs/kava/pull/1967
 [#1954]: https://github.com/Kava-Labs/kava/pull/1954

--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ replace (
 	// See https://github.com/cosmos/cosmos-sdk/pull/13093
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	// Use ethermint fork that respects min-gas-price with NoBaseFee true and london enabled, and includes eip712 support
-	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v26.5
+	github.com/evmos/ethermint => github.com/kava-labs/ethermint v0.21.0-kava-v26.6
 	// See https://github.com/cosmos/cosmos-sdk/pull/10401, https://github.com/cosmos/cosmos-sdk/commit/0592ba6158cd0bf49d894be1cef4faeec59e8320
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	// Downgraded to avoid bugs in following commits which causes "version does not exist" errors

--- a/go.sum
+++ b/go.sum
@@ -885,8 +885,8 @@ github.com/kava-labs/cometbft-db v0.9.1-kava.2 h1:ZQaio886ifvml9XtJB4IYHhlArgA3+
 github.com/kava-labs/cometbft-db v0.9.1-kava.2/go.mod h1:PvUZbx7zeR7I4CAvtKBoii/5ia5gXskKjDjIVpt7gDw=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.2 h1:rbUXwJFlrRd05G1D5S5zAlmTTBbkcf0w36QFf5+i9tk=
 github.com/kava-labs/cosmos-sdk v0.47.10-iavl-v1-kava.2/go.mod h1:OwLYEBcsnijCLE8gYkwQ7jycZZ/Acd+a83pJU+V+MKw=
-github.com/kava-labs/ethermint v0.21.0-kava-v26.5 h1:JmDk/4u//SnBOqkTzXv0nf+ZPaqV2W+NThyKFnwlLiw=
-github.com/kava-labs/ethermint v0.21.0-kava-v26.5/go.mod h1:zGcUyJhdcoO0VfxAQwiXpGjBAV8w+Hig1yaH2l7KB5k=
+github.com/kava-labs/ethermint v0.21.0-kava-v26.6 h1:9MUnu1xe7Oc3kv0CtvRtBMbPBUcpKZnQsbVJhWA8L0M=
+github.com/kava-labs/ethermint v0.21.0-kava-v26.6/go.mod h1:zGcUyJhdcoO0VfxAQwiXpGjBAV8w+Hig1yaH2l7KB5k=
 github.com/kava-labs/iavl v1.2.0-kava.2 h1:RfEqQ9u7fvhzXOfYxxqEnVNCTb3pYJiT7X86N6cgI0M=
 github.com/kava-labs/iavl v1.2.0-kava.2/go.mod h1:nNoeUFw64lfPvcj3yZ7W7BvmlTxu9ANGsJcUiPSOAdw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
## Description
Bumps ethermint to `v0.21.0-kava-v26.6` which includes the bugfix described in https://github.com/Kava-Labs/ethermint/pull/82

## Checklist
 - [x] Changelog has been updated as necessary.
