### PR TITLE
ci: alert only on lints introduced in this branch

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -21,7 +21,7 @@ jobs:
         id: load-version
         run: |
           GOLANGCI_VERSION=$(cat .golangci-version)
-          REV=$(git merge-base origin/master HEAD)
+          REV=$(git merge-base v0.26.2-iavl-v1 HEAD)
           echo "GOLANGCI_VERSION=$GOLANGCI_VERSION" >> $GITHUB_ENV
           echo "REV=$REV" >> $GITHUB_ENV
       - name: golangci-lint


### PR DESCRIPTION
Updates the linting I for `release/v0.27.x` branch to alert only on new broken lints introduced in the release branch.

This is necessary for the v0.27 branch because the linter CI was introduced during v0.26. the v0.26 branch broke come (non-critical) lints that do not need fixed in this branch. This maintains the pattern of ensuring new code follows linter rules without requiring sweeping changes to previously released code.

Future release branches will not need this change because they will be based on master. (This release is based on `v0.26.2-iavl-v1`)
