### PR TITLE
chore: fix misc lints from v0.27 branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -27,6 +27,8 @@ pull_request_rules:
           - release/v0.24.x
           - release/v0.25.x
           - release/v0.26.x
+          - release/v0.26.x-iavl-v1
+          - release/v0.27.x
 
   - name: Backport patches to the release/v0.17.x branch
     conditions:
@@ -99,3 +101,21 @@ pull_request_rules:
       backport:
         branches:
           - release/v0.26.x
+
+  - name: Backport patches to the release/v0.26.x-iavl-v1 branch
+    conditions:
+      - base=master
+      - label=A:backport/v0.26.x-iavl-v1
+    actions:
+      backport:
+        branches:
+          - release/v0.26.x-iavl-v1
+
+  - name: Backport patches to the release/v0.27.x branch
+    conditions:
+      - base=master
+      - label=A:backport/v0.27.x
+    actions:
+      backport:
+        branches:
+          - release/v0.27.x

--- a/tests/util/addresses.go
+++ b/tests/util/addresses.go
@@ -7,6 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const (
+	MnemonicEntropyBits = 128
+)
+
 func SdkToEvmAddress(addr sdk.AccAddress) common.Address {
 	return common.BytesToAddress(addr.Bytes())
 }
@@ -17,9 +21,13 @@ func EvmToSdkAddress(addr common.Address) sdk.AccAddress {
 
 // RandomMnemonic generates a random BIP39 mnemonic from 128 bits of entropy
 func RandomMnemonic() (string, error) {
-	entropy, err := bip39.NewEntropy(128)
+	entropy, err := bip39.NewEntropy(MnemonicEntropyBits)
 	if err != nil {
 		return "", errorsmod.Wrap(err, "failed to generate entropy for new mnemonic")
 	}
-	return bip39.NewMnemonic(entropy)
+	mnemonic, err := bip39.NewMnemonic(entropy)
+	if err != nil {
+		return mnemonic, errorsmod.Wrap(err, "failed to create mnemonic")
+	}
+	return mnemonic, nil
 }

--- a/tests/util/evmsigner.go
+++ b/tests/util/evmsigner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	etherminttypes "github.com/evmos/ethermint/types"
 )
 
 var (
@@ -81,8 +82,8 @@ func NewEvmSigner(
 	}, nil
 }
 
-func NewEvmSignerFromMnemonic(evmClient *ethclient.Client, evmChainId *big.Int, mnemonic string) (*EvmSigner, error) {
-	hdPath := hd.CreateHDPath(60, 0, 0)
+func NewEvmSignerFromMnemonic(evmClient *ethclient.Client, evmChainID *big.Int, mnemonic string) (*EvmSigner, error) {
+	hdPath := hd.CreateHDPath(etherminttypes.Bip44CoinType, 0, 0)
 	privKeyBytes, err := hd.Secp256k1.Derive()(mnemonic, "", hdPath.String())
 	if err != nil {
 		return nil, errorsmod.Wrap(err, "failed to derive private key from mnemonic")
@@ -90,10 +91,10 @@ func NewEvmSignerFromMnemonic(evmClient *ethclient.Client, evmChainId *big.Int, 
 	privKey := &ethsecp256k1.PrivKey{Key: privKeyBytes}
 	ecdsaPrivKey, err := crypto.HexToECDSA(hex.EncodeToString(privKey.Bytes()))
 	if err != nil {
-		return nil, err
+		return nil, errorsmod.Wrap(err, "failed to convert hex to ECDSA")
 	}
 
-	return NewEvmSigner(evmClient, ecdsaPrivKey, evmChainId)
+	return NewEvmSigner(evmClient, ecdsaPrivKey, evmChainID)
 }
 
 func (s *EvmSigner) Run(requests <-chan EvmTxRequest) <-chan EvmTxResponse {

--- a/x/hard/keeper/borrow_test.go
+++ b/x/hard/keeper/borrow_test.go
@@ -1,9 +1,8 @@
+//nolint:lll // these tests have some long lines :D
 package keeper_test
 
 import (
 	"time"
-
-	"github.com/kava-labs/kava/x/hard/keeper"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/cometbft/cometbft/crypto"
@@ -12,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/kava-labs/kava/app"
 	"github.com/kava-labs/kava/x/hard"
+	"github.com/kava-labs/kava/x/hard/keeper"
 	"github.com/kava-labs/kava/x/hard/types"
 	pricefeedtypes "github.com/kava-labs/kava/x/pricefeed/types"
 )


### PR DESCRIPTION
These lints are broken on the v0.27 release branch. Fixing them here and backporting them to the release to resolve CI problems.

The broken lints I've fixed here are limited to those introduced to the v0.27 release branch since v0.26.2-iavl-v1.

Additionally, I've added backport labels for iavl v1 release branches.