### PR TITLE
docs: prepare for tag+release of v0.26.2-iavl-v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,16 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [unreleased]
 
-### Bug Fixes
 
-* (ethermint) Fix infinite loop edge cases in evm indexer
-  * [ethermint#77] Wait for chain to start syncing when in statesync before starting evm indexer
-  * [ethermint#82] Wait after failed attempts to fetch block or block results in evm indexer
+## [v0.26.2-iavl-v1]
 
-
-## [v0.26.2-iavl-v1-alpha.0]
-
-This is the first release candidate for Kava on IAVL V1.
+This is the first release for Kava on IAVL V1.
 
 IAVL V1 is a new format for the low-level data storage used by the Kava blockchain.
 Using IAVL V1 brings performance speedups for syncing and massively reduces the data stored on disk
@@ -55,7 +49,7 @@ The release is compatible with v0 data, but for the full performance benefits, n
 encouraged to update their data to the v1 format.
 
 For full-archive operators, an IAVL V1 snapshot will be made available in the coming weeks.
-For validators & operators of pruning nodes, it is recommended that node data is re-created from scratch
+For validators & operators of pruning nodes, it is recommended that node data is recreated from scratch
 via statesync.
 
 Future minor versions of v0.26 will be made available for both iavl v0 and iavl v1.
@@ -76,6 +70,12 @@ For more details see the [IAVL V1 migration guide](/migrate/v0_26/iavl-v1.md).
     a state similar to if the data has been pruned.
     - An IAVL v1 reference node is saved at the upgrade height pointing to the version 1 data so app
     data for the upgrade version can be properly loaded.
+
+### Bug Fixes
+
+* (ethermint) Fix infinite loop edge cases in evm indexer
+  * [ethermint#77] Wait for chain to start syncing when in statesync before starting evm indexer
+  * [ethermint#82] Wait after failed attempts to fetch block or block results in evm indexer
 
 
 ## [v0.26.2]
@@ -464,8 +464,8 @@ the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.38.4/CHANGELOG.md).
 [#750]: https://github.com/Kava-Labs/kava/pull/750
 [#751]: https://github.com/Kava-Labs/kava/pull/751
 [#780]: https://github.com/Kava-Labs/kava/pull/780
-[unreleased]: https://github.com/Kava-Labs/kava/compare/v0.26.2-iavl-v1-alpha.0...release/v0.26.x-iavl-v1
-[v0.26.2-iavl-v1-alpha.0]: https://github.com/Kava-Labs/kava/compare/v0.26.2...v0.26.2-iavl-v1-alpha.0
+[unreleased]: https://github.com/Kava-Labs/kava/compare/v0.26.2-iavl-v1...release/v0.26.x-iavl-v1
+[v0.26.2-iavl-v1]: https://github.com/Kava-Labs/kava/compare/v0.26.2...v0.26.2-iavl-v1
 [v0.26.2]: https://github.com/Kava-Labs/kava/compare/v0.26.1...v0.26.2
 [v0.26.1]: https://github.com/Kava-Labs/kava/compare/v0.26.0...v0.26.1
 [v0.26.0]: https://github.com/Kava-Labs/kava/compare/v0.25.0...v0.26.0

--- a/migrate/v0_26/iavl-v1.md
+++ b/migrate/v0_26/iavl-v1.md
@@ -1,10 +1,11 @@
 # IAVL V1
 
-**IAVL V1 is a work in progress. Proceed at your own risk until a non-alpha version is tagged.**
-
 IAVL V1 is an updated data format for the low-level storage of application data in the Kava blockchain.
-The change in format results in much more performant syncing of the chain, and greatly reduced the
+The change in format results in much more performant syncing of the chain, and greatly reduces the
 storage footprint required for Kava nodes.
+
+The first version of Kava using IAVL V1 is `v0.26.2-iavl-v1`. Future major versions will use IAVL V1
+unless otherwise specified.
 
 Steps for using IAVL V1:
 
@@ -12,17 +13,17 @@ Steps for using IAVL V1:
 1. Replace or recreate your node data with IAVL V1: see [Data](#data).
 2. Install an IAVL V1 binary:
 ```sh
-git checkout v0.26.2-alpha.0
+git checkout v0.26.2-iavl-v1
 make install
 ```
-3. Start kava as usual: `kava start`
+1. Start kava as usual: `kava start`
 
 **For `rocksdb` nodes:**
 1. Replace or recreate your node data with IAVL V1: see [Data](#data).
 2. Update your default memory allocator: see [default memory allocator](#default-memory-allocator)
 3. Install an IAVL V1 binary:
 ```sh
-git checkout v0.26.2-alpha.0
+git checkout v0.26.2-iavl-v1
 make install COSMOS_BUILD_OPTIONS=rocksdb
 ```
 4. Start kava with the desired memory allocator: `LD_PRELOAD=/path/to/tcmalloc kava start`
@@ -42,7 +43,15 @@ A public RPC server is available at `https://rpc.kava.io:443`.
 
 ### Full-archive node
 
-For nodes with the complete historical data, we expect to release archive data snapshots in the coming weeks. Stay tuned.
+For nodes with the complete historical data, we are in the process of creating and sharing a snapshot
+of full-archive node data. An update will be made when they are publicly available.
+
+In addition to the most recent version on this file, the Release Notes for
+[`v0.26.2-iavl-v1`](https://github.com/Kava-Labs/kava/releases/tag/v0.26.2-iavl-v1) will contain
+links to data when they are available.
+
+Node operators can expect a more performant kava process that uses less than half the data storage
+required of IAVL V0.
 
 ## Default memory allocator
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Consider using Conventional Commits prefixes like feat, fix, docs -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Updates the changelog & IAVL V1 migration doc in preparation of tagging the first non-alpha iavl v1 verison of kava 🎉 

The actual tag will be made as a reference to the merged commit of this PR.

## Checklist
 - [x] Changelog has been updated as necessary.
