### PR TITLE
fix(ci): Build RocksDB docker image on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -74,7 +74,7 @@ jobs:
 
   docker-rocksdb:
     # https://github.com/marketplace/actions/build-and-push-docker-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # ensure working with latest code
       - name: Checkout
@@ -93,6 +93,7 @@ jobs:
           # Latest version causes segfault:
           # https://github.com/docker/setup-qemu-action/issues/198
           image: tonistiigi/binfmt:qemu-v7.0.0-28
+          platforms: linux/amd64,linux/arm64
 
       # cross-platform build of the image
       - name: Set up Docker Buildx

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,18 +1,18 @@
 name: Continuous Integration (Release)
 on:
   push:
-    # tags:
-    #   - "v[0-9]+.[0-9]+.[0-9]+*"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # run default ci checks against released version
-  #default-checks:
-  #  uses: ./.github/workflows/ci-default.yml
+  default-checks:
+    uses: ./.github/workflows/ci-default.yml
 
   # get the version tag that triggered this workflow
   get-version-tag:
     # prep version release only if all checks pass
-    # needs: default-checks
+    needs: default-checks
     runs-on: ubuntu-latest
     outputs:
       git-tag: ${{ steps.git-tag.outputs.tag }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,18 +1,18 @@
 name: Continuous Integration (Release)
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    # tags:
+    #   - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   # run default ci checks against released version
-  default-checks:
-    uses: ./.github/workflows/ci-default.yml
+  #default-checks:
+  #  uses: ./.github/workflows/ci-default.yml
 
   # get the version tag that triggered this workflow
   get-version-tag:
     # prep version release only if all checks pass
-    needs: default-checks
+    # needs: default-checks
     runs-on: ubuntu-latest
     outputs:
       git-tag: ${{ steps.git-tag.outputs.tag }}


### PR DESCRIPTION
## Description
- Segfault still occurs with workaround, see https://github.com/docker/setup-qemu-action/issues/198

